### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ are contained in one package (i.e. all tasks used in one pipeline are packaged t
 | `cognee-community-retriever-code`      | Retriever  | Custom CODE retriever package                                         |
 | `cognee-community-tasks-codify`        | Task       | Custom codify tasks package                                           |
 | `cognee-community-tasks-scrapegraph`   | Task       | Web scraping tasks powered by [ScrapeGraphAI](https://github.com/ScrapeGraphAI/scrapegraph-py) |
+| `cognee-community-tasks-exa`           | Task       | Web search tasks powered by [Exa](https://exa.ai)                     |
 
 ## Repository Structure
 

--- a/packages/task/exa_tasks/README.md
+++ b/packages/task/exa_tasks/README.md
@@ -1,0 +1,149 @@
+# cognee-community-tasks-exa
+
+Custom cognee tasks for searching the web using [Exa](https://exa.ai).
+
+## Overview
+
+This package provides two async tasks:
+
+- **`search_web`** – run a neural/keyword/hybrid web search with Exa and return structured results.
+- **`search_and_add`** – run an Exa search and ingest the returned content directly into a cognee dataset.
+
+## Installation
+
+```bash
+uv pip install cognee-community-tasks-exa
+```
+
+Or install locally with all dependencies:
+
+```bash
+cd packages/task/exa_tasks
+uv sync --all-extras
+# OR
+poetry install
+```
+
+## Requirements
+
+You need two API keys:
+
+| Variable | Description |
+|---|---|
+| `LLM_API_KEY` | OpenAI (or other LLM provider) API key used by cognee |
+| `EXA_API_KEY` | [Exa](https://dashboard.exa.ai) API key |
+
+Set them in your environment or in a `.env` file:
+
+```bash
+export LLM_API_KEY="sk-..."
+export EXA_API_KEY="..."
+```
+
+## Usage
+
+### Search only
+
+```python
+import asyncio
+from cognee_community_tasks_exa import search_web
+
+results = asyncio.run(
+    search_web(
+        query="Latest advances in retrieval augmented generation",
+        num_results=5,
+        include_highlights=True,
+        category="research paper",
+    )
+)
+
+for item in results:
+    print(item["url"], item["title"])
+    print(item["content"][:200])
+```
+
+### Search and add to cognee
+
+```python
+import asyncio
+from cognee_community_tasks_exa import search_and_add
+
+asyncio.run(
+    search_and_add(
+        query="How do knowledge graphs improve LLM memory?",
+        num_results=5,
+        dataset_name="exa_search",
+    )
+)
+```
+
+## Run the example
+
+```bash
+cd packages/task/exa_tasks
+uv run python examples/example.py
+# OR
+poetry run python examples/example.py
+```
+
+## API Reference
+
+### `search_web`
+
+```python
+async def search_web(
+    query: str,
+    num_results: int = 10,
+    search_type: str = "auto",
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    category: Optional[str] = None,
+    start_published_date: Optional[str] = None,
+    end_published_date: Optional[str] = None,
+    include_text: bool = True,
+    include_highlights: bool = False,
+    include_summary: bool = False,
+    summary_query: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> List[dict]
+```
+
+Returns a list of dicts with keys:
+
+```python
+{
+    "url": "https://example.com/post",
+    "title": "Example post",
+    "content": "Best available text/summary/highlights...",
+    "text": "...",             # full text, if requested
+    "highlights": [...],        # list, if requested
+    "summary": "...",          # LLM summary, if requested
+    "score": 0.92,
+    "published_date": "2026-01-12",
+    "author": "Alice",
+}
+```
+
+Search types: `auto` (default), `neural`, `fast`, `deep-lite`, `deep`, `deep-reasoning`, `instant`.
+
+Categories: `company`, `research paper`, `news`, `personal site`, `financial report`, `pdf`, `github`, `tweet`, `movie`, `song`, `linkedin profile`.
+
+### `search_and_add`
+
+```python
+async def search_and_add(
+    query: str,
+    num_results: int = 10,
+    search_type: str = "auto",
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    category: Optional[str] = None,
+    start_published_date: Optional[str] = None,
+    end_published_date: Optional[str] = None,
+    summary_query: Optional[str] = None,
+    api_key: Optional[str] = None,
+    dataset_name: str = "exa",
+) -> Any
+```
+
+Runs the search with text + highlights enabled, combines every result with content into a single text document, calls `cognee.add`, and then `cognee.cognify`. Returns the cognify result.

--- a/packages/task/exa_tasks/cognee_community_tasks_exa/__init__.py
+++ b/packages/task/exa_tasks/cognee_community_tasks_exa/__init__.py
@@ -1,0 +1,1 @@
+from cognee_community_tasks_exa.exa_task import search_and_add, search_web

--- a/packages/task/exa_tasks/cognee_community_tasks_exa/exa_task.py
+++ b/packages/task/exa_tasks/cognee_community_tasks_exa/exa_task.py
@@ -1,0 +1,243 @@
+import asyncio
+import os
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import cognee
+from cognee.shared.logging_utils import get_logger
+from exa_py import Exa
+
+logger = get_logger("ExaTask")
+
+SearchType = Literal["auto", "neural", "fast", "deep-lite", "deep", "deep-reasoning", "instant"]
+Category = Literal[
+    "company",
+    "research paper",
+    "news",
+    "personal site",
+    "financial report",
+    "pdf",
+    "github",
+    "tweet",
+    "movie",
+    "song",
+    "linkedin profile",
+]
+
+
+@dataclass
+class ExaSearchResult:
+    """Typed representation of a single Exa search result."""
+
+    url: str
+    title: str | None = None
+    text: str | None = None
+    highlights: list[str] = field(default_factory=list)
+    summary: str | None = None
+    score: float | None = None
+    published_date: str | None = None
+    author: str | None = None
+
+    def best_content(self) -> str:
+        """Return the most informative content field that is available.
+
+        Exa may return any combination of text/highlights/summary depending on
+        the request. Cascade through fields rather than assuming one is set.
+        """
+        if self.text:
+            return self.text
+        if self.summary:
+            return self.summary
+        if self.highlights:
+            return "\n".join(self.highlights)
+        return ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "url": self.url,
+            "title": self.title,
+            "content": self.best_content(),
+            "text": self.text,
+            "highlights": self.highlights,
+            "summary": self.summary,
+            "score": self.score,
+            "published_date": self.published_date,
+            "author": self.author,
+        }
+
+
+def _parse_result(raw: Any) -> ExaSearchResult:
+    """Parse an exa-py Result object (or dict-like) into an ExaSearchResult."""
+    get = (lambda k: raw.get(k)) if isinstance(raw, dict) else (lambda k: getattr(raw, k, None))
+    highlights = get("highlights") or []
+    if not isinstance(highlights, list):
+        highlights = [highlights]
+    return ExaSearchResult(
+        url=get("url") or "",
+        title=get("title"),
+        text=get("text"),
+        highlights=list(highlights),
+        summary=get("summary"),
+        score=get("score"),
+        published_date=get("published_date") or get("publishedDate"),
+        author=get("author"),
+    )
+
+
+def _build_exa_client(api_key: str | None) -> Exa:
+    if api_key is None:
+        api_key = os.getenv("EXA_API_KEY")
+    if not api_key:
+        raise ValueError("Exa API key is required. Set the EXA_API_KEY environment variable.")
+    client = Exa(api_key=api_key)
+    client.headers["x-exa-integration"] = "cognee-community"
+    return client
+
+
+async def search_web(
+    query: str,
+    num_results: int = 10,
+    search_type: SearchType = "auto",
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
+    category: Category | None = None,
+    start_published_date: str | None = None,
+    end_published_date: str | None = None,
+    include_text: bool = True,
+    include_highlights: bool = False,
+    include_summary: bool = False,
+    summary_query: str | None = None,
+    api_key: str | None = None,
+) -> list[dict]:
+    """Search the web with Exa and return structured results.
+
+    Parameters
+    ----------
+    query : str
+        Natural language search query.
+    num_results : int
+        Number of results to return (1-100, default 10).
+    search_type : str
+        One of ``auto``, ``neural``, ``fast``, ``deep-lite``, ``deep``,
+        ``deep-reasoning``, ``instant``.
+    include_domains, exclude_domains : Optional[List[str]]
+        Domain allow/deny lists.
+    category : Optional[str]
+        Category filter (e.g. ``company``, ``research paper``, ``news``).
+    start_published_date, end_published_date : Optional[str]
+        ISO 8601 date bounds on publication date.
+    include_text : bool
+        Return the full page text content.
+    include_highlights : bool
+        Return query-relevant highlights.
+    include_summary : bool
+        Return an LLM-generated summary. Combine with ``summary_query`` for
+        a targeted summary.
+    summary_query : Optional[str]
+        Natural language prompt used to generate each result's summary.
+    api_key : Optional[str]
+        Exa API key. Falls back to the ``EXA_API_KEY`` environment variable.
+
+    Returns
+    -------
+    List[dict]
+        Result dicts with keys ``url``, ``title``, ``content``, ``text``,
+        ``highlights``, ``summary``, ``score``, ``published_date``, ``author``.
+    """
+    client = _build_exa_client(api_key)
+
+    contents: dict[str, Any] = {}
+    if include_text:
+        contents["text"] = True
+    if include_highlights:
+        contents["highlights"] = True
+    if include_summary:
+        contents["summary"] = {"query": summary_query} if summary_query else True
+
+    kwargs: dict[str, Any] = {
+        "query": query,
+        "num_results": num_results,
+        "type": search_type,
+    }
+    if include_domains:
+        kwargs["include_domains"] = include_domains
+    if exclude_domains:
+        kwargs["exclude_domains"] = exclude_domains
+    if category:
+        kwargs["category"] = category
+    if start_published_date:
+        kwargs["start_published_date"] = start_published_date
+    if end_published_date:
+        kwargs["end_published_date"] = end_published_date
+
+    logger.info(f"Running Exa search: {query!r} (type={search_type}, n={num_results})")
+
+    def _do_search():
+        if contents:
+            return client.search_and_contents(**kwargs, **contents)
+        return client.search(**kwargs)
+
+    try:
+        response = await asyncio.to_thread(_do_search)
+    except Exception as e:
+        logger.error(f"Exa search failed: {e!s}")
+        raise
+
+    raw_results = getattr(response, "results", response)
+    parsed = [_parse_result(r) for r in raw_results]
+    logger.info(f"Exa returned {len(parsed)} results")
+    return [r.to_dict() for r in parsed]
+
+
+async def search_and_add(
+    query: str,
+    num_results: int = 10,
+    search_type: SearchType = "auto",
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
+    category: Category | None = None,
+    start_published_date: str | None = None,
+    end_published_date: str | None = None,
+    summary_query: str | None = None,
+    api_key: str | None = None,
+    dataset_name: str = "exa",
+) -> Any:
+    """Run an Exa search and add the returned content to a cognee dataset.
+
+    Each result is combined into a single text document and passed to
+    ``cognee.add`` followed by ``cognee.cognify``.
+
+    Parameters mirror :func:`search_web`. Content retrieval is forced on so
+    that there is something to ingest.
+    """
+    results = await search_web(
+        query=query,
+        num_results=num_results,
+        search_type=search_type,
+        include_domains=include_domains,
+        exclude_domains=exclude_domains,
+        category=category,
+        start_published_date=start_published_date,
+        end_published_date=end_published_date,
+        include_text=True,
+        include_highlights=True,
+        include_summary=summary_query is not None,
+        summary_query=summary_query,
+        api_key=api_key,
+    )
+
+    usable = [r for r in results if r.get("content")]
+    if not usable:
+        raise RuntimeError("No Exa results returned any content to ingest.")
+
+    combined_text = "\n\n".join(
+        f"Source: {r['url']}\nTitle: {r.get('title') or ''}\n{r['content']}" for r in usable
+    )
+
+    await cognee.add(combined_text, dataset_name=dataset_name)
+    result = await cognee.cognify()
+
+    logger.info(
+        f"Added {len(usable)} Exa results for query {query!r} to cognee dataset '{dataset_name}'"
+    )
+    return result

--- a/packages/task/exa_tasks/examples/example.py
+++ b/packages/task/exa_tasks/examples/example.py
@@ -1,0 +1,47 @@
+import asyncio
+import os
+
+import cognee
+
+from cognee_community_tasks_exa import search_and_add, search_web
+
+
+async def main():
+    # Set required API keys
+    os.environ["LLM_API_KEY"] = os.getenv("LLM_API_KEY", "YOUR_OPENAI_API_KEY")
+    os.environ["EXA_API_KEY"] = os.getenv("EXA_API_KEY", "YOUR_EXA_API_KEY")
+
+    query = "How do knowledge graphs improve LLM memory?"
+
+    # --- Example 1: search only ---
+    print(f"Searching Exa for: {query!r}")
+    results = await search_web(
+        query=query,
+        num_results=5,
+        include_highlights=True,
+    )
+    for item in results:
+        print(f"\nURL: {item['url']}")
+        print(f"  Title: {item.get('title')}")
+        content_preview = str(item["content"])[:300]
+        print(f"  Content preview: {content_preview}...")
+
+    # --- Example 2: search and add to cognee ---
+    print("\nSearching and adding results to cognee...")
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await search_and_add(
+        query=query,
+        num_results=5,
+        dataset_name="exa_search",
+    )
+
+    search_results = await cognee.search("What is cognee?")
+    print("\nSearch results after ingestion:")
+    for result in search_results:
+        print(f"  - {result}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/task/exa_tasks/pyproject.toml
+++ b/packages/task/exa_tasks/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "cognee-community-tasks-exa"
+version = "0.1.0"
+description = "Package containing custom cognee tasks for searching the web using Exa"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    "cognee==0.5.3",
+    "exa-py>=2.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/task/exa_tasks/tests/test_exa.py
+++ b/packages/task/exa_tasks/tests/test_exa.py
@@ -1,0 +1,184 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognee_community_tasks_exa import search_web
+from cognee_community_tasks_exa.exa_task import (
+    ExaSearchResult,
+    _parse_result,
+    search_and_add,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch):
+    monkeypatch.setenv("EXA_API_KEY", "test-api-key")
+
+
+def _fake_result(**overrides):
+    """Build a SimpleNamespace mimicking an exa-py Result."""
+    data = {
+        "url": "https://example.com",
+        "title": "Example",
+        "text": None,
+        "highlights": None,
+        "summary": None,
+        "score": 0.9,
+        "published_date": "2026-01-01",
+        "author": None,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def _fake_exa_instance(results):
+    inst = MagicMock()
+    inst.headers = {}
+    inst.search_and_contents.return_value = SimpleNamespace(results=results)
+    inst.search.return_value = SimpleNamespace(results=results)
+    return inst
+
+
+class TestSearchWeb:
+    def test_raises_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="EXA_API_KEY"):
+            asyncio.run(search_web("anything", api_key=None))
+
+    def test_returns_parsed_results(self):
+        results = [
+            _fake_result(url="https://a.example", title="A", text="body A"),
+            _fake_result(url="https://b.example", title="B", text="body B"),
+        ]
+        inst = _fake_exa_instance(results)
+
+        with patch("cognee_community_tasks_exa.exa_task.Exa", return_value=inst):
+            out = asyncio.run(search_web("hello world", num_results=2))
+
+        assert len(out) == 2
+        assert out[0]["url"] == "https://a.example"
+        assert out[0]["title"] == "A"
+        assert out[0]["content"] == "body A"
+        inst.search_and_contents.assert_called_once()
+        call_kwargs = inst.search_and_contents.call_args.kwargs
+        assert call_kwargs["query"] == "hello world"
+        assert call_kwargs["num_results"] == 2
+        assert call_kwargs["text"] is True
+
+    def test_calls_plain_search_when_no_contents_requested(self):
+        inst = _fake_exa_instance([_fake_result()])
+        with patch("cognee_community_tasks_exa.exa_task.Exa", return_value=inst):
+            asyncio.run(
+                search_web(
+                    "q",
+                    include_text=False,
+                    include_highlights=False,
+                    include_summary=False,
+                )
+            )
+        inst.search.assert_called_once()
+        inst.search_and_contents.assert_not_called()
+
+    def test_sets_integration_header(self):
+        inst = _fake_exa_instance([_fake_result()])
+        with patch("cognee_community_tasks_exa.exa_task.Exa", return_value=inst):
+            asyncio.run(search_web("q"))
+        assert inst.headers.get("x-exa-integration") == "cognee-community"
+
+    def test_passes_filters(self):
+        inst = _fake_exa_instance([])
+        with patch("cognee_community_tasks_exa.exa_task.Exa", return_value=inst):
+            asyncio.run(
+                search_web(
+                    "q",
+                    include_domains=["example.com"],
+                    exclude_domains=["spam.com"],
+                    category="research paper",
+                    start_published_date="2026-01-01",
+                    end_published_date="2026-04-01",
+                    include_highlights=True,
+                    include_summary=True,
+                    summary_query="summarize this",
+                )
+            )
+        kwargs = inst.search_and_contents.call_args.kwargs
+        assert kwargs["include_domains"] == ["example.com"]
+        assert kwargs["exclude_domains"] == ["spam.com"]
+        assert kwargs["category"] == "research paper"
+        assert kwargs["start_published_date"] == "2026-01-01"
+        assert kwargs["end_published_date"] == "2026-04-01"
+        assert kwargs["highlights"] is True
+        assert kwargs["summary"] == {"query": "summarize this"}
+
+    def test_explicit_api_key_is_used(self):
+        inst = _fake_exa_instance([])
+        with patch("cognee_community_tasks_exa.exa_task.Exa", return_value=inst) as mock_cls:
+            asyncio.run(search_web("q", api_key="explicit-key"))
+        mock_cls.assert_called_once_with(api_key="explicit-key")
+
+
+class TestContentFallback:
+    def test_prefers_text_over_summary_and_highlights(self):
+        r = _parse_result(_fake_result(text="full text", summary="summary text", highlights=["h1"]))
+        assert r.best_content() == "full text"
+
+    def test_falls_back_to_summary_when_text_missing(self):
+        r = _parse_result(_fake_result(text=None, summary="summary text", highlights=["h1"]))
+        assert r.best_content() == "summary text"
+
+    def test_falls_back_to_highlights_when_text_and_summary_missing(self):
+        r = _parse_result(_fake_result(text=None, summary=None, highlights=["h1", "h2"]))
+        assert r.best_content() == "h1\nh2"
+
+    def test_returns_empty_when_nothing_available(self):
+        r = _parse_result(_fake_result(text=None, summary=None, highlights=None))
+        assert r.best_content() == ""
+
+    def test_parses_dict_input(self):
+        r = _parse_result(
+            {
+                "url": "https://x.example",
+                "title": "X",
+                "text": "text",
+                "highlights": ["h"],
+                "score": 0.5,
+                "publishedDate": "2026-01-01",
+            }
+        )
+        assert isinstance(r, ExaSearchResult)
+        assert r.url == "https://x.example"
+        assert r.highlights == ["h"]
+        assert r.published_date == "2026-01-01"
+
+
+class TestSearchAndAdd:
+    def test_raises_when_no_results_have_content(self):
+        inst = _fake_exa_instance([_fake_result(text=None, summary=None, highlights=None)])
+
+        with (
+            patch("cognee_community_tasks_exa.exa_task.Exa", return_value=inst),
+            pytest.raises(RuntimeError, match="No Exa results"),
+        ):
+            asyncio.run(search_and_add(query="q"))
+
+    def test_calls_cognee_add_and_cognify(self):
+        inst = _fake_exa_instance([_fake_result(text="body content")])
+
+        mock_cognee = MagicMock()
+        mock_cognee.add = AsyncMock()
+        mock_cognee.cognify = AsyncMock(return_value="graph_result")
+
+        with (
+            patch("cognee_community_tasks_exa.exa_task.Exa", return_value=inst),
+            patch("cognee_community_tasks_exa.exa_task.cognee", mock_cognee),
+        ):
+            result = asyncio.run(search_and_add(query="q", dataset_name="test_dataset"))
+
+        mock_cognee.add.assert_called_once()
+        call_kwargs = mock_cognee.add.call_args
+        assert "test_dataset" in str(call_kwargs)
+
+        mock_cognee.cognify.assert_called_once()
+        assert result == "graph_result"


### PR DESCRIPTION
## Summary

Adds `cognee-community-tasks-exa`, a new task package that lets cognee pipelines search the web with [Exa](https://exa.ai) and optionally ingest the results into a cognee dataset.

- **`search_web`** runs a neural/hybrid web search with Exa and returns structured results. Exposes search types (`auto`, `neural`, `fast`, `deep-lite`, `deep`, `deep-reasoning`, `instant`), categories (e.g. `research paper`, `news`, `company`), domain allow/deny lists, date-range filters, and content modes (full text, highlights, LLM summary).
- **`search_and_add`** runs the search and passes the combined content to `cognee.add` + `cognee.cognify`, matching the shape of the existing `scrapegraph_tasks` package.

## Example

```python
import asyncio
from cognee_community_tasks_exa import search_web, search_and_add

# Search only
results = asyncio.run(
    search_web(
        query="Latest advances in retrieval augmented generation",
        num_results=5,
        include_highlights=True,
        category="research paper",
    )
)

# Search + ingest into cognee
asyncio.run(
    search_and_add(
        query="How do knowledge graphs improve LLM memory?",
        num_results=5,
        dataset_name="exa_search",
    )
)
```

Requires `EXA_API_KEY` (free tier available at https://dashboard.exa.ai).

## Files changed

- `packages/task/exa_tasks/` — new package (code, tests, example, README, pyproject)
- `README.md` — registers the new package in the Custom Packages table

## Package layout

Follows the same structure as `cognee-community-tasks-scrapegraph`:

```
packages/task/exa_tasks/
  cognee_community_tasks_exa/
    __init__.py
    exa_task.py
  examples/example.py
  tests/test_exa.py
  README.md
  pyproject.toml
```

## Test plan

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `pytest tests/` — 13/13 pass (response parsing, content fallback across text/summary/highlights, missing-API-key guard, filter propagation, cognee ingestion path)
- [ ] `examples/example.py` — requires live `EXA_API_KEY` and `LLM_API_KEY`; not exercised in CI

## DCO

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.