### PR TITLE
fix: remove insights search type from tests, put graph completion ins…

### DIFF
--- a/packages/hybrid/duckdb/tests/test_duckdb.py
+++ b/packages/hybrid/duckdb/tests/test_duckdb.py
@@ -162,7 +162,7 @@ async def main():
     random_node_name = random_node.payload["text"]
 
     search_results = await cognee.search(
-        query_type=SearchType.INSIGHTS, query_text=random_node_name
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
     )
     assert len(search_results) != 0, "The search results list is empty."
     print("\n\nExtracted sentences are:\n")

--- a/packages/hybrid/falkordb/tests/test_falkordb.py
+++ b/packages/hybrid/falkordb/tests/test_falkordb.py
@@ -149,7 +149,7 @@ async def main():
     random_node_name = random_node.payload["text"]
 
     search_results = await cognee.search(
-        query_type=SearchType.INSIGHTS, query_text=random_node_name
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
     )
     assert len(search_results) != 0, "The search results list is empty."
     print("\n\nExtracted sentences are:\n")

--- a/packages/vector/milvus/tests/test_milvus.py
+++ b/packages/vector/milvus/tests/test_milvus.py
@@ -163,7 +163,7 @@ async def main() -> None:
     random_node_name = random_node.payload["text"]
 
     search_results = await cognee.search(
-        query_type=SearchType.INSIGHTS, query_text=random_node_name
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
     )
     assert len(search_results) != 0, "The search results list is empty."
     print("\n\nExtracted sentences are:\n")

--- a/packages/vector/opensearch/tests/test_opensearch.py
+++ b/packages/vector/opensearch/tests/test_opensearch.py
@@ -162,7 +162,7 @@ async def main():
     random_node_name = random_node.payload["text"]
 
     search_results = await cognee.search(
-        query_type=SearchType.INSIGHTS, query_text=random_node_name
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
     )
     assert len(search_results) != 0, "The search results list is empty."
     print("\n\nExtracted sentences are:\n")

--- a/packages/vector/qdrant/tests/test_qdrant.py
+++ b/packages/vector/qdrant/tests/test_qdrant.py
@@ -172,7 +172,7 @@ async def main():
     random_node_name = random_node.payload["text"]
 
     search_results = await cognee.search(
-        query_type=SearchType.INSIGHTS, query_text=random_node_name
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
     )
     assert len(search_results) != 0, "The search results list is empty."
     print("\n\nExtracted sentences are:\n")

--- a/packages/vector/redis/tests/test_redis.py
+++ b/packages/vector/redis/tests/test_redis.py
@@ -163,7 +163,7 @@ async def main():
     random_node_name = random_node.payload["text"]
 
     search_results = await cognee.search(
-        query_type=SearchType.INSIGHTS, query_text=random_node_name
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
     )
     assert len(search_results) != 0, "The search results list is empty."
     print("\n\nExtracted sentences are:\n")

--- a/packages/vector/weaviate/tests/test_weaviate.py
+++ b/packages/vector/weaviate/tests/test_weaviate.py
@@ -175,7 +175,7 @@ async def main():
     random_node_name = random_node.payload["text"]
 
     search_results = await cognee.search(
-        query_type=SearchType.INSIGHTS, query_text=random_node_name
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
     )
     assert len(search_results) != 0, "The search results list is empty."
     print("\n\nExtracted sentences are:\n")


### PR DESCRIPTION
…tead

<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->
Since INSIGHTS was removed, changed it to GRAPH_COMPLETION for adapter tests.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
