### PR TITLE
feat: add Moss vector adapter

### DIFF
--- a/packages/vector/moss/.env.example
+++ b/packages/vector/moss/.env.example
@@ -1,0 +1,6 @@
+MOSS_PROJECT_ID=your-project-id
+MOSS_PROJECT_KEY=your-project-key
+
+LLM_API_KEY=your-openai-api-key
+LLM_MODEL=openai/gpt-4o-mini
+LLM_PROVIDER=openai

--- a/packages/vector/moss/README.md
+++ b/packages/vector/moss/README.md
@@ -1,0 +1,84 @@
+# Cognee Community Vector Adapter - Moss
+
+Use [Moss](https://usemoss.dev) as the vector database for [Cognee](https://github.com/topoteretes/cognee).
+
+Moss is a vector search service - indexes are built in the cloud and loaded locally for sub-10ms queries. No infrastructure to manage. Create an account, grab your credentials, and plug them in.
+
+## Prerequisites
+
+1. Create a Moss account at [portal.usemoss.dev](https://portal.usemoss.dev)
+2. Create a project and copy your **Project ID** and **Project Key**
+3. An OpenAI API key (Cognee uses it for LLM and embeddings by default)
+
+## Installation
+
+```bash
+pip install cognee-community-vector-adapter-moss
+```
+
+Or install from source:
+
+```bash
+cd packages/vector/moss
+pip install -e .
+```
+
+## Configuration
+
+Set environment variables:
+
+```bash
+export MOSS_PROJECT_ID="your-project-id"
+export MOSS_PROJECT_KEY="your-project-key"
+export LLM_API_KEY="your-openai-api-key"
+```
+
+Or create a `.env` file (see `.env.example`).
+
+## Usage
+
+```python
+import asyncio
+import os
+from cognee_community_vector_adapter_moss import register  # noqa: F401
+from cognee import add, cognify, config, search
+
+async def main():
+    config.set_vector_db_config({
+        "vector_db_provider": "moss",
+        "vector_db_key": os.getenv("MOSS_PROJECT_KEY"),
+        "vector_db_name": os.getenv("MOSS_PROJECT_ID"),
+        "vector_dataset_database_handler": "moss",
+    })
+
+    await add("Natural language processing is a subfield of computer science.")
+    await cognify()
+
+    results = await search(query_text="Tell me about NLP")
+    for r in results:
+        print(r)
+
+asyncio.run(main())
+```
+
+## How It Works
+
+The adapter multiplexes all Cognee collections into a **single Moss index** (`cognee-index-{timestamp}`). This keeps usage within Moss's free tier (3 indexes). Each document is tagged with a `_collection` metadata field, and all searches filter by it.
+
+- Embeddings are computed by Cognee's embedding engine and passed to Moss via `DocumentInfo(embedding=[...])`
+- The index is loaded locally via `load_index(auto_refresh=True)` for fast sub-10ms queries
+- Async Moss jobs (`create_index`, `add_docs`) are polled to completion internally
+
+## Running Tests
+
+```bash
+MOSS_PROJECT_ID="..." MOSS_PROJECT_KEY="..." LLM_API_KEY="..." python tests/test_moss.py
+```
+
+Tests cover: vector search (text + vector), nodeset filtering, graph completion, chunks, summaries, and prune cleanup.
+
+## Resources
+
+- [Moss Documentation](https://docs.moss.dev)
+- [Moss Quickstart](https://docs.moss.dev/docs/start/quickstart)
+- [Cognee Documentation](https://docs.cognee.dev)

--- a/packages/vector/moss/cognee_community_vector_adapter_moss/MossDatasetDatabaseHandler.py
+++ b/packages/vector/moss/cognee_community_vector_adapter_moss/MossDatasetDatabaseHandler.py
@@ -1,0 +1,37 @@
+from typing import Optional
+from uuid import UUID
+
+from cognee.infrastructure.databases.dataset_database_handler import DatasetDatabaseHandlerInterface
+from cognee.infrastructure.databases.vector import get_vectordb_config
+from cognee.infrastructure.databases.vector.create_vector_engine import create_vector_engine
+from cognee.modules.users.models import DatasetDatabase, User
+
+
+class MossDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
+    @classmethod
+    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        vector_config = get_vectordb_config()
+
+        if vector_config.vector_db_provider != "moss":
+            raise ValueError(
+                "MossDatasetDatabaseHandler can only be used with the "
+                "Moss vector database provider."
+            )
+
+        return {
+            "vector_database_provider": vector_config.vector_db_provider,
+            "vector_database_url": vector_config.vector_db_url,
+            "vector_database_key": vector_config.vector_db_key,
+            "vector_database_name": vector_config.vector_db_name,
+            "vector_dataset_database_handler": "moss",
+        }
+
+    @classmethod
+    async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
+        vector_engine = create_vector_engine(
+            vector_db_provider=dataset_database.vector_database_provider,
+            vector_db_url=dataset_database.vector_database_url,
+            vector_db_key=dataset_database.vector_database_key,
+            vector_db_name=dataset_database.vector_database_name,
+        )
+        await vector_engine.prune()

--- a/packages/vector/moss/cognee_community_vector_adapter_moss/__init__.py
+++ b/packages/vector/moss/cognee_community_vector_adapter_moss/__init__.py
@@ -1,0 +1,3 @@
+from .moss_adapter import MossAdapter
+
+__all__ = ["MossAdapter"]

--- a/packages/vector/moss/cognee_community_vector_adapter_moss/moss_adapter.py
+++ b/packages/vector/moss/cognee_community_vector_adapter_moss/moss_adapter.py
@@ -1,0 +1,388 @@
+import asyncio
+import json
+import time
+from typing import List, Optional
+
+from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
+from cognee.infrastructure.databases.vector import VectorDBInterface
+from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.engine.utils import parse_id
+from cognee.shared.logging_utils import get_logger
+from moss import (
+    DocumentInfo,
+    GetDocumentsOptions,
+    JobStatus,
+    MossClient,
+    MutationOptions,
+    QueryOptions,
+)
+
+logger = get_logger("MossAdapter")
+
+JOB_POLL_INTERVAL = 2
+JOB_POLL_TIMEOUT = 300
+RETRY_COUNT = 3
+RETRY_BACKOFF = 2
+
+
+def _stringify_metadata(obj):
+    """Flatten a dict so all values are strings (Moss requirement)."""
+    result = {}
+    for k, v in obj.items():
+        if isinstance(v, str):
+            result[str(k)] = v
+        elif isinstance(v, (dict, list)):
+            result[str(k)] = json.dumps(v)
+        else:
+            result[str(k)] = str(v)
+    return result
+
+
+class IndexSchema(DataPoint):
+    text: str
+
+    metadata: dict = {"index_fields": ["text"]}
+    belongs_to_set: List[str] = []
+
+
+class MossAdapter(VectorDBInterface):
+    name = "Moss"
+
+    def __init__(
+        self,
+        url,
+        api_key,
+        embedding_engine: EmbeddingEngine,
+        database_name: str = "cognee_db",
+    ):
+        self.embedding_engine = embedding_engine
+        self.database_name = database_name
+        self.api_key = api_key
+        self.client = MossClient(project_id=database_name, project_key=api_key)
+        self._index_name = f"cognee-index-{int(time.time())}"
+        self._index_ready = False
+        self._index_loaded = False
+        self._collections: set[str] = set()
+        self._create_lock = asyncio.Lock()
+        self._load_lock = asyncio.Lock()
+
+    async def _find_existing_index(self):
+        """Check if a cognee index already exists in the project."""
+        if self._index_ready:
+            return True
+        try:
+            indexes = await self.client.list_indexes()
+            for idx in indexes:
+                if idx.name.startswith("cognee-index-"):
+                    self._index_name = idx.name
+                    self._index_ready = True
+                    return True
+        except Exception:
+            pass
+        return False
+
+    async def _create_index_with_docs(self, docs: list[DocumentInfo]):
+        """Create the Moss index with the first batch of real documents."""
+        async with self._create_lock:
+            if self._index_ready:
+                return
+            try:
+                logger.info("Creating Moss index '%s' with %d docs", self._index_name, len(docs))
+                result = await self.client.create_index(self._index_name, docs)
+                await self._wait_for_job(result.job_id)
+                self._index_ready = True
+                logger.info("Moss index '%s' created", self._index_name)
+            except Exception as e:
+                logger.error("Error creating Moss index: %s", str(e))
+                raise
+
+    async def _load_index(self):
+        """Load the index locally for querying. Only needed before search/retrieve."""
+        if self._index_loaded:
+            return
+        async with self._load_lock:
+            if self._index_loaded:
+                return
+            logger.info("Loading Moss index '%s' locally", self._index_name)
+            await self.client.load_index(self._index_name, auto_refresh=True)
+            self._index_loaded = True
+            logger.info("Moss index '%s' loaded", self._index_name)
+
+    async def _wait_for_job(self, job_id: str):
+        elapsed = 0
+        while elapsed < JOB_POLL_TIMEOUT:
+            resp = await self.client.get_job_status(job_id)
+            status_val = resp.status.value
+            if status_val == "completed":
+                return resp
+            if status_val == "failed":
+                raise RuntimeError(f"Moss job {job_id} failed: {resp.error}")
+            await asyncio.sleep(JOB_POLL_INTERVAL)
+            elapsed += JOB_POLL_INTERVAL
+        raise TimeoutError(f"Moss job {job_id} timed out after {JOB_POLL_TIMEOUT}s")
+
+    async def embed_data(self, data: list[str]) -> list[float]:
+        return await self.embedding_engine.embed_text(data)
+
+    async def has_collection(self, collection_name: str) -> bool:
+        if collection_name in self._collections:
+            return True
+        await self._find_existing_index()
+        return self._index_ready
+
+    async def create_collection(
+        self,
+        collection_name: str,
+        payload_schema=None,
+    ):
+        self._collections.add(collection_name)
+
+    async def create_data_points(self, collection_name: str, data_points: list[DataPoint]):
+        self._collections.add(collection_name)
+
+        data_vectors = await self.embed_data(
+            [DataPoint.get_embeddable_data(data_point) for data_point in data_points]
+        )
+
+        docs = []
+        for i, data_point in enumerate(data_points):
+            raw = data_point.model_dump()
+            payload = _stringify_metadata({
+                **raw,
+                "_collection": collection_name,
+                "database_name": self.database_name,
+            })
+            docs.append(
+                DocumentInfo(
+                    id=str(data_point.id),
+                    text=DataPoint.get_embeddable_data(data_point),
+                    metadata=payload,
+                    embedding=data_vectors[i],
+                )
+            )
+
+        try:
+            if not self._index_ready:
+                await self._find_existing_index()
+
+            if not self._index_ready:
+                await self._create_index_with_docs(docs)
+            else:
+                logger.info("Adding %d docs to Moss index '%s' [%s]", len(docs), self._index_name, collection_name)
+                result = await self.client.add_docs(
+                    self._index_name, docs, MutationOptions(upsert=True)
+                )
+                await self._wait_for_job(result.job_id)
+                self._index_loaded = False
+        except Exception as e:
+            logger.error("Error adding data points to Moss: %s", str(e))
+            raise
+
+    async def create_vector_index(self, index_name: str, index_property_name: str):
+        await self.create_collection(f"{index_name}_{index_property_name}")
+
+    async def index_data_points(
+        self, index_name: str, index_property_name: str, data_points: list[DataPoint]
+    ):
+        await self.create_data_points(
+            f"{index_name}_{index_property_name}",
+            [
+                IndexSchema(
+                    id=data_point.id,
+                    text=getattr(data_point, data_point.metadata["index_fields"][0]),
+                    belongs_to_set=(data_point.belongs_to_set or []),
+                )
+                for data_point in data_points
+            ],
+        )
+
+    async def retrieve(self, collection_name: str, data_point_ids: list[str]):
+        if not self._index_ready:
+            await self._find_existing_index()
+        if not self._index_ready:
+            return []
+        await self._load_index()
+        try:
+            docs = await self.client.get_docs(
+                self._index_name, GetDocumentsOptions(doc_ids=data_point_ids)
+            )
+            return [
+                ScoredResult(
+                    id=parse_id(doc.id),
+                    payload=doc.metadata,
+                    score=0.0,
+                )
+                for doc in docs
+                if doc.metadata and doc.metadata.get("_collection") == collection_name
+            ]
+        except Exception as e:
+            logger.error("Error retrieving from Moss: %s", str(e))
+            return []
+
+    async def search(
+        self,
+        collection_name: str,
+        query_text: str | None = None,
+        query_vector: list[float] | None = None,
+        limit: int | None = 15,
+        with_vector: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: str = "OR",
+    ) -> list[ScoredResult]:
+        if query_text is None and query_vector is None:
+            raise MissingQueryParameterError()
+
+        if not await self.has_collection(collection_name):
+            return []
+
+        await self._load_index()
+
+        if query_vector is None:
+            query_vector = (await self.embed_data([query_text]))[0]
+
+        effective_limit = limit or 15
+        if node_name:
+            effective_limit = effective_limit * 5
+
+        query_opts = QueryOptions(
+            top_k=effective_limit,
+            embedding=query_vector,
+        )
+
+        metadata_filter = self._build_filter(collection_name)
+        if metadata_filter:
+            query_opts.filter = metadata_filter
+
+        last_err = None
+        for attempt in range(RETRY_COUNT):
+            try:
+                result = await self.client.query(
+                    self._index_name,
+                    query_text or "",
+                    query_opts,
+                )
+
+                scored = [
+                    ScoredResult(
+                        id=parse_id(doc.id),
+                        payload=doc.metadata if include_payload else None,
+                        score=1 - doc.score if hasattr(doc, "score") and doc.score is not None else 0.0,
+                    )
+                    for doc in result.docs
+                ]
+
+                if node_name:
+                    pre_filter = len(scored)
+                    scored = self._filter_by_node_name(
+                        scored, result.docs, node_name, node_name_filter_operator
+                    )
+                    scored = scored[: limit or 15]
+                    logger.info("Moss search '%s': %d results (%d before nodeset filter)", collection_name, len(scored), pre_filter)
+                else:
+                    logger.info("Moss search '%s': %d results", collection_name, len(scored))
+
+                return scored
+            except Exception as e:
+                last_err = e
+                if "503" in str(e) or "502" in str(e) or "429" in str(e):
+                    logger.warning("Moss search attempt %d/%d failed (retryable): %s", attempt + 1, RETRY_COUNT, str(e))
+                    await asyncio.sleep(RETRY_BACKOFF * (attempt + 1))
+                    continue
+                logger.error("Error in Moss search: %s", str(e), exc_info=True)
+                return []
+        logger.error("Moss search failed after %d retries: %s", RETRY_COUNT, str(last_err))
+        return []
+
+    def _build_filter(self, collection_name: str) -> Optional[dict]:
+        conditions = [
+            {"field": "_collection", "condition": {"$eq": collection_name}},
+            {"field": "database_name", "condition": {"$eq": self.database_name}},
+        ]
+        return {"$and": conditions}
+
+    @staticmethod
+    def _filter_by_node_name(
+        scored: list[ScoredResult],
+        raw_docs,
+        node_name: List[str],
+        operator: str,
+    ) -> list[ScoredResult]:
+        """Post-query filter on belongs_to_set (stored as JSON string in Moss metadata)."""
+        filtered = []
+        for sr, doc in zip(scored, raw_docs):
+            raw = doc.metadata.get("belongs_to_set", "[]") if doc.metadata else "[]"
+            try:
+                doc_sets = set(json.loads(raw))
+            except (json.JSONDecodeError, TypeError):
+                doc_sets = set()
+
+            requested = set(node_name)
+            if operator == "AND":
+                if requested.issubset(doc_sets):
+                    filtered.append(sr)
+            else:
+                if requested & doc_sets:
+                    filtered.append(sr)
+        return filtered
+
+    async def batch_search(
+        self,
+        collection_name: str,
+        query_texts: list[str],
+        limit: int | None = None,
+        with_vectors: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: str = "OR",
+    ):
+        results = await asyncio.gather(
+            *[
+                self.search(
+                    collection_name=collection_name,
+                    query_text=text,
+                    limit=limit,
+                    with_vector=with_vectors,
+                    include_payload=include_payload,
+                    node_name=node_name,
+                    node_name_filter_operator=node_name_filter_operator,
+                )
+                for text in query_texts
+            ]
+        )
+        return list(results)
+
+    async def delete_data_points(self, collection_name: str, data_point_ids: list[str]):
+        if not self._index_ready:
+            await self._find_existing_index()
+        if not self._index_ready:
+            return
+        try:
+            result = await self.client.delete_docs(self._index_name, data_point_ids)
+            return result
+        except Exception as e:
+            logger.error("Error deleting from Moss: %s", str(e))
+            raise
+
+    async def prune(self):
+        logger.info("Pruning Moss indexes")
+        try:
+            indexes = await self.client.list_indexes()
+            for index in indexes:
+                if index.name.startswith("cognee-index-"):
+                    if self._index_loaded:
+                        await self.client.unload_index(index.name)
+                    await self.client.delete_index(index.name)
+            self._collections.clear()
+            self._index_ready = False
+            self._index_loaded = False
+        except RuntimeError as e:
+            if "403" in str(e) or "Authentication" in str(e):
+                logger.warning("Moss prune skipped (invalid credentials): %s", str(e))
+            else:
+                raise
+        except Exception as e:
+            logger.error("Error pruning Moss indexes: %s", str(e))
+            raise

--- a/packages/vector/moss/cognee_community_vector_adapter_moss/register.py
+++ b/packages/vector/moss/cognee_community_vector_adapter_moss/register.py
@@ -1,0 +1,8 @@
+from cognee.infrastructure.databases.dataset_database_handler import use_dataset_database_handler
+from cognee.infrastructure.databases.vector import use_vector_adapter
+
+from .moss_adapter import MossAdapter
+from .MossDatasetDatabaseHandler import MossDatasetDatabaseHandler
+
+use_vector_adapter("moss", MossAdapter)
+use_dataset_database_handler("moss", MossDatasetDatabaseHandler, "moss")

--- a/packages/vector/moss/example.py
+++ b/packages/vector/moss/example.py
@@ -1,0 +1,45 @@
+import asyncio
+import os
+import pathlib
+
+from dotenv import load_dotenv
+
+load_dotenv(pathlib.Path(__file__).parent / ".env")
+
+from cognee_community_vector_adapter_moss import register  # noqa: F401
+
+
+async def main():
+    from cognee import SearchType, add, cognify, config, prune, search
+
+    config.set_vector_db_config(
+        {
+            "vector_db_provider": "moss",
+            "vector_db_key": os.getenv("MOSS_PROJECT_KEY", ""),
+            "vector_db_name": os.getenv("MOSS_PROJECT_ID", ""),
+            "vector_dataset_database_handler": "moss",
+        }
+    )
+
+    await prune.prune_data()
+    await prune.prune_system(metadata=True)
+
+    text = """
+    Natural language processing (NLP) is an interdisciplinary
+    subfield of computer science and information retrieval.
+    """
+
+    await add(text)
+
+    await cognify()
+
+    query_text = "Tell me about NLP"
+
+    search_results = await search(query_type=SearchType.GRAPH_COMPLETION, query_text=query_text)
+
+    for result_text in search_results:
+        print(result_text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/vector/moss/pyproject.toml
+++ b/packages/vector/moss/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "cognee-community-vector-adapter-moss"
+version = "0.1.0"
+description = "Moss vector database adapter for cognee"
+readme = "README.md"
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "moss>=1.0.0",
+    "cognee>=1.0.0",
+    "python-dotenv>=0.19.0"
+]

--- a/packages/vector/moss/tests/test_moss.py
+++ b/packages/vector/moss/tests/test_moss.py
@@ -1,0 +1,160 @@
+import os
+import pathlib
+
+from dotenv import load_dotenv
+
+load_dotenv(pathlib.Path(__file__).parent.parent / ".env")
+
+import cognee
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.modules.search.operations import get_history
+from cognee.modules.search.types import SearchType
+from cognee.modules.users.methods import get_default_user
+from cognee.shared.logging_utils import get_logger
+
+from cognee_community_vector_adapter_moss import register  # noqa: F401
+
+logger = get_logger()
+
+TEST_DATA_DIR = pathlib.Path(__file__).parent.parent.parent.parent / "test_data"
+
+
+async def main():
+    cognee.config.set_vector_db_config(
+        {
+            "vector_db_provider": "moss",
+            "vector_db_key": os.getenv("MOSS_PROJECT_KEY", ""),
+            "vector_db_name": os.getenv("MOSS_PROJECT_ID", ""),
+            "vector_dataset_database_handler": "moss",
+        }
+    )
+
+    data_directory_path = str(
+        pathlib.Path(
+            os.path.join(pathlib.Path(__file__).parent, ".data_storage/test_moss")
+        ).resolve()
+    )
+    cognee.config.data_root_directory(data_directory_path)
+    cognee_directory_path = str(
+        pathlib.Path(
+            os.path.join(pathlib.Path(__file__).parent, ".cognee_system/test_moss")
+        ).resolve()
+    )
+    cognee.config.system_root_directory(cognee_directory_path)
+
+    # Clean slate
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    # Add both files with node sets, cognify once
+    nlp_path = str(TEST_DATA_DIR / "Natural_language_processing.txt")
+    quantum_path = str(TEST_DATA_DIR / "Quantum_computers.txt")
+
+    await cognee.add([nlp_path], "natural_language", node_set=["NLP"])
+    await cognee.add([quantum_path], "quantum", node_set=["Quantum", "Computers"])
+    await cognee.cognify(["quantum", "natural_language"])
+
+    # Test: document retrieval
+    from cognee.modules.users.permissions.methods import get_document_ids_for_user
+
+    user = await get_default_user()
+    document_ids = await get_document_ids_for_user(user.id, ["natural_language"])
+    assert len(document_ids) == 1, f"Expected 1 doc in natural_language, got {len(document_ids)}"
+
+    document_ids = await get_document_ids_for_user(user.id)
+    assert len(document_ids) == 2, f"Expected 2 total docs, got {len(document_ids)}"
+    print("PASSED: document_retrieval")
+
+    # Test: vector search with query_vector
+    vector_engine = get_vector_engine()
+    query_text = "Tell me about NLP"
+    query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
+
+    result = await vector_engine.search(
+        collection_name="Entity_name", query_vector=query_vector, limit=5
+    )
+    assert len(result) > 0, "Search returned no results"
+    assert all(hasattr(r, "id") and hasattr(r, "score") for r in result)
+    print("PASSED: vector_search")
+
+    # Test: vector search with query_text
+    result = await vector_engine.search(
+        collection_name="Entity_name",
+        query_text="Natural language processing",
+        limit=5,
+        include_payload=True,
+    )
+    assert len(result) > 0, "Text search returned no results"
+    assert result[0].payload is not None, "Payload should be included"
+    print("PASSED: text_search")
+
+    # Test: graph completion search
+    random_node = (
+        await vector_engine.search(
+            collection_name="Entity_name", query_text="Quantum computer", include_payload=True
+        )
+    )[0]
+    random_node_name = random_node.payload["text"]
+
+    search_results = await cognee.search(
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
+    )
+    assert len(search_results) != 0, "Graph completion search results are empty"
+    print("PASSED: graph_completion_search")
+
+    # Test: chunks search with dataset filter
+    search_results = await cognee.search(
+        query_type=SearchType.CHUNKS, query_text=random_node_name, datasets=["quantum"]
+    )
+    assert len(search_results) != 0, "Chunks search results are empty"
+    print("PASSED: chunks_search")
+
+    # Test: summaries search
+    search_results = await cognee.search(
+        query_type=SearchType.SUMMARIES, query_text=random_node_name
+    )
+    assert len(search_results) != 0, "Summaries search results are empty"
+    print("PASSED: summaries_search")
+
+    # Test: search history
+    user = await get_default_user()
+    history = await get_history(user.id)
+    assert len(history) > 0, "Search history is empty"
+    print("PASSED: search_history")
+
+    # Test: nodeset filtering (OR) — NLP or Quantum should return results
+    result = await vector_engine.search(
+        collection_name="DocumentChunk_text",
+        query_vector=query_vector,
+        include_payload=True,
+        limit=10,
+        node_name=["NLP", "Quantum"],
+        node_name_filter_operator="OR",
+    )
+    assert len(result) > 0, "OR filter search returned no results"
+    print("PASSED: nodeset_filter_or")
+
+    # Test: nodeset filtering (AND) — NLP AND Quantum never overlap, expect empty
+    result = await vector_engine.search(
+        collection_name="DocumentChunk_text",
+        query_vector=query_vector,
+        include_payload=True,
+        limit=10,
+        node_name=["NLP", "Quantum"],
+        node_name_filter_operator="AND",
+    )
+    assert len(result) == 0, f"AND filter for non-overlapping nodesets should return empty, got {len(result)}"
+    print("PASSED: nodeset_filter_and")
+
+    # Test: prune cleans up
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    print("PASSED: prune")
+
+    print("\nAll tests passed!")
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
## Description

Add [Moss](https://usemoss.dev) as a community vector database adapter for Cognee. Moss builds indexes in the cloud and loads them locally for sub-10ms queries.

**What's included:**
- `MossAdapter` implementing `VectorDBInterface` (single-index architecture, metadata-based collection filtering)
- `MossDatasetDatabaseHandler` for per-dataset isolation
- Auto-registration via `from cognee_community_vector_adapter_moss import register`
- `example.py`, `tests/test_moss.py`, `README.md`, `pyproject.toml`, `.env.example`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.