### PR TITLE
fix(falkordb): use double quotes in vector search queryNodes

### DIFF
--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -836,8 +836,8 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
 
         query = dedent(f"""
             CALL db.idx.vector.queryNodes(
-                '{label}',
-                '{attribute_name}_vector',
+                "{label}",
+                "{attribute_name}_vector",
                 {limit},
                 vecf32({query_vector})
             )


### PR DESCRIPTION
## Summary

- Fix FalkorDB vector search (`CHUNKS`, `SUMMARIES` search types) returning 0 results due to single-quote stripping by falkordb-py driver

## Problem

The `falkordb-py` Python driver serializes query parameters via a `CYPHER key=value` prefix prepended to the query string. During this serialization, **single quotes are stripped** from the query text.

In `FalkorDBAdapter.search()`, the `db.idx.vector.queryNodes` call uses single-quoted string arguments:

```python
CALL db.idx.vector.queryNodes(
    '{label}',                    # single quotes get stripped
    '{attribute_name}_vector',    # single quotes get stripped
    ...
)
```

After serialization, FalkorDB receives bare identifiers (`DocumentChunk` instead of `"DocumentChunk"`), causing parse errors like `'DocumentChunk' not defined`. The search silently returns 0 results.

## Fix

Replace single quotes with double quotes in the `queryNodes` call. Double quotes survive the CYPHER prefix serialization and are correctly parsed by FalkorDB.

## Testing

Tested with FalkorDB `latest` image, cognee 0.5.5, 4096-dimension embeddings (Qwen3-Embedding-8B):

| Search Type | Before | After |
|---|---|---|
| CHUNKS | 0 results (parse error) | Finds documents |
| SUMMARIES | 0 results (parse error) | Finds summaries |
| GRAPH_COMPLETION | Worked (uses graph, not vector search) | Still works |

Self-search (query with stored vector) returns score=0.0000 (perfect match), confirming the vector index and search work correctly with double quotes.