### PR TITLE
feat: add cognee-community-tasks-scrapegraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ are contained in one package (i.e. all tasks used in one pipeline are packaged t
 
 | Package Name                       | Type       | Description                    |
 |------------------------------------|------------|--------------------------------|
-| `cognee-community-pipeline-codify` | Pipeline   | Custom codify pipeline package |
-| `cognee-community-retriever-code`  | Retriever  | Custom CODE retriever package  |
-| `cognee-community-tasks-codify`    | Task       | Custom codify tasks package    |
+| `cognee-community-pipeline-codify`     | Pipeline   | Custom codify pipeline package                                        |
+| `cognee-community-retriever-code`      | Retriever  | Custom CODE retriever package                                         |
+| `cognee-community-tasks-codify`        | Task       | Custom codify tasks package                                           |
+| `cognee-community-tasks-scrapegraph`   | Task       | Web scraping tasks powered by [ScrapeGraphAI](https://github.com/ScrapeGraphAI/scrapegraph-py) |
 
 ## Repository Structure
 

--- a/packages/task/scrapegraph_tasks/README.md
+++ b/packages/task/scrapegraph_tasks/README.md
@@ -1,0 +1,118 @@
+# cognee-community-tasks-scrapegraph
+
+Custom cognee tasks for scraping web content using [ScrapeGraphAI](https://github.com/ScrapeGraphAI/scrapegraph-py).
+
+## Overview
+
+This package provides two async tasks:
+
+- **`scrape_urls`** – scrape a list of URLs with a natural language prompt and return structured results.
+- **`scrape_and_add`** – scrape URLs and ingest the content directly into a cognee dataset.
+
+## Installation
+
+```bash
+uv pip install cognee-community-tasks-scrapegraph
+```
+
+Or install locally with all dependencies:
+
+```bash
+cd packages/task/scrapegraph_tasks
+uv sync --all-extras
+# OR
+poetry install
+```
+
+## Requirements
+
+You need two API keys:
+
+| Variable | Description |
+|---|---|
+| `LLM_API_KEY` | OpenAI (or other LLM provider) API key used by cognee |
+| `SGAI_API_KEY` | [ScrapeGraphAI](https://scrapegraphai.com) API key |
+
+Set them in your environment or in a `.env` file:
+
+```bash
+export LLM_API_KEY="sk-..."
+export SGAI_API_KEY="sgai-..."
+```
+
+## Usage
+
+### Scrape only
+
+```python
+import asyncio
+from cognee_community_tasks_scrapegraph import scrape_urls
+
+results = asyncio.run(
+    scrape_urls(
+        urls=["https://cognee.ai", "https://docs.cognee.ai"],
+        user_prompt="Extract the main content, title, and key information from this page",
+    )
+)
+
+for item in results:
+    print(item["url"], item["content"])
+```
+
+### Scrape and add to cognee
+
+```python
+import asyncio
+from cognee_community_tasks_scrapegraph import scrape_and_add
+
+asyncio.run(
+    scrape_and_add(
+        urls=["https://cognee.ai"],
+        user_prompt="Extract the main content and key information",
+        dataset_name="web_scrape",
+    )
+)
+```
+
+## Run the example
+
+```bash
+cd packages/task/scrapegraph_tasks
+uv run python examples/example.py
+# OR
+poetry run python examples/example.py
+```
+
+## API Reference
+
+### `scrape_urls`
+
+```python
+async def scrape_urls(
+    urls: List[str],
+    user_prompt: str = "Extract the main content, title, and key information from this page",
+    api_key: Optional[str] = None,
+) -> List[dict]
+```
+
+Returns a list of dicts:
+
+```python
+[
+    {"url": "https://example.com", "content": {...}},           # success
+    {"url": "https://bad.invalid", "content": "", "error": "..."}, # failure
+]
+```
+
+### `scrape_and_add`
+
+```python
+async def scrape_and_add(
+    urls: List[str],
+    user_prompt: str = "Extract the main content, title, and key information from this page",
+    api_key: Optional[str] = None,
+    dataset_name: str = "scrapegraph",
+) -> Any
+```
+
+Scrapes all URLs, combines the successful results into a single text document, calls `cognee.add`, and then `cognee.cognify`. Returns the cognify result.

--- a/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/__init__.py
+++ b/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/__init__.py
@@ -1,0 +1,1 @@
+from cognee_community_tasks_scrapegraph.scrapegraph_task import scrape_and_add, scrape_urls

--- a/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
+++ b/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
@@ -1,0 +1,108 @@
+import os
+from typing import Any, List, Optional
+
+from cognee.shared.logging_utils import get_logger
+from scrapegraph_py import Client
+
+logger = get_logger("ScrapegraphTask")
+
+
+async def scrape_urls(
+    urls: List[str],
+    user_prompt: str = "Extract the main content, title, and key information from this page",
+    api_key: Optional[str] = None,
+) -> List[dict]:
+    """
+    Scrape web content from a list of URLs using ScrapeGraphAI.
+
+    Parameters
+    ----------
+    urls : List[str]
+        List of URLs to scrape.
+    user_prompt : str
+        Natural language instruction describing what to extract from each page.
+    api_key : Optional[str]
+        ScrapeGraphAI API key. Falls back to the ``SGAI_API_KEY`` environment variable.
+
+    Returns
+    -------
+    List[dict]
+        List of dicts with ``url``, ``content``, and optionally ``error`` keys.
+    """
+    if api_key is None:
+        api_key = os.getenv("SGAI_API_KEY")
+
+    if not api_key:
+        raise ValueError(
+            "ScrapeGraphAI API key is required. Set the SGAI_API_KEY environment variable."
+        )
+
+    client = Client(api_key=api_key)
+    results = []
+
+    try:
+        for url in urls:
+            logger.info(f"Scraping URL: {url}")
+            try:
+                response = client.smartscraper(
+                    website_url=url,
+                    user_prompt=user_prompt,
+                )
+                results.append(
+                    {
+                        "url": url,
+                        "content": response.get("result", ""),
+                    }
+                )
+                logger.info(f"Successfully scraped: {url}")
+            except Exception as e:
+                logger.error(f"Failed to scrape {url}: {str(e)}")
+                results.append({"url": url, "content": "", "error": str(e)})
+    finally:
+        client.close()
+
+    return results
+
+
+async def scrape_and_add(
+    urls: List[str],
+    user_prompt: str = "Extract the main content, title, and key information from this page",
+    api_key: Optional[str] = None,
+    dataset_name: str = "scrapegraph",
+) -> Any:
+    """
+    Scrape web content from a list of URLs and add it to cognee.
+
+    Parameters
+    ----------
+    urls : List[str]
+        List of URLs to scrape.
+    user_prompt : str
+        Natural language instruction describing what to extract from each page.
+    api_key : Optional[str]
+        ScrapeGraphAI API key. Falls back to the ``SGAI_API_KEY`` environment variable.
+    dataset_name : str
+        Name of the cognee dataset to add the scraped content to.
+
+    Returns
+    -------
+    Any
+        The cognee graph result after processing the scraped content.
+    """
+    import cognee
+
+    scraped = await scrape_urls(urls=urls, user_prompt=user_prompt, api_key=api_key)
+
+    successful = [item for item in scraped if not item.get("error")]
+    if not successful:
+        raise RuntimeError("No URLs were scraped successfully.")
+
+    combined_text = "\n\n".join(
+        f"Source: {item['url']}\n{item['content']}" for item in successful
+    )
+
+    await cognee.add(combined_text, dataset_name=dataset_name)
+    result = await cognee.cognify()
+
+    logger.info(f"Added {len(successful)} scraped pages to cognee dataset '{dataset_name}'")
+    return result

--- a/packages/task/scrapegraph_tasks/examples/example.py
+++ b/packages/task/scrapegraph_tasks/examples/example.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+
+import cognee
+from cognee_community_tasks_scrapegraph import scrape_and_add, scrape_urls
+
+
+async def main():
+    # Set required API keys
+    os.environ["LLM_API_KEY"] = os.getenv("LLM_API_KEY", "YOUR_OPENAI_API_KEY")
+    os.environ["SGAI_API_KEY"] = os.getenv("SGAI_API_KEY", "YOUR_SGAI_API_KEY")
+
+    urls = [
+        "https://cognee.ai",
+        "https://docs.cognee.ai",
+    ]
+
+    # --- Example 1: scrape only ---
+    print("Scraping URLs...")
+    results = await scrape_urls(
+        urls=urls,
+        user_prompt="Extract the main content, title, and key information from this page",
+    )
+    for item in results:
+        print(f"\nURL: {item['url']}")
+        if item.get("error"):
+            print(f"  Error: {item['error']}")
+        else:
+            content_preview = str(item["content"])[:300]
+            print(f"  Content preview: {content_preview}...")
+
+    # --- Example 2: scrape and add to cognee ---
+    print("\nScraping and adding to cognee...")
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await scrape_and_add(
+        urls=urls,
+        user_prompt="Extract the main content, title, and key information from this page",
+        dataset_name="web_scrape",
+    )
+
+    search_results = await cognee.search("What is cognee?")
+    print("\nSearch results after ingestion:")
+    for result in search_results:
+        print(f"  - {result}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/task/scrapegraph_tasks/pyproject.toml
+++ b/packages/task/scrapegraph_tasks/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "cognee-community-tasks-scrapegraph"
+version = "0.1.0"
+description = "Package containing custom cognee tasks for scraping web content using ScrapeGraphAI"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    "cognee==0.5.2",
+    "scrapegraph-py>=1.7.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/task/scrapegraph_tasks/tests/test_scrapegraph.py
+++ b/packages/task/scrapegraph_tasks/tests/test_scrapegraph.py
@@ -1,0 +1,95 @@
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cognee_community_tasks_scrapegraph import scrape_urls
+from cognee_community_tasks_scrapegraph.scrapegraph_task import scrape_and_add
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch):
+    monkeypatch.setenv("SGAI_API_KEY", "test-api-key")
+
+
+class TestScrapeUrls:
+    def test_raises_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("SGAI_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="SGAI_API_KEY"):
+            asyncio.run(scrape_urls(["https://example.com"], api_key=None))
+
+    def test_returns_results_for_each_url(self):
+        mock_client = MagicMock()
+        mock_client.smartscraper.return_value = {"result": {"title": "Example", "content": "Text"}}
+
+        with patch("cognee_community_tasks_scrapegraph.scrapegraph_task.Client", return_value=mock_client):
+            results = asyncio.run(
+                scrape_urls(
+                    urls=["https://example.com", "https://example.org"],
+                    user_prompt="Extract title and content",
+                )
+            )
+
+        assert len(results) == 2
+        assert results[0]["url"] == "https://example.com"
+        assert results[1]["url"] == "https://example.org"
+        assert results[0]["content"] == {"title": "Example", "content": "Text"}
+        mock_client.close.assert_called_once()
+
+    def test_handles_per_url_error_gracefully(self):
+        mock_client = MagicMock()
+        mock_client.smartscraper.side_effect = Exception("Network error")
+
+        with patch("cognee_community_tasks_scrapegraph.scrapegraph_task.Client", return_value=mock_client):
+            results = asyncio.run(scrape_urls(urls=["https://bad-url.invalid"]))
+
+        assert len(results) == 1
+        assert results[0]["url"] == "https://bad-url.invalid"
+        assert results[0]["content"] == ""
+        assert "error" in results[0]
+        mock_client.close.assert_called_once()
+
+    def test_explicit_api_key_is_used(self):
+        mock_client = MagicMock()
+        mock_client.smartscraper.return_value = {"result": "ok"}
+
+        with patch(
+            "cognee_community_tasks_scrapegraph.scrapegraph_task.Client", return_value=mock_client
+        ) as mock_cls:
+            asyncio.run(scrape_urls(["https://example.com"], api_key="explicit-key"))
+
+        mock_cls.assert_called_once_with(api_key="explicit-key")
+
+
+class TestScrapeAndAdd:
+    def test_raises_when_all_urls_fail(self):
+        mock_client = MagicMock()
+        mock_client.smartscraper.side_effect = Exception("Network error")
+
+        with patch("cognee_community_tasks_scrapegraph.scrapegraph_task.Client", return_value=mock_client):
+            with pytest.raises(RuntimeError, match="No URLs were scraped successfully"):
+                asyncio.run(scrape_and_add(urls=["https://bad-url.invalid"]))
+
+    def test_calls_cognee_add_and_cognify(self):
+        mock_client = MagicMock()
+        mock_client.smartscraper.return_value = {"result": "scraped content"}
+
+        mock_cognee = MagicMock()
+        mock_cognee.add = AsyncMock()
+        mock_cognee.cognify = AsyncMock(return_value="graph_result")
+
+        with patch("cognee_community_tasks_scrapegraph.scrapegraph_task.Client", return_value=mock_client):
+            with patch("cognee_community_tasks_scrapegraph.scrapegraph_task.cognee", mock_cognee):
+                result = asyncio.run(
+                    scrape_and_add(
+                        urls=["https://example.com"],
+                        dataset_name="test_dataset",
+                    )
+                )
+
+        mock_cognee.add.assert_called_once()
+        call_kwargs = mock_cognee.add.call_args
+        assert "test_dataset" in str(call_kwargs)
+
+        mock_cognee.cognify.assert_called_once()
+        assert result == "graph_result"


### PR DESCRIPTION
## Description

This PR adds a new community task package **`cognee-community-tasks-scrapegraph`** that integrates [ScrapeGraphAI](https://github.com/ScrapeGraphAI/scrapegraph-py) with cognee.

### What's included

**New package** — `packages/task/scrapegraph_tasks/`

| File | Purpose |
|---|---|
| `pyproject.toml` | Package metadata; depends on `cognee==0.5.2` and `scrapegraph-py>=1.7.0` |
| `cognee_community_tasks_scrapegraph/scrapegraph_task.py` | Two async tasks: `scrape_urls` and `scrape_and_add` |
| `cognee_community_tasks_scrapegraph/__init__.py` | Public exports |
| `examples/example.py` | Runnable demo showing both tasks |
| `tests/test_scrapegraph.py` | Unit tests with mocked client (no real API calls) |
| `README.md` | Installation, usage, and API reference |

### Tasks

- **`scrape_urls(urls, user_prompt, api_key)`** — scrapes a list of URLs using ScrapeGraphAI's `smartscraper` and returns structured results per URL.
- **`scrape_and_add(urls, user_prompt, api_key, dataset_name)`** — scrapes URLs and ingests the combined content into a cognee dataset via `cognee.add` + `cognee.cognify`.

### README

Added `cognee-community-tasks-scrapegraph` to the **Custom Packages** table in the root `README.md`.

---

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.