### PR TITLE
fix: ascii-fold relationship type names in falkor sanitize_relationship_name

### DIFF
--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -344,7 +344,14 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
 
     def sanitize_relationship_name(self, relationship_name: str) -> str:
         """
-        Sanitize relationship name to be valid for Cypher queries.
+        Sanitize relationship name to be a valid Cypher identifier.
+
+        FalkorDB's Cypher parser only accepts identifiers matching
+        ``[A-Za-z_][A-Za-z0-9_]*`` for unquoted relationship types, so
+        non-ASCII letters (á, ç, ñ, …) must be folded to ASCII before
+        substitution. Without this, names extracted from non-English text
+        such as ``responsável_por`` produce queries the parser rejects with
+        ``Invalid input ...: expected '|', '*', '{', a parameter or ']'``.
 
         Parameters:
         -----------
@@ -354,10 +361,17 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         --------
             - str: A sanitized relationship name valid for Cypher
         """
-        # Replace hyphens, spaces, and other special characters with underscores
         import re
+        import unicodedata
 
-        sanitized = re.sub(r"[^\w]", "_", relationship_name)
+        # Decompose accented chars into base + combining marks, then drop
+        # the combining marks: á → a, ç → c, ã → a, ñ → n.
+        normalized = unicodedata.normalize("NFKD", relationship_name)
+        ascii_only = "".join(c for c in normalized if not unicodedata.combining(c))
+
+        # ``re.ASCII`` forces \w to mean [a-zA-Z0-9_], so any remaining
+        # non-ASCII characters (CJK, Cyrillic, …) collapse to underscores.
+        sanitized = re.sub(r"[^\w]", "_", ascii_only, flags=re.ASCII)
         # Remove consecutive underscores
         sanitized = re.sub(r"_+", "_", sanitized)
         # Remove leading/trailing underscores

--- a/packages/hybrid/falkordb/tests/test_sanitize_relationship_name.py
+++ b/packages/hybrid/falkordb/tests/test_sanitize_relationship_name.py
@@ -1,0 +1,89 @@
+"""Unit tests for relationship-name sanitization.
+
+These tests verify that ``FalkorDBAdapter.sanitize_relationship_name``
+produces identifiers that FalkorDB's Cypher parser accepts (ASCII-only,
+matching ``[A-Za-z_][A-Za-z0-9_]*``). No FalkorDB connection is required.
+"""
+
+import re
+
+from cognee_community_hybrid_adapter_falkor.falkor_adapter import FalkorDBAdapter
+
+
+# Cypher's grammar for unquoted identifiers, which is what FalkorDB accepts
+# for relationship types in patterns like ``[edge:TYPE]``.
+_VALID_CYPHER_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _sanitize(name: str) -> str:
+    # ``sanitize_relationship_name`` is an instance method that doesn't
+    # actually touch ``self``, so we call it unbound with ``None`` to avoid
+    # constructing a real adapter (which would require a FalkorDB connection).
+    return FalkorDBAdapter.sanitize_relationship_name(None, name)  # type: ignore[arg-type]
+
+
+def test_ascii_unchanged():
+    assert _sanitize("knows") == "knows"
+    assert _sanitize("works_for") == "works_for"
+
+
+def test_hyphens_and_spaces_become_underscores():
+    assert _sanitize("works-for") == "works_for"
+    assert _sanitize("works for") == "works_for"
+
+
+def test_consecutive_separators_collapse():
+    assert _sanitize("works---for") == "works_for"
+    assert _sanitize("a   b   c") == "a_b_c"
+
+
+def test_portuguese_accents_are_folded():
+    # Without the fix, Python's Unicode-aware ``\w`` lets these chars pass
+    # through unchanged, so the resulting identifier breaks the Cypher parser.
+    assert _sanitize("responsável_por") == "responsavel_por"
+    assert _sanitize("é_relacionado") == "e_relacionado"
+    assert _sanitize("ação") == "acao"
+
+
+def test_spanish_and_french_accents_are_folded():
+    assert _sanitize("niño") == "nino"
+    assert _sanitize("café") == "cafe"
+    assert _sanitize("über") == "uber"
+
+
+def test_non_latin_collapses_to_underscore():
+    # Cyrillic / CJK have no ASCII fold, so they collapse to underscores
+    # and we still get a valid (if opaque) identifier.
+    assert _VALID_CYPHER_IDENT.match(_sanitize("знает"))  # "knows" in Russian
+    assert _VALID_CYPHER_IDENT.match(_sanitize("知道"))    # "knows" in Chinese
+
+
+def test_leading_digit_gets_underscore_prefix():
+    assert _sanitize("123foo") == "_123foo"
+
+
+def test_empty_or_only_separators_returns_default():
+    assert _sanitize("") == "RELATIONSHIP"
+    assert _sanitize("___") == "RELATIONSHIP"
+    assert _sanitize("---") == "RELATIONSHIP"
+
+
+def test_all_outputs_are_valid_cypher_identifiers():
+    samples = [
+        "knows",
+        "responsável_por",
+        "ação",
+        "café",
+        "niño",
+        "знает",
+        "知道",
+        "works-for",
+        "123foo",
+        "  spaces  ",
+        "MIXED-Case_Name",
+    ]
+    for name in samples:
+        result = _sanitize(name)
+        assert _VALID_CYPHER_IDENT.match(result), (
+            f"{name!r} → {result!r} is not a valid Cypher identifier"
+        )


### PR DESCRIPTION
## Summary

`FalkorDBAdapter.sanitize_relationship_name` uses `re.sub(r"[^\w]", "_", ...)` to clean relationship type identifiers before interpolating them into Cypher. Python's `\w` is Unicode-aware by default, so accented characters (á, ç, ã, ñ, é, …) **pass through unchanged**. The resulting identifier is then embedded unquoted into a `MERGE` query, which FalkorDB's Cypher parser rejects because its identifier grammar is `[A-Za-z_][A-Za-z0-9_]*`.

## Reproduction

When cognee extracts knowledge from non-English text (Portuguese in my case), it produces relationship types like `responsável_por`. The adapter then issues:

```cypher
MERGE (source)-[edge:responsável_por]->(target)
```

FalkorDB returns:

```
ResponseError: errMsg: Invalid input ' ': expected '|', '*', '{', a parameter or ']'
errCtx: MERGE (source)-[edge:responsável_por]->(target)
errCtxOffset: 28
```

The parser stops at `respons`, hits the byte sequence for `á`, and resyncs by reporting an unexpected token. Any non-Latin source text (Portuguese, Spanish, French, Cyrillic, CJK, …) hits this.

## Fix

`unicodedata.normalize("NFKD", …)` decomposes accented characters into base + combining marks; we then drop the combining marks to get ASCII-only equivalents (`responsável_por` → `responsavel_por`). For characters with no ASCII fold (CJK, Cyrillic) `re.sub(..., flags=re.ASCII)` collapses them to `_`, still producing a valid identifier. The downstream behavior (consecutive-underscore collapse, leading-digit prefix, empty-name fallback) is preserved unchanged.

## Tests

Added `tests/test_sanitize_relationship_name.py` (9 unit tests, no FalkorDB connection required) covering:

- ASCII passthrough
- Hyphen/space replacement and consecutive-separator collapse
- Portuguese, Spanish, French, German accent folding
- Cyrillic / CJK collapse to valid identifiers
- Leading-digit underscore prefix
- Empty / separator-only fallback to `"RELATIONSHIP"`
- Generic invariant: every output matches `^[A-Za-z_][A-Za-z0-9_]*$`

## Test plan
- [x] `poetry run pytest tests/test_sanitize_relationship_name.py -v` — 9 passed
- [x] `poetry run pytest tests/test_sanitize_params.py -v` — sibling tests still pass