### PR TITLE
fix(qdrant): replace deprecated client.search() with client.query_points()

### DIFF
--- a/packages/vector/qdrant/cognee_community_vector_adapter_qdrant/qdrant_adapter.py
+++ b/packages/vector/qdrant/cognee_community_vector_adapter_qdrant/qdrant_adapter.py
@@ -112,7 +112,8 @@ class QDrantAdapter(VectorDBInterface):
         points = [convert_to_qdrant_point(point) for point in data_points]
 
         try:
-            client.upload_points(collection_name=collection_name, points=points)
+            # Use upsert for AsyncQdrantClient (upload_points doesn't exist or is sync)
+            await client.upsert(collection_name=collection_name, points=points)
         except UnexpectedResponse as error:
             if "Collection not found" in str(error):
                 raise CollectionNotFoundError(


### PR DESCRIPTION
## Problem

Der Qdrant-Adapter verwendet die veraltete `client.search()` Methode, die in neueren Versionen von `qdrant-client` nicht mehr verfügbar ist. Dies führt zu folgendem Fehler:

```
'AsyncQdrantClient' object has no attribute 'search'
```

## Lösung

- Ersetzt `client.search()` durch `client.query_points()` in der `search()` Methode
- Ersetzt `client.search_batch()` durch `client.query_batch()` in der `batch_search()` Methode
- Passt die Parameter-Namen an die neue API an (`query_vector` statt `vector`)
- Passt die Ergebnis-Parsing-Logik an die neue API-Struktur an

## Änderungen

- `packages/vector/qdrant/cognee_community_vector_adapter_qdrant/qdrant_adapter.py`:
  - `search()`: Verwendet jetzt `query_points()` mit `models.NamedVector`
  - `batch_search()`: Verwendet jetzt `query_batch()` mit `models.Query`

## Getestet mit

- `qdrant-client` Version: >=1.7.0
- Python: 3.12
