### PR TITLE
feat: ArcadeDB hybrid adapter (graph + vector) — Cognee 1.0+ compatible

### DIFF
--- a/packages/hybrid/arcadedb/README.md
+++ b/packages/hybrid/arcadedb/README.md
@@ -1,0 +1,186 @@
+# Cognee Community ArcadeDB Hybrid Adapter
+
+A community-maintained adapter that enables [Cognee](https://github.com/topoteretes/cognee) to work with [ArcadeDB](https://arcadedb.com/) as a unified hybrid database — both graph and vector operations in a single engine.
+
+Based on [PR#94](https://github.com/topoteretes/cognee-community/pull/94) by [@lvca](https://github.com/lvca) (ArcadeDB team) with additional fixes for Cognee 1.0+ compatibility and production reliability.
+
+## Installation
+
+```bash
+pip install cognee-community-hybrid-adapter-arcadedb
+
+# Optional: Bolt protocol support (faster graph operations)
+pip install "cognee-community-hybrid-adapter-arcadedb[bolt]"
+```
+
+## Usage
+
+```python
+import asyncio
+import os
+import pathlib
+from os import path
+from cognee import config, prune, add, cognify, search, SearchType
+
+# Import the register module to enable ArcadeDB support
+from cognee_community_hybrid_adapter_arcadedb import register
+
+async def main():
+    # Set up local directories
+    system_path = pathlib.Path(__file__).parent
+    config.system_root_directory(path.join(system_path, ".cognee_system"))
+    config.data_root_directory(path.join(system_path, ".cognee_data"))
+
+    # Configure databases
+    config.set_relational_db_config({
+        "db_provider": "sqlite",
+    })
+
+    # Configure ArcadeDB as both vector and graph database
+    config.set_vector_db_config({
+        "vector_db_provider": "arcadedb",
+        "vector_db_url": os.getenv("ARCADEDB_URL", "localhost"),
+        "vector_db_port": int(os.getenv("ARCADEDB_HTTP_PORT", "2480")),
+        "vector_db_username": os.getenv("ARCADEDB_USERNAME", "root"),
+        "vector_db_password": os.getenv("ARCADEDB_PASSWORD", ""),
+    })
+    config.set_graph_db_config({
+        "graph_database_provider": "arcadedb",
+        "graph_database_url": os.getenv("ARCADEDB_URL", "localhost"),
+        "graph_database_port": int(os.getenv("ARCADEDB_HTTP_PORT", "2480")),
+        "graph_database_username": os.getenv("ARCADEDB_USERNAME", "root"),
+        "graph_database_password": os.getenv("ARCADEDB_PASSWORD", ""),
+    })
+
+    # Optional: Clean previous data
+    await prune.prune_data()
+    await prune.prune_system(metadata=True)
+
+    # Add and process your content
+    await add("""
+    Natural language processing (NLP) is an interdisciplinary
+    subfield of computer science and information retrieval.
+    """)
+
+    await cognify()
+
+    # Search using graph completion
+    search_results = await search(
+        query_type=SearchType.GRAPH_COMPLETION,
+        query_text="Tell me about NLP",
+    )
+
+    for result in search_results:
+        print("\nSearch result:\n" + result)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Configuration
+
+The ArcadeDB adapter can be configured as both a vector database and graph database, providing true hybrid capabilities.
+
+### Environment Variables
+
+```bash
+export ARCADEDB_URL="localhost"
+export ARCADEDB_HTTP_PORT="2480"
+export ARCADEDB_USERNAME="root"
+export ARCADEDB_PASSWORD="your-password"
+export GRAPH_DATASET_DATABASE_HANDLER="arcadedb_graph_local"
+export VECTOR_DATASET_DATABASE_HANDLER="arcadedb_vector_local"
+```
+
+### ArcadeDB Setup
+
+ArcadeDB is a multi-model database that natively supports graph traversal, vector search, and document operations in a single engine.
+
+**HTTP only (simplest):**
+
+```bash
+docker run -p 2480:2480 \
+  -e JAVA_OPTS="-Darcadedb.server.rootPassword=your-password" \
+  arcadedata/arcadedb:latest
+```
+
+**With Bolt protocol (recommended for better graph performance):**
+
+```bash
+docker run -p 2480:2480 -p 7687:7687 \
+  -e JAVA_OPTS="-Darcadedb.server.rootPassword=your-password \
+    -Darcadedb.server.plugins=Bolt:com.arcadedb.bolt.BoltProtocolPlugin" \
+  arcadedata/arcadedb:latest
+```
+
+### Configuration Parameters
+
+**Graph Database Configuration:**
+- `graph_database_provider`: Set to `"arcadedb"`
+- `graph_database_url`: ArcadeDB server hostname (default: `"localhost"`)
+- `graph_database_port`: HTTP API port (default: `2480`)
+- `graph_database_username`: Database username
+- `graph_database_password`: Database password
+
+**Vector Database Configuration:**
+- `vector_db_provider`: Set to `"arcadedb"`
+- `vector_db_url`: ArcadeDB server hostname (default: `"localhost"`)
+- `vector_db_port`: HTTP API port (default: `2480`)
+- `vector_db_username`: Database username
+- `vector_db_password`: Database password
+
+## How it works
+
+### Graph operations
+
+Graph operations use the **Neo4j Bolt protocol** when the `BoltProtocolPlugin` is enabled (port 7687), with automatic fallback to the **HTTP API** (OpenCypher). The adapter verifies Bolt connectivity on first use and transparently falls back if unavailable.
+
+### Vector operations
+
+Vector operations use ArcadeDB's HTTP API for SQL queries:
+
+- **Index creation**: `CREATE INDEX ... LSM_VECTOR METADATA { dimensions: N, similarity: 'COSINE' }`
+- **Vector storage**: Stored as `ARRAY_OF_FLOATS` properties on vertex records
+- **Search**: `SELECT expand(vectorNeighbors('Type[prop]', [vec], k))` returns results sorted by distance
+
+### Auto-detection
+
+The adapter automatically:
+- Detects the Cypher vertex type casing (`Vertex` vs `vertex`) based on ArcadeDB version
+- Creates the target database on first use (if it doesn't exist)
+- Retries on HTTP 503 `ConcurrentModificationException` (ArcadeDB uses optimistic concurrency)
+
+## Key differences from PR#94
+
+This adapter is based on [PR#94](https://github.com/topoteretes/cognee-community/pull/94) by [@lvca](https://github.com/lvca) with the following improvements:
+
+| Area | Description |
+|------|-------------|
+| **Bug fix** | `index_data_points()` now delegates to `create_data_points()` for proper vector embedding and storage. Without this fix, vectors are never populated on TextSummary/DocumentChunk nodes, making vector search return empty results. |
+| **Cognee 1.0+** | `get_neighborhood()` implementation for the new `GraphDBInterface` API |
+| **Compatibility** | Auto-detection of Cypher type casing (ArcadeDB 26.3 vs 26.4+) |
+| **Reliability** | Retry with backoff on HTTP 503 `ConcurrentModificationException` |
+| **Database** | Lazy auto-creation with privilege-aware probing (from PR#94 commit `2b0b9f7`) |
+
+## Requirements
+
+- Python >= 3.11, <= 3.13
+- ArcadeDB >= 26.3 (tested with 26.4.2)
+- Cognee >= 1.0.3
+
+## About ArcadeDB
+
+ArcadeDB is a multi-model database engine that combines the power of graph databases, document stores, and vector search in a single, unified system:
+
+- **Graph**: Full OpenCypher and Gremlin support, with Neo4j Bolt protocol compatibility
+- **Vector**: Native HNSW/LSM_VECTOR indexes with cosine/euclidean similarity
+- **Document**: JSON document storage with SQL queries
+- **Multi-model**: Use all paradigms together in a single query
+
+Key benefits:
+- **No separate vector DB needed** — keep embeddings co-located with the knowledge graph
+- **Distributed via Raft** — built-in high availability (no external coordination service)
+- **Low latency** — optimized for fast traversals and real-time analytics
+- **SQL + Cypher** — query in either language, or mix them
+
+Learn more at [arcadedb.com](https://arcadedb.com/) and the [GitHub repository](https://github.com/ArcadeData/arcadedb).

--- a/packages/hybrid/arcadedb/__init__.py
+++ b/packages/hybrid/arcadedb/__init__.py
@@ -1,0 +1,1 @@
+"""ArcadeDB hybrid adapter package for Cognee."""

--- a/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/ArcadeDBDatasetDatabaseHandlerGraphLocal.py
+++ b/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/ArcadeDBDatasetDatabaseHandlerGraphLocal.py
@@ -1,0 +1,50 @@
+from typing import Optional
+from uuid import UUID
+
+from cognee.infrastructure.databases.dataset_database_handler import DatasetDatabaseHandlerInterface
+from cognee.infrastructure.databases.graph import get_graph_config
+from cognee.infrastructure.databases.graph.get_graph_engine import create_graph_engine
+from cognee.modules.users.models import DatasetDatabase, User
+
+
+class ArcadeDBDatasetDatabaseHandlerGraphLocal(DatasetDatabaseHandlerInterface):
+    @classmethod
+    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        graph_config = get_graph_config()
+
+        if graph_config.graph_database_provider != "arcadedb":
+            raise ValueError(
+                "ArcadeDBDatasetDatabaseHandlerGraph can only be used with the "
+                "ArcadeDB graph database provider."
+            )
+
+        return {
+            "graph_database_name": f"{dataset_id}",
+            "graph_database_url": graph_config.graph_database_url,
+            "graph_database_provider": graph_config.graph_database_provider,
+            "graph_database_key": graph_config.graph_database_key,
+            "graph_dataset_database_handler": "arcadedb_graph_local",
+            "graph_database_connection_info": {
+                "graph_database_username": graph_config.graph_database_username,
+                "graph_database_password": graph_config.graph_database_password,
+            },
+        }
+
+    @classmethod
+    async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
+        graph_engine = create_graph_engine(
+            graph_database_provider=dataset_database.graph_database_provider,
+            graph_database_url=dataset_database.graph_database_url,
+            graph_database_name=dataset_database.graph_database_name,
+            graph_database_key=dataset_database.graph_database_key,
+            graph_database_username=dataset_database.graph_database_connection_info.get(
+                "graph_database_username", ""
+            ),
+            graph_database_password=dataset_database.graph_database_connection_info.get(
+                "graph_database_password", ""
+            ),
+            graph_dataset_database_handler="",
+            graph_file_path="",
+        )
+
+        await graph_engine.delete_graph()

--- a/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/ArcadeDBDatasetDatabaseHandlerVectorLocal.py
+++ b/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/ArcadeDBDatasetDatabaseHandlerVectorLocal.py
@@ -1,0 +1,37 @@
+from typing import Optional
+from uuid import UUID
+
+from cognee.infrastructure.databases.dataset_database_handler import DatasetDatabaseHandlerInterface
+from cognee.infrastructure.databases.vector import get_vectordb_config
+from cognee.infrastructure.databases.vector.create_vector_engine import create_vector_engine
+from cognee.modules.users.models import DatasetDatabase, User
+
+
+class ArcadeDBDatasetDatabaseHandlerVectorLocal(DatasetDatabaseHandlerInterface):
+    @classmethod
+    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        vector_config = get_vectordb_config()
+
+        if vector_config.vector_db_provider != "arcadedb":
+            raise ValueError(
+                "ArcadeDBDatasetDatabaseHandlerVector can only be used with the "
+                "ArcadeDB vector database provider."
+            )
+
+        return {
+            "vector_database_provider": vector_config.vector_db_provider,
+            "vector_database_url": vector_config.vector_db_url,
+            "vector_database_key": vector_config.vector_db_key,
+            "vector_database_name": f"{dataset_id}",
+            "vector_dataset_database_handler": "arcadedb_vector_local",
+        }
+
+    @classmethod
+    async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
+        vector_engine = create_vector_engine(
+            vector_db_provider=dataset_database.vector_database_provider,
+            vector_db_url=dataset_database.vector_database_url,
+            vector_db_key=dataset_database.vector_database_key,
+            vector_db_name=dataset_database.vector_database_name,
+        )
+        await vector_engine.prune()

--- a/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/__init__.py
+++ b/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/__init__.py
@@ -1,0 +1,1 @@
+"""ArcadeDB hybrid adapter for Cognee — graph + vector in one database."""

--- a/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/arcadedb_adapter.py
+++ b/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/arcadedb_adapter.py
@@ -1,0 +1,1473 @@
+"""ArcadeDB Hybrid Adapter for Graph and Vector Database
+
+ArcadeDB is a multi-model database that supports both graph traversal
+(OpenCypher) and vector search (SQL with LSM_VECTOR/HNSW indexes and
+the vectorNeighbors() function).
+
+Graph operations use either:
+- Neo4j Bolt protocol (if the BoltProtocolPlugin is enabled, port 7687)
+- HTTP API with Cypher (fallback, port 2480)
+
+Vector operations always use ArcadeDB's HTTP API for SQL queries
+(index creation, vector property updates, and KNN search).
+"""
+
+import asyncio
+import json
+import time
+from datetime import datetime
+from enum import Enum
+from textwrap import dedent
+from typing import Any, Optional
+from uuid import UUID
+
+import aiohttp
+from cognee.infrastructure.databases.graph.config import get_graph_context_config
+from cognee.infrastructure.databases.graph.graph_db_interface import (
+    EdgeData,
+    GraphDBInterface,
+    Node,
+    NodeData,
+)
+from cognee.infrastructure.databases.vector.embeddings import get_embedding_engine
+from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import (
+    EmbeddingEngine,
+)
+from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.infrastructure.databases.vector.vector_db_interface import (
+    VectorDBInterface,
+)
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.engine.utils import parse_id
+from cognee.modules.storage.utils import JSONEncoder
+from cognee.shared.logging_utils import ERROR, get_logger
+
+logger = get_logger("ArcadeDBAdapter", level=ERROR)
+
+
+class IndexSchema(DataPoint):
+    """Schema for indexing that includes text data and associated metadata."""
+
+    text: str
+    metadata: dict = {"index_fields": ["text"]}
+    belongs_to_set: list[str] = []
+
+
+class ArcadeDBAdapter(VectorDBInterface, GraphDBInterface):
+    """
+    Hybrid adapter for ArcadeDB supporting both graph and vector operations.
+
+    Graph operations use the Neo4j Bolt protocol when available (requires
+    the BoltProtocolPlugin on port 7687), falling back to HTTP API Cypher.
+    Vector operations always use the HTTP API for SQL queries.
+    """
+
+    def __init__(
+        self,
+        graph_database_url: str,
+        graph_database_username: Optional[str] = None,
+        graph_database_password: Optional[str] = None,
+        embedding_engine: Optional[EmbeddingEngine] = None,
+        driver: Optional[Any] = None,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        database_name: Optional[str] = "cognee",
+        **kwargs,
+    ):
+        raw_url = url if url else graph_database_url
+        self.graph_database_username = graph_database_username
+        self.graph_database_password = graph_database_password
+        self.database_name = database_name or "cognee"
+
+        # Derive host from URL
+        host = raw_url.split("://")[-1].split(":")[0].split("/")[0]
+
+        # HTTP base URL (always needed for SQL/vector operations)
+        http_port = kwargs.get("http_port", 2480)
+        self.http_base_url = f"http://{host}:{http_port}"
+
+        # Try to set up Bolt driver for graph operations
+        self._bolt_driver = None
+        bolt_port = kwargs.get("bolt_port", 7687)
+
+        if driver is not None:
+            # Pre-built driver provided
+            self._bolt_driver = driver
+            logger.info("Using provided Bolt driver")
+        else:
+            try:
+                from neo4j import AsyncGraphDatabase
+
+                bolt_url = f"bolt://{host}:{bolt_port}"
+                auth = None
+                if graph_database_username and graph_database_password:
+                    auth = (graph_database_username, graph_database_password)
+
+                self._bolt_driver = AsyncGraphDatabase.driver(
+                    bolt_url,
+                    auth=auth,
+                    max_connection_lifetime=120,
+                )
+                logger.info("Bolt driver initialized at %s", bolt_url)
+            except ImportError:
+                logger.info(
+                    "neo4j package not installed, using HTTP for Cypher"
+                )
+            except Exception as e:
+                logger.info(
+                    "Could not initialize Bolt driver: %s, using HTTP", e
+                )
+
+        self.embedding_engine = (
+            get_embedding_engine() if not embedding_engine else embedding_engine
+        )
+
+        # Track which vector indexes have been created this session
+        self._vector_indexes: set[str] = set()
+        # Track whether Bolt is confirmed working
+        self._bolt_verified = False
+        # Track whether the target database has been ensured
+        self._database_ensured = False
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _now() -> int:
+        """Return current time in milliseconds for updated_at fields."""
+        return int(time.time() * 1000)
+
+    @staticmethod
+    def _split_collection_name(collection_name: str) -> tuple[str, str]:
+        """Split Cognee collection names into logical type and indexed field."""
+        if "_" in collection_name:
+            logical_type, _, attr_name = collection_name.partition("_")
+        else:
+            logical_type = collection_name
+            attr_name = "text"
+
+        return logical_type, attr_name
+
+    _vector_storage_type_cache: Optional[str] = None
+
+    async def _vector_storage_type(self) -> str:
+        """
+        Auto-detect the physical ArcadeDB type used for vector storage.
+
+        ArcadeDB's Cypher MERGE creates vertex types whose case depends on the
+        server version: 26.3.x → ``vertex`` (lowercase), 26.4+ → ``Vertex``
+        (PascalCase).  Rather than hard-coding one or the other, we probe the
+        schema on first call and cache the result.
+        """
+        if self._vector_storage_type_cache is not None:
+            return self._vector_storage_type_cache
+
+        try:
+            result = await self._sql("SELECT types FROM schema")
+            for record in result.get("result", []):
+                types = record.get("types", [])
+                for t in types:
+                    if t.lower() == "vertex":
+                        self._vector_storage_type_cache = t
+                        return t
+        except Exception:
+            pass
+
+        # Default for modern ArcadeDB (26.4+)
+        self._vector_storage_type_cache = "Vertex"
+        return "Vertex"
+
+    @staticmethod
+    def _escape_sql_literal(value: str) -> str:
+        """Escape a string for safe embedding in simple SQL literals."""
+        return value.replace("'", "''")
+
+    async def _upsert_cypher_node(
+        self, node_id: str, properties: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Upsert a graph node through the generic Vertex-backed Cypher path."""
+        return await self._cypher(
+            "MERGE (node {id: $node_id}) "
+            "ON CREATE SET node += $properties, node.updated_at = $now "
+            "ON MATCH SET node += $properties, node.updated_at = $now "
+            "RETURN node.id AS nodeId",
+            {"node_id": node_id, "properties": properties, "now": self._now()},
+        )
+
+    async def _store_vertex_vectors(
+        self,
+        node_id: str,
+        node_type: str,
+        embeddable_properties: dict[str, Any],
+    ) -> None:
+        """
+        Persist embeddable property vectors on the shared Vertex storage.
+
+        Cognee's graph pipeline writes nodes through the generic `MERGE (node
+        {id: ...})` path, so vector properties must be updated on `Vertex`
+        records keyed by `id` and the logical `type`.
+        """
+        values_to_embed = [
+            (prop_name, str(prop_value))
+            for prop_name, prop_value in embeddable_properties.items()
+            if prop_value is not None and str(prop_value).strip()
+        ]
+        if not values_to_embed:
+            return
+
+        vectors = await self.embed_data(
+            [prop_value for _, prop_value in values_to_embed]
+        )
+        escaped_node_id = self._escape_sql_literal(node_id)
+        escaped_node_type = self._escape_sql_literal(node_type)
+
+        for (prop_name, _), vector in zip(values_to_embed, vectors):
+            if not vector:
+                continue
+
+            await self.create_vector_index(node_type, prop_name)
+
+            vector_prop = f"{prop_name}_vector"
+            vec_str = ",".join(str(f) for f in vector)
+            await self._sql(
+                f"UPDATE `{await self._vector_storage_type()}` "
+                f"SET `{vector_prop}` = [{vec_str}] "
+                f"WHERE id = '{escaped_node_id}' "
+                f"AND type = '{escaped_node_type}'"
+            )
+
+    def _get_auth(self) -> Optional[aiohttp.BasicAuth]:
+        if self.graph_database_username and self.graph_database_password:
+            return aiohttp.BasicAuth(
+                self.graph_database_username, self.graph_database_password
+            )
+        return None
+
+    async def _ensure_database(self) -> None:
+        """Make sure the target database exists before the first real call.
+
+        ArcadeDB does not auto-create databases on connect, so the very
+        first HTTP/Bolt call against a fresh server would otherwise fail
+        with a 500 ``Database '<name>' is not available``.
+
+        We first probe ``GET /api/v1/exists/<db>``, which any authenticated
+        database user can call. Only if the database is missing do we
+        attempt ``POST /api/v1/server create database <db>``, which requires
+        server-level (root) credentials. This keeps the adapter usable
+        for non-root users connecting to a pre-created database.
+        """
+        if self._database_ensured:
+            return
+
+        async with aiohttp.ClientSession(auth=self._get_auth()) as session:
+            # Step 1: check if the database already exists
+            exists_url = (
+                f"{self.http_base_url}/api/v1/exists/{self.database_name}"
+            )
+            async with session.get(exists_url) as resp:
+                exists_body = await resp.text()
+                if resp.status == 200:
+                    try:
+                        if json.loads(exists_body).get("result") is True:
+                            self._database_ensured = True
+                            return
+                    except (ValueError, AttributeError):
+                        pass
+                elif resp.status in (401, 403):
+                    raise RuntimeError(
+                        f"ArcadeDB authentication failed on "
+                        f"/api/v1/exists ({resp.status}). Check the "
+                        f"username and password supplied to the adapter."
+                    )
+
+            # Step 2: database missing — try to create it (needs root creds)
+            create_url = f"{self.http_base_url}/api/v1/server"
+            payload = {"command": f"create database {self.database_name}"}
+            async with session.post(create_url, json=payload) as resp:
+                body = await resp.text()
+                if resp.status == 200:
+                    logger.info(
+                        "Created ArcadeDB database '%s'", self.database_name
+                    )
+                    self._database_ensured = True
+                elif "already exists" in body.lower():
+                    self._database_ensured = True
+                elif resp.status in (401, 403):
+                    raise RuntimeError(
+                        f"ArcadeDB database '{self.database_name}' does "
+                        f"not exist and the supplied credentials lack the "
+                        f"server-level privileges required to create it "
+                        f"(HTTP {resp.status}). Either create the database "
+                        f"manually or supply root credentials."
+                    )
+                else:
+                    raise RuntimeError(
+                        f"ArcadeDB create database failed "
+                        f"({resp.status}): {body}"
+                    )
+
+    async def _http_request(
+        self,
+        endpoint: str,
+        payload: dict,
+    ) -> dict:
+        """Execute a request via ArcadeDB's HTTP API.
+
+        Retries up to 5 times on HTTP 503 (ConcurrentModificationException)
+        because ArcadeDB uses optimistic concurrency control and concurrent
+        writes to the same page can transiently conflict.  The database itself
+        advises "Please retry the operation" in the error body.
+        """
+        import asyncio as _asyncio
+
+        if not self._database_ensured:
+            await self._ensure_database()
+        url = f"{self.http_base_url}/api/v1/{endpoint}/{self.database_name}"
+
+        max_retries = 5
+        for attempt in range(max_retries):
+            async with aiohttp.ClientSession(auth=self._get_auth()) as session:
+                async with session.post(url, json=payload) as resp:
+                    body = await resp.text()
+                    if resp.status == 503 and attempt < max_retries - 1:
+                        # ArcadeDB ConcurrentModificationException — back off and retry
+                        await _asyncio.sleep(0.3 * (attempt + 1))
+                        continue
+                    if resp.status != 200:
+                        raise RuntimeError(
+                            f"ArcadeDB HTTP error ({resp.status}): {body}"
+                        )
+                    return json.loads(body)
+        # Should not reach here, but just in case
+        raise RuntimeError(f"ArcadeDB HTTP error (503): {body}")
+
+    async def _sql(self, sql: str) -> dict:
+        """Execute an SQL command via HTTP."""
+        return await self._http_request(
+            "command", {"language": "sql", "command": sql}
+        )
+
+    async def _sql_query(self, sql: str) -> dict:
+        """Execute an SQL read query via HTTP."""
+        return await self._http_request(
+            "query", {"language": "sql", "command": sql}
+        )
+
+    async def _cypher_via_http(
+        self,
+        cypher: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        """Execute Cypher via HTTP API. Returns flat dicts."""
+        payload = {"language": "cypher", "command": cypher}
+        if params:
+            payload["params"] = params
+        result = await self._http_request("command", payload)
+        return result.get("result", [])
+
+    async def _cypher_via_bolt(
+        self,
+        cypher: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        """Execute Cypher via Bolt protocol. Normalizes response to flat dicts."""
+        from neo4j.exceptions import ServiceUnavailable
+
+        try:
+            async with self._bolt_driver.session(
+                database=self.database_name
+            ) as session:
+                result = await session.run(cypher, params)
+                records = await result.data()
+
+            # Normalize: Bolt returns {"alias": <Node/value>} per record.
+            # Convert Node objects to plain dicts for consistency with HTTP.
+            normalized = []
+            for record in records:
+                flat = {}
+                for key, value in record.items():
+                    if hasattr(value, "items"):
+                        # Already a dict (properties)
+                        flat.update(value)
+                    elif hasattr(value, "_properties"):
+                        # neo4j Node object
+                        flat.update(dict(value._properties))
+                    else:
+                        flat[key] = value
+                normalized.append(flat)
+            return normalized
+
+        except (ServiceUnavailable, OSError) as e:
+            # Bolt not available, disable and fall back to HTTP
+            logger.info("Bolt connection failed: %s, falling back to HTTP", e)
+            self._bolt_driver = None
+            self._bolt_verified = False
+            return await self._cypher_via_http(cypher, params)
+
+    async def _cypher(
+        self,
+        cypher: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        """Execute Cypher query using Bolt if available, otherwise HTTP.
+
+        On the first call, verifies that Bolt is actually reachable.
+        If Bolt fails, permanently falls back to HTTP for the session.
+        """
+        if self._bolt_driver is not None:
+            if not self._bolt_verified:
+                # First call: verify Bolt connectivity
+                try:
+                    result = await self._cypher_via_bolt(
+                        "RETURN true AS ok"
+                    )
+                    if result and result[0].get("ok"):
+                        self._bolt_verified = True
+                        logger.info(
+                            "Bolt protocol verified, using Bolt for Cypher"
+                        )
+                    else:
+                        raise RuntimeError("Bolt verification returned no data")
+                except Exception as e:
+                    logger.info(
+                        "Bolt verification failed: %s, using HTTP", e
+                    )
+                    self._bolt_driver = None
+
+            if self._bolt_driver is not None:
+                return await self._cypher_via_bolt(cypher, params)
+
+        return await self._cypher_via_http(cypher, params)
+
+    async def _cypher_projection(
+        self,
+        cypher: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Execute graph projection queries via HTTP so aliased nested maps stay
+        under their original keys.
+
+        Bolt normalization intentionally flattens Node objects and dict-valued
+        aliases for most adapter reads. That behavior is convenient for
+        `RETURN node`, but it breaks projection queries like
+        `properties(n) AS properties`, where Cognee expects a nested
+        `record["properties"]` mapping.
+        """
+
+        return await self._cypher_via_http(cypher, params)
+
+    # -------------------------------------------------------------------------
+    # GraphDBInterface - Cypher operations
+    # -------------------------------------------------------------------------
+
+    async def query(
+        self,
+        query: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        return await self._cypher(query, params)
+
+    async def has_node(self, node_id: str) -> bool:
+        results = await self._cypher(
+            "MATCH (n) WHERE n.id = $node_id RETURN COUNT(n) > 0 AS node_exists",
+            {"node_id": node_id},
+        )
+        return results[0]["node_exists"] if results else False
+
+    async def add_node(self, node: DataPoint):
+        serialized = self.serialize_properties(node.model_dump())
+        node_id = str(node.id)
+        result = await self._upsert_cypher_node(node_id, serialized)
+
+        await self._store_vertex_vectors(
+            node_id=node_id,
+            node_type=str(serialized.get("type") or type(node).__name__),
+            embeddable_properties={
+                prop_name: getattr(node, prop_name, None)
+                for prop_name in DataPoint.get_embeddable_property_names(node)
+            },
+        )
+
+        return result
+
+    async def add_nodes(self, nodes: list[DataPoint]) -> None:
+        if not nodes:
+            return []
+
+        # ArcadeDB's HTTP Cypher parser rejects the batch form
+        # `SET n += node.properties` used with `UNWIND $nodes AS node`.
+        # Keep the write path compatible with both Bolt and HTTP fallback by
+        # reusing the proven single-node upsert query.
+        results = []
+        for node in nodes:
+            results.append(await self.add_node(node))
+
+        return results
+
+    async def extract_node(self, node_id: str):
+        results = await self.extract_nodes([node_id])
+        return results[0] if results else None
+
+    async def extract_nodes(self, node_ids: list[str]):
+        return await self._cypher(
+            "UNWIND $node_ids AS id MATCH (node {id: id}) RETURN node",
+            {"node_ids": node_ids},
+        )
+
+    async def delete_node(self, node_id: str):
+        return await self._cypher(
+            "MATCH (node {id: $node_id}) DETACH DELETE node",
+            {"node_id": node_id},
+        )
+
+    async def delete_nodes(self, node_ids: list[str]) -> None:
+        return await self._cypher(
+            "UNWIND $node_ids AS id MATCH (node {id: id}) DETACH DELETE node",
+            {"node_ids": node_ids},
+        )
+
+    async def has_edge(self, from_node: UUID, to_node: UUID, edge_label: str) -> bool:
+        records = await self._cypher(
+            "MATCH (from_node)-[relationship]->(to_node) "
+            "WHERE from_node.id = $from_node_id AND to_node.id = $to_node_id "
+            "AND type(relationship) = $edge_label "
+            "RETURN COUNT(relationship) > 0 AS edge_exists",
+            {
+                "from_node_id": str(from_node),
+                "to_node_id": str(to_node),
+                "edge_label": edge_label,
+            },
+        )
+        return records[0]["edge_exists"] if records else False
+
+    async def has_edges(self, edges):
+        params = {
+            "edges": [
+                {
+                    "from_node": str(edge[0]),
+                    "to_node": str(edge[1]),
+                    "relationship_name": edge[2],
+                }
+                for edge in edges
+            ],
+        }
+        results = await self._cypher(
+            "UNWIND $edges AS edge "
+            "MATCH (a)-[r]->(b) "
+            "WHERE a.id = edge.from_node AND b.id = edge.to_node "
+            "AND type(r) = edge.relationship_name "
+            "RETURN DISTINCT edge.from_node AS from_node, "
+            "edge.to_node AS to_node, "
+            "edge.relationship_name AS relationship_name",
+            params,
+        )
+        return [
+            (
+                r["from_node"],
+                r["to_node"],
+                r["relationship_name"],
+            )
+            for r in results
+        ]
+
+    async def add_edge(
+        self,
+        from_node: UUID,
+        to_node: UUID,
+        relationship_name: str,
+        edge_properties: Optional[dict[str, Any]] = None,
+    ):
+        serialized = self.serialize_properties(edge_properties or {})
+        return await self._cypher(
+            dedent(f"""\
+                MATCH (from_node {{id: $from_node}}),
+                      (to_node {{id: $to_node}})
+                MERGE (from_node)-[r:{relationship_name}]->(to_node)
+                ON CREATE SET r += $properties, r.updated_at = $now
+                ON MATCH SET r += $properties, r.updated_at = $now
+                RETURN r"""),
+            {
+                "from_node": str(from_node),
+                "to_node": str(to_node),
+                "properties": serialized,
+                "now": self._now(),
+            },
+        )
+
+    async def add_edges(
+        self, edges: list[tuple[str, str, str, dict[str, Any]]]
+    ) -> None:
+        if not edges:
+            return []
+
+        results = []
+        for src, dst, rel_type, properties in edges:
+            edge_properties = {
+                **(properties or {}),
+                "source_node_id": str(src),
+                "target_node_id": str(dst),
+            }
+            results.append(
+                await self.add_edge(src, dst, rel_type, edge_properties)
+            )
+
+        return results
+
+    async def get_edges(self, node_id: str):
+        results = await self._cypher(
+            "MATCH (n {id: $node_id})-[r]-(m) "
+            "RETURN n.id AS source_id, m.id AS target_id, type(r) AS rel_type",
+            {"node_id": node_id},
+        )
+        return [
+            (r["source_id"], r["target_id"], {"relationship_name": r["rel_type"]})
+            for r in results
+        ]
+
+    async def get_disconnected_nodes(self) -> list[str]:
+        results = await self._cypher(
+            "MATCH (n) WHERE NOT (n)--() RETURN collect(n.id) AS ids"
+        )
+        return results[0]["ids"] if results else []
+
+    async def get_predecessors(
+        self, node_id: str, edge_label: Optional[str] = None
+    ) -> list[str]:
+        if edge_label is not None:
+            results = await self._cypher(
+                "MATCH (node)<-[r]-(predecessor) "
+                "WHERE node.id = $node_id AND type(r) = $edge_label "
+                "RETURN predecessor",
+                {"node_id": node_id, "edge_label": edge_label},
+            )
+        else:
+            results = await self._cypher(
+                "MATCH (node)<-[r]-(predecessor) "
+                "WHERE node.id = $node_id RETURN predecessor",
+                {"node_id": node_id},
+            )
+        return results
+
+    async def get_successors(
+        self, node_id: str, edge_label: Optional[str] = None
+    ) -> list[str]:
+        if edge_label is not None:
+            results = await self._cypher(
+                "MATCH (node)-[r]->(successor) "
+                "WHERE node.id = $node_id AND type(r) = $edge_label "
+                "RETURN successor",
+                {"node_id": node_id, "edge_label": edge_label},
+            )
+        else:
+            results = await self._cypher(
+                "MATCH (node)-[r]->(successor) "
+                "WHERE node.id = $node_id RETURN successor",
+                {"node_id": node_id},
+            )
+        return results
+
+    async def get_neighbors(self, node_id: str) -> list[dict[str, Any]]:
+        predecessors, successors = await asyncio.gather(
+            self.get_predecessors(node_id), self.get_successors(node_id)
+        )
+        return predecessors + successors
+
+    async def get_node(self, node_id: str) -> Optional[dict[str, Any]]:
+        results = await self._cypher(
+            "MATCH (node {id: $node_id}) RETURN node",
+            {"node_id": node_id},
+        )
+        return results[0] if results else None
+
+    async def get_nodes(self, node_ids: list[str]) -> list[dict[str, Any]]:
+        return await self._cypher(
+            "UNWIND $node_ids AS id MATCH (node {id: id}) RETURN node",
+            {"node_ids": node_ids},
+        )
+
+    async def get_connections(self, node_id: UUID) -> list:
+        predecessors, successors = await asyncio.gather(
+            self._cypher(
+                "MATCH (node)<-[r]-(neighbour) "
+                "WHERE node.id = $node_id "
+                "RETURN neighbour.id AS src, type(r) AS rel, node.id AS dst",
+                {"node_id": str(node_id)},
+            ),
+            self._cypher(
+                "MATCH (node)-[r]->(neighbour) "
+                "WHERE node.id = $node_id "
+                "RETURN node.id AS src, type(r) AS rel, neighbour.id AS dst",
+                {"node_id": str(node_id)},
+            ),
+        )
+
+        connections = []
+        for r in predecessors:
+            connections.append(
+                (r["src"], {"relationship_name": r["rel"]}, r["dst"])
+            )
+        for r in successors:
+            connections.append(
+                (r["src"], {"relationship_name": r["rel"]}, r["dst"])
+            )
+        return connections
+
+    async def remove_connection_to_predecessors_of(
+        self, node_ids: list[str], edge_label: str
+    ) -> None:
+        await self._cypher(
+            "UNWIND $node_ids AS nid "
+            "MATCH (node {id: nid})-[r]->(predecessor) "
+            "WHERE type(r) = $edge_label DELETE r",
+            {"node_ids": node_ids, "edge_label": edge_label},
+        )
+
+    async def remove_connection_to_successors_of(
+        self, node_ids: list[str], edge_label: str
+    ) -> None:
+        await self._cypher(
+            "UNWIND $node_ids AS nid "
+            "MATCH (node {id: nid})<-[r]-(successor) "
+            "WHERE type(r) = $edge_label DELETE r",
+            {"node_ids": node_ids, "edge_label": edge_label},
+        )
+
+    async def delete_graph(self):
+        return await self._cypher("MATCH (node) DETACH DELETE node")
+
+    def serialize_properties(self, properties=None):
+        if properties is None:
+            properties = {}
+        serialized = {}
+        for key, value in properties.items():
+            if value is None:
+                continue
+            elif isinstance(value, UUID):
+                serialized[key] = str(value)
+            elif isinstance(value, Enum):
+                serialized[key] = value.value
+            elif isinstance(value, datetime):
+                serialized[key] = int(value.timestamp() * 1000)
+            elif isinstance(value, dict):
+                serialized[key] = json.dumps(value, cls=JSONEncoder)
+            elif isinstance(value, list):
+                if value and isinstance(value[0], float):
+                    continue  # Skip vector properties in Cypher serialization
+                serialized[key] = json.dumps(value, cls=JSONEncoder)
+            else:
+                serialized[key] = value
+        return serialized
+
+    async def get_graph_data(self):
+        result = await self._cypher_projection(
+            "MATCH (n) RETURN n.id AS id, labels(n) AS labels, "
+            "properties(n) AS properties"
+        )
+        nodes = [(r["id"], r["properties"]) for r in result]
+
+        result = await self._cypher_projection(
+            "MATCH (n)-[r]->(m) RETURN n.id AS source, m.id AS target, "
+            "TYPE(r) AS type, properties(r) AS properties"
+        )
+        edges = [
+            (r["source"], r["target"], r["type"], r["properties"])
+            for r in result
+        ]
+        return (nodes, edges)
+
+    async def get_triplets_batch(
+        self, offset: int = 0, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """
+        Return graph triplets in the structure expected by cognee memify.
+
+        We intentionally use the HTTP Cypher path here because the Bolt result
+        normalizer flattens nested maps, while memify needs distinct nested
+        dictionaries for start_node, relationship_properties and end_node.
+        """
+
+        safe_offset = max(int(offset), 0)
+        safe_limit = max(int(limit), 0)
+
+        results = await self._cypher_via_http(
+            dedent(
+                f"""\
+                MATCH (start_node)-[relationship]->(end_node)
+                RETURN properties(start_node) AS start_node,
+                       properties(relationship) AS relationship_properties,
+                       type(relationship) AS relationship_name,
+                       properties(end_node) AS end_node
+                SKIP {safe_offset}
+                LIMIT {safe_limit}
+                """
+            )
+        )
+
+        triplets: list[dict[str, Any]] = []
+        for row in results:
+            start_node = row.get("start_node") or {}
+            end_node = row.get("end_node") or {}
+            relationship_properties = row.get("relationship_properties") or {}
+
+            if not isinstance(start_node, dict):
+                start_node = dict(start_node)
+            if not isinstance(end_node, dict):
+                end_node = dict(end_node)
+            if not isinstance(relationship_properties, dict):
+                relationship_properties = dict(relationship_properties)
+
+            relationship_name = row.get("relationship_name")
+            if relationship_name:
+                relationship_properties = {
+                    **relationship_properties,
+                    "relationship_name": relationship_name,
+                }
+
+            triplets.append(
+                {
+                    "start_node": start_node,
+                    "relationship_properties": relationship_properties,
+                    "end_node": end_node,
+                }
+            )
+
+        return triplets
+
+    async def get_nodeset_subgraph(
+        self,
+        node_type: type[Any],
+        node_name: list[str],
+        node_name_filter_operator: str = "OR",
+    ) -> tuple[list[tuple[int, dict]], list[tuple[int, int, str, dict]]]:
+        label = node_type.__name__
+
+        primary_result = await self._cypher_projection(
+            f"UNWIND $names AS wantedName MATCH (n:{label}) "
+            "WHERE n.name = wantedName "
+            "RETURN DISTINCT n.id AS id, properties(n) AS properties",
+            {"names": node_name},
+        )
+        if not primary_result:
+            return [], []
+
+        primary_ids = [r["id"] for r in primary_result]
+
+        if node_name_filter_operator == "OR":
+            neighbor_result = await self._cypher_projection(
+                "MATCH (n)-[]-(nbr) WHERE n.id IN $ids "
+                "RETURN DISTINCT nbr.id AS id, properties(nbr) AS properties",
+                {"ids": primary_ids},
+            )
+        else:
+            neighbor_result = await self._cypher_projection(
+                "MATCH (n)-[]-(nbr) WHERE n.id IN $ids "
+                "WITH nbr, COUNT(DISTINCT n.id) AS matched_count "
+                "WHERE matched_count = $primary_count "
+                "RETURN nbr.id AS id, properties(nbr) AS properties",
+                {"ids": primary_ids, "primary_count": len(primary_ids)},
+            )
+
+        neighbor_ids = [r["id"] for r in neighbor_result] if neighbor_result else []
+        all_ids = list(set(primary_ids + neighbor_ids))
+
+        nodes_result = await self._cypher_projection(
+            "MATCH (n) WHERE n.id IN $ids "
+            "RETURN n.id AS id, properties(n) AS properties",
+            {"ids": all_ids},
+        )
+        nodes = [(r["id"], r["properties"]) for r in nodes_result]
+
+        edges_result = await self._cypher_projection(
+            "MATCH (a)-[r]->(b) WHERE a.id IN $ids AND b.id IN $ids "
+            "RETURN a.id AS source, b.id AS target, "
+            "type(r) AS type, properties(r) AS properties",
+            {"ids": all_ids},
+        )
+        edges = [
+            (r["source"], r["target"], r["type"], r["properties"])
+            for r in edges_result
+        ]
+        return nodes, edges
+
+    async def get_filtered_graph_data(self, attribute_filters):
+        if not attribute_filters:
+            return await self.get_graph_data()
+
+        where_clauses_n = []
+        where_clauses_m = []
+        params = {}
+
+        for i, filter_dict in enumerate(attribute_filters):
+            for attr, values in filter_dict.items():
+                if not values:
+                    continue
+                param_name = f"values_{i}_{attr}"
+                normalized = [
+                    str(v) if isinstance(v, UUID) else v for v in values
+                ]
+                where_clauses_n.append(f"n.{attr} IN ${param_name}")
+                where_clauses_m.append(f"m.{attr} IN ${param_name}")
+                params[param_name] = normalized
+
+        if not where_clauses_n:
+            return await self.get_graph_data()
+
+        node_where = " AND ".join(where_clauses_n)
+        edge_where = (
+            f"{' AND '.join(where_clauses_n)} AND "
+            f"{' AND '.join(where_clauses_m)}"
+        )
+
+        result_nodes = await self._cypher_projection(
+            f"MATCH (n) WHERE {node_where} "
+            "RETURN n.id AS id, properties(n) AS properties",
+            params,
+        )
+        nodes = [(r["id"], r["properties"]) for r in result_nodes]
+
+        result_edges = await self._cypher_projection(
+            f"MATCH (n)-[r]->(m) WHERE {edge_where} "
+            "RETURN n.id AS source, m.id AS target, "
+            "TYPE(r) AS type, properties(r) AS properties",
+            params,
+        )
+        edges = [
+            (r["source"], r["target"], r["type"], r["properties"])
+            for r in result_edges
+        ]
+        return (nodes, edges)
+
+    async def get_graph_metrics(self, include_optional=False):
+        try:
+            node_count = await self._cypher(
+                "MATCH (n) RETURN count(n) AS cnt"
+            )
+            edge_count = await self._cypher(
+                "MATCH ()-[r]->() RETURN count(r) AS cnt"
+            )
+            num_nodes = node_count[0]["cnt"] if node_count else 0
+            num_edges = edge_count[0]["cnt"] if edge_count else 0
+
+            metrics = {
+                "num_nodes": num_nodes,
+                "num_edges": num_edges,
+                "mean_degree": (
+                    (2 * num_edges) / num_nodes if num_nodes > 0 else 0
+                ),
+                "edge_density": (
+                    num_edges / (num_nodes * (num_nodes - 1))
+                    if num_nodes > 1
+                    else 0
+                ),
+                "num_connected_components": 1 if num_nodes > 0 else 0,
+                "sizes_of_connected_components": (
+                    [num_nodes] if num_nodes > 0 else []
+                ),
+            }
+
+            if include_optional:
+                self_loops = await self._cypher(
+                    "MATCH (n)-[r]->(n) RETURN COUNT(r) AS cnt"
+                )
+                metrics.update(
+                    {
+                        "num_selfloops": (
+                            self_loops[0]["cnt"] if self_loops else 0
+                        ),
+                        "diameter": -1,
+                        "avg_shortest_path_length": -1,
+                        "avg_clustering": -1,
+                    }
+                )
+            else:
+                metrics.update(
+                    {
+                        "num_selfloops": -1,
+                        "diameter": -1,
+                        "avg_shortest_path_length": -1,
+                        "avg_clustering": -1,
+                    }
+                )
+            return metrics
+
+        except Exception as e:
+            logger.error(f"Failed to get graph metrics: {e}")
+            return {
+                "num_nodes": 0,
+                "num_edges": 0,
+                "mean_degree": 0,
+                "edge_density": 0,
+                "num_connected_components": 0,
+                "sizes_of_connected_components": [],
+                "num_selfloops": -1,
+                "diameter": -1,
+                "avg_shortest_path_length": -1,
+                "avg_clustering": -1,
+            }
+
+    async def is_empty(self) -> bool:
+        result = await self._cypher("MATCH (n) RETURN true LIMIT 1")
+        return len(result) == 0
+
+    async def get_neighborhood(
+        self,
+        node_ids: list[str],
+        depth: int = 1,
+        edge_types: Optional[list[str]] = None,
+    ) -> tuple[list[tuple[str, dict[str, Any]]], list[tuple[str, str, str, dict[str, Any]]]]:
+        """
+        Get the k-hop neighborhood subgraph around a set of seed nodes.
+
+        Returns all nodes and edges within `depth` hops of any seed node,
+        in the same format as get_graph_data().
+        Optional edge_type filtering to constrain traversal paths.
+
+        Uses _cypher_projection (HTTP path) to preserve nested property maps.
+        """
+        if not node_ids:
+            return [], []
+
+        # Step 1: Collect all node IDs within depth hops
+        if edge_types:
+            path_query = dedent(f"""\
+                MATCH path = (seed)-[*1..{depth}]-(neighbor)
+                WHERE seed.id IN $node_ids
+                  AND ALL(r IN relationships(path) WHERE TYPE(r) IN $edge_types)
+                RETURN DISTINCT neighbor.id AS nid
+            """)
+        else:
+            path_query = dedent(f"""\
+                MATCH (seed)-[*1..{depth}]-(neighbor)
+                WHERE seed.id IN $node_ids
+                RETURN DISTINCT neighbor.id AS nid
+            """)
+
+        params: dict[str, Any] = {"node_ids": node_ids}
+        if edge_types:
+            params["edge_types"] = edge_types
+
+        result = await self._cypher_projection(path_query, params)
+        neighbor_ids = [record["nid"] for record in result if record.get("nid")]
+
+        all_ids = list(set(node_ids) | set(neighbor_ids))
+
+        # Step 2: Fetch all nodes
+        nodes_result = await self._cypher_projection(
+            "MATCH (n) WHERE n.id IN $ids "
+            "RETURN n.id AS id, properties(n) AS properties",
+            {"ids": all_ids},
+        )
+        nodes = []
+        for record in nodes_result:
+            props = record.get("properties", {})
+            node_id = record.get("id", "")
+            if isinstance(props, dict):
+                nodes.append((node_id, props))
+            else:
+                nodes.append((node_id, dict(props)))
+
+        # Step 3: Fetch all edges between collected nodes
+        edges_result = await self._cypher_projection(
+            "MATCH (a)-[r]->(b) WHERE a.id IN $ids AND b.id IN $ids "
+            "RETURN a.id AS source, b.id AS target, "
+            "TYPE(r) AS type, properties(r) AS properties",
+            {"ids": all_ids},
+        )
+        edges = []
+        for record in edges_result:
+            props = record.get("properties", {})
+            if not isinstance(props, dict):
+                props = dict(props)
+            edges.append((
+                record["source"],
+                record["target"],
+                record["type"],
+                props,
+            ))
+
+        return (nodes, edges)
+
+    # -------------------------------------------------------------------------
+    # VectorDBInterface - SQL operations (always HTTP)
+    # -------------------------------------------------------------------------
+
+    async def embed_data(self, data: list[str]) -> list[list[float]]:
+        """Embed text data into vectors using the configured embedding engine."""
+        if not data:
+            return []
+
+        non_blank = [s for s in data if s and s.strip()]
+        if not non_blank:
+            return [[] for _ in data]
+
+        result = await self.embedding_engine.embed_text(non_blank)
+
+        if len(non_blank) == len(data):
+            return result
+
+        it = iter(result)
+        return [next(it) if (s and s.strip()) else [] for s in data]
+
+    async def has_collection(self, collection_name: str) -> bool:
+        """Check if a vertex type (collection) exists in ArcadeDB."""
+        type_name = (
+            collection_name.split("_")[0]
+            if "_" in collection_name
+            else collection_name
+        )
+        try:
+            await self._sql(
+                f"SELECT count(*) AS cnt FROM `{type_name}` LIMIT 0"
+            )
+            return True
+        except RuntimeError:
+            return False
+
+    async def create_collection(
+        self, collection_name: str, payload_schema: Optional[Any] = None
+    ):
+        """Create a vertex type in ArcadeDB if it does not exist."""
+        type_name = (
+            collection_name.split("_")[0]
+            if "_" in collection_name
+            else collection_name
+        )
+        try:
+            await self._sql(
+                f"CREATE VERTEX TYPE `{type_name}` IF NOT EXISTS"
+            )
+        except RuntimeError:
+            pass
+
+    async def create_vector_index(
+        self, index_name: str, index_property_name: str
+    ) -> None:
+        """Create an LSM_VECTOR (HNSW) index on the shared Vertex storage."""
+        vector_prop = f"{index_property_name}_vector"
+        storage_type = await self._vector_storage_type()
+        index_key = f"{storage_type}.{vector_prop}"
+
+        if index_key in self._vector_indexes:
+            return
+
+        # Keep the logical collection for compatibility with collection checks,
+        # but store vector properties on the physical Vertex type because
+        # Cypher MERGE writes nodes there and tracks the model class in `type`.
+        await self.create_collection(index_name)
+
+        vector_size = self.embedding_engine.get_vector_size()
+
+        try:
+            await self._sql(
+                f"CREATE PROPERTY `{storage_type}`.`{vector_prop}` "
+                "IF NOT EXISTS ARRAY_OF_FLOATS"
+            )
+        except RuntimeError:
+            pass
+
+        try:
+            await self._sql(
+                f"CREATE INDEX ON `{storage_type}` (`{vector_prop}`) "
+                f"LSM_VECTOR METADATA {{ dimensions: {vector_size}, "
+                f"similarity: 'COSINE' }}"
+            )
+            self._vector_indexes.add(index_key)
+        except RuntimeError as e:
+            err_msg = str(e).lower()
+            if (
+                "already exists" in err_msg
+                or "duplicate" in err_msg
+                or "existent index" in err_msg
+                or "defined on the properties" in err_msg
+            ):
+                self._vector_indexes.add(index_key)
+            else:
+                raise
+
+    async def create_data_points(
+        self, collection_name: str, data_points: list[DataPoint]
+    ):
+        """Embed and store data points as vertices with vector properties."""
+        if not data_points:
+            return
+
+        # Collect all embeddable values for batch embedding
+        embeddable_values: list[str] = []
+        vector_map: dict[str, dict[str, Optional[int]]] = {}
+        created_types: set[str] = set()
+
+        for dp in data_points:
+            prop_names = DataPoint.get_embeddable_property_names(dp)
+            key = str(dp.id)
+            vector_map[key] = {}
+
+            for prop_name in prop_names:
+                prop_value = getattr(dp, prop_name, None)
+                if prop_value is not None:
+                    vector_map[key][prop_name] = len(embeddable_values)
+                    embeddable_values.append(str(prop_value))
+                else:
+                    vector_map[key][prop_name] = None
+
+        # Batch embed all values at once
+        vectorized_values = (
+            await self.embed_data(embeddable_values)
+            if embeddable_values
+            else []
+        )
+
+        for dp in data_points:
+            node_label = type(dp).__name__
+            dp_key = str(dp.id)
+
+            if node_label not in created_types:
+                await self.create_collection(node_label)
+                created_types.add(node_label)
+
+            properties = self.serialize_properties(dp.model_dump())
+            await self._upsert_cypher_node(dp_key, properties)
+
+            embeddable_properties = {}
+            for prop_name in DataPoint.get_embeddable_property_names(dp):
+                vec_idx = vector_map[dp_key].get(prop_name)
+                if vec_idx is not None and vec_idx < len(vectorized_values):
+                    embeddable_properties[prop_name] = vectorized_values[vec_idx]
+
+            if embeddable_properties:
+                escaped_node_label = self._escape_sql_literal(node_label)
+                escaped_dp_key = self._escape_sql_literal(dp_key)
+                for prop_name, vector in embeddable_properties.items():
+                    await self.create_vector_index(node_label, prop_name)
+                    vector_prop = f"{prop_name}_vector"
+                    vec_str = ",".join(str(f) for f in vector)
+                    await self._sql(
+                        f"UPDATE `{await self._vector_storage_type()}` "
+                        f"SET `{vector_prop}` = [{vec_str}] "
+                        f"WHERE id = '{escaped_dp_key}' "
+                        f"AND type = '{escaped_node_label}'"
+                    )
+
+    async def index_data_points(
+        self,
+        index_name: str,
+        index_property_name: str,
+        data_points: list[DataPoint],
+    ) -> None:
+        """Embed data points and store vectors, delegating to create_data_points.
+
+        Follows the same pattern as LanceDB, ChromaDB, and PGVector adapters:
+        create the index structure AND embed + persist vectors in one call.
+        """
+        await self.create_data_points(
+            f"{index_name}_{index_property_name}",
+            data_points,
+        )
+
+    async def retrieve(self, collection_name: str, data_point_ids: list[str]):
+        """Retrieve data points by their IDs."""
+        return await self._cypher(
+            "MATCH (node) WHERE node.id IN $node_ids RETURN node",
+            {"node_ids": [str(dp_id) for dp_id in data_point_ids]},
+        )
+
+    async def search(
+        self,
+        collection_name: str,
+        query_text: Optional[str] = None,
+        query_vector: Optional[list[float]] = None,
+        limit: Optional[int] = None,
+        with_vector: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[list[str]] = None,
+        node_name_filter_operator: str = "OR",
+    ) -> list:
+        """Perform vector similarity search using ArcadeDB's vectorNeighbors()."""
+        if query_text is None and query_vector is None:
+            raise ValueError(
+                "Either query_text or query_vector must be provided"
+            )
+
+        if query_text and not query_vector:
+            query_vector = (await self.embed_data([query_text]))[0]
+
+        logical_type, attr_name = self._split_collection_name(collection_name)
+
+        vector_prop = f"{attr_name}_vector"
+        storage_type = await self._vector_storage_type()
+
+        if limit is None:
+            limit = 10
+        if limit == 0:
+            return []
+
+        vec_str = ",".join(str(f) for f in query_vector)
+        candidate_limit = max(limit * 10, limit)
+        escaped_logical_type = self._escape_sql_literal(logical_type)
+
+        try:
+            result = await self._sql_query(
+                f"SELECT *, distance FROM ("
+                f"  SELECT expand(vectorNeighbors("
+                f"    '{storage_type}[{vector_prop}]', "
+                f"[{vec_str}], {candidate_limit}"
+                f"  ))"
+                f") WHERE type = '{escaped_logical_type}' "
+                f"LIMIT {limit}"
+            )
+        except RuntimeError as e:
+            if "not found" in str(e).lower() or "index" in str(e).lower():
+                raise CollectionNotFoundError(
+                    f"No vector index found for collection {collection_name}"
+                )
+            raise
+
+        records = result.get("result", [])
+
+        # Apply node_name filtering if specified
+        if node_name:
+            filtered = []
+            for record in records:
+                belongs_to = record.get("belongs_to_set", [])
+                if isinstance(belongs_to, str):
+                    try:
+                        belongs_to = json.loads(belongs_to)
+                    except (json.JSONDecodeError, TypeError):
+                        belongs_to = [belongs_to]
+
+                if node_name_filter_operator == "OR":
+                    if any(n in belongs_to for n in node_name):
+                        filtered.append(record)
+                else:
+                    if all(n in belongs_to for n in node_name):
+                        filtered.append(record)
+            records = filtered
+
+        scored_results = []
+        for record in records:
+            distance = record.get("distance", 0.0)
+            record_id = record.get("id", "")
+
+            payload_data = {}
+            if include_payload:
+                payload_data = {
+                    k: v
+                    for k, v in record.items()
+                    if k
+                    not in ("@rid", "@cat", "@type", "distance")
+                    and not k.endswith("_vector")
+                }
+                if "name" in payload_data:
+                    payload_data["text"] = payload_data["name"]
+
+            scored_results.append(
+                ScoredResult(
+                    id=parse_id(record_id),
+                    score=distance,
+                    payload=payload_data if include_payload else None,
+                )
+            )
+
+        return scored_results
+
+    async def batch_search(
+        self,
+        collection_name: str,
+        query_texts: list[str],
+        limit: Optional[int] = None,
+        with_vectors: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[list[str]] = None,
+        node_name_filter_operator: str = "OR",
+    ) -> list:
+        """Perform batch vector search across multiple queries."""
+        query_vectors = await self.embedding_engine.embed_text(query_texts)
+
+        results = await asyncio.gather(
+            *[
+                self.search(
+                    collection_name=collection_name,
+                    query_vector=qv,
+                    limit=limit,
+                    with_vector=with_vectors,
+                    include_payload=include_payload,
+                    node_name=node_name,
+                    node_name_filter_operator=node_name_filter_operator,
+                )
+                for qv in query_vectors
+            ]
+        )
+        return results
+
+    async def delete_data_points(
+        self, collection_name: str, data_point_ids: list[UUID]
+    ):
+        """Delete data points by their IDs."""
+        return await self._cypher(
+            "MATCH (node) WHERE node.id IN $node_ids DETACH DELETE node",
+            {"node_ids": [str(dp_id) for dp_id in data_point_ids]},
+        )
+
+    async def prune(self):
+        """Remove all data from the database."""
+        await self.delete_graph()
+
+
+class ArcadeDBVectorAdapter(ArcadeDBAdapter):
+    """
+    Vector-provider shim for Cognee.
+
+    Cognee's vector factory instantiates custom providers with the vector-style
+    signature (`url`, `api_key`, `embedding_engine`, `database_name`) and does
+    not pass graph connection fields. For ArcadeDB we still need the graph
+    connection details because the hybrid adapter shares HTTP auth and database
+    naming between graph and vector operations.
+
+    Compatible with Cognee >= 1.0.0 (includes get_neighborhood support).
+    """
+
+    def __init__(
+        self,
+        url: str,
+        api_key: Optional[str] = None,
+        embedding_engine: Optional[EmbeddingEngine] = None,
+        database_name: Optional[str] = "cognee",
+        **kwargs,
+    ):
+        graph_config = get_graph_context_config()
+
+        if isinstance(graph_config, dict):
+            graph_database_url = graph_config.get("graph_database_url") or url
+            graph_database_username = graph_config.get(
+                "graph_database_username"
+            )
+            graph_database_password = graph_config.get(
+                "graph_database_password"
+            )
+            graph_database_name = graph_config.get("graph_database_name")
+        else:
+            graph_database_url = (
+                getattr(graph_config, "graph_database_url", None) or url
+            )
+            graph_database_username = getattr(
+                graph_config, "graph_database_username", None
+            )
+            graph_database_password = getattr(
+                graph_config, "graph_database_password", None
+            )
+            graph_database_name = getattr(
+                graph_config, "graph_database_name", None
+            )
+
+        super().__init__(
+            graph_database_url=graph_database_url,
+            graph_database_username=graph_database_username,
+            graph_database_password=graph_database_password,
+            embedding_engine=embedding_engine,
+            url=url,
+            api_key=api_key,
+            database_name=database_name or graph_database_name or "cognee",
+            **kwargs,
+        )

--- a/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/register.py
+++ b/packages/hybrid/arcadedb/cognee_community_hybrid_adapter_arcadedb/register.py
@@ -1,0 +1,16 @@
+from cognee.infrastructure.databases.dataset_database_handler import use_dataset_database_handler
+from cognee.infrastructure.databases.graph import use_graph_adapter
+from cognee.infrastructure.databases.vector import use_vector_adapter
+
+from .arcadedb_adapter import ArcadeDBAdapter, ArcadeDBVectorAdapter
+from .ArcadeDBDatasetDatabaseHandlerGraphLocal import ArcadeDBDatasetDatabaseHandlerGraphLocal
+from .ArcadeDBDatasetDatabaseHandlerVectorLocal import ArcadeDBDatasetDatabaseHandlerVectorLocal
+
+use_vector_adapter("arcadedb", ArcadeDBVectorAdapter)
+use_graph_adapter("arcadedb", ArcadeDBAdapter)
+use_dataset_database_handler(
+    "arcadedb_graph_local", ArcadeDBDatasetDatabaseHandlerGraphLocal, "arcadedb"
+)
+use_dataset_database_handler(
+    "arcadedb_vector_local", ArcadeDBDatasetDatabaseHandlerVectorLocal, "arcadedb"
+)

--- a/packages/hybrid/arcadedb/examples/example.py
+++ b/packages/hybrid/arcadedb/examples/example.py
@@ -1,0 +1,81 @@
+"""
+Example: Using ArcadeDB as a hybrid (graph + vector) backend for Cognee.
+
+Prerequisites:
+  - ArcadeDB running on localhost:2480
+  - pip install cognee-community-hybrid-adapter-arcadedb
+"""
+
+import asyncio
+import os
+import pathlib
+from os import path
+
+from cognee import config, prune, add, cognify, search, SearchType
+
+# Importing the register module lets Cognee know about the ArcadeDB adapter
+from cognee_community_hybrid_adapter_arcadedb import register  # noqa: F401
+
+
+async def main():
+    # Set up local directories
+    system_path = pathlib.Path(__file__).parent
+    config.system_root_directory(path.join(system_path, ".cognee_system"))
+    config.data_root_directory(path.join(system_path, ".cognee_data"))
+
+    # Configure databases
+    config.set_relational_db_config({
+        "db_provider": "sqlite",
+    })
+
+    # Configure ArcadeDB as both vector and graph database
+    arcadedb_url = os.getenv("ARCADEDB_URL", "localhost")
+    arcadedb_user = os.getenv("ARCADEDB_USERNAME", "root")
+    arcadedb_pass = os.getenv("ARCADEDB_PASSWORD", "playwithdata")
+
+    config.set_vector_db_config({
+        "vector_db_provider": "arcadedb",
+        "vector_db_url": arcadedb_url,
+        "vector_db_port": int(os.getenv("ARCADEDB_HTTP_PORT", "2480")),
+        "vector_db_username": arcadedb_user,
+        "vector_db_password": arcadedb_pass,
+    })
+    config.set_graph_db_config({
+        "graph_database_provider": "arcadedb",
+        "graph_database_url": arcadedb_url,
+        "graph_database_port": int(os.getenv("ARCADEDB_HTTP_PORT", "2480")),
+        "graph_database_username": arcadedb_user,
+        "graph_database_password": arcadedb_pass,
+    })
+
+    # Optional: Clean previous data
+    await prune.prune_data()
+    await prune.prune_system(metadata=True)
+
+    # Add and process content
+    await add("""
+    Natural language processing (NLP) is an interdisciplinary
+    subfield of computer science and information retrieval.
+    """)
+
+    await add("""
+    Machine learning is a subset of artificial intelligence that
+    provides systems the ability to automatically learn and improve
+    from experience without being explicitly programmed.
+    """)
+
+    await cognify()
+
+    # Search using graph completion
+    query_text = "Tell me about NLP"
+    search_results = await search(
+        query_type=SearchType.GRAPH_COMPLETION,
+        query_text=query_text,
+    )
+
+    for result in search_results:
+        print("\nSearch result:\n" + result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/hybrid/arcadedb/pyproject.toml
+++ b/packages/hybrid/arcadedb/pyproject.toml
@@ -1,0 +1,50 @@
+[project]
+name = "cognee-community-hybrid-adapter-arcadedb"
+version = "0.4.0"
+description = "ArcadeDB hybrid database adapter for Cognee (graph + vector)"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    "aiohttp>=3.9.0",
+    "cognee>=1.0.3,<2.0.0",
+    "starlette>=0.48.0",
+    "instructor>=1.11",
+]
+
+[project.optional-dependencies]
+bolt = [
+    "neo4j>=5.0.0,<6.0.0",
+]
+dev = [
+    "mypy>=1.0.0",
+    "types-requests",
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = [
+  "cognee.*",
+  "neo4j.*",
+  "aiohttp.*",
+]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/packages/hybrid/arcadedb/tests/test_arcadedb_hybrid.py
+++ b/packages/hybrid/arcadedb/tests/test_arcadedb_hybrid.py
@@ -1,0 +1,43 @@
+"""
+Integration test for ArcadeDB hybrid adapter.
+
+Requires a running ArcadeDB instance. Set environment variables:
+  ARCADEDB_URL, ARCADEDB_HTTP_PORT, ARCADEDB_USERNAME, ARCADEDB_PASSWORD
+"""
+
+import os
+
+import pytest
+
+# Skip all tests in this module if ArcadeDB is not available
+pytestmark = pytest.mark.skipif(
+    os.getenv("ARCADEDB_URL") is None,
+    reason="ArcadeDB not available (set ARCADEDB_URL to run)",
+)
+
+
+@pytest.fixture
+def adapter():
+    from cognee_community_hybrid_adapter_arcadedb.arcadedb_adapter import (
+        ArcadeDBAdapter,
+    )
+
+    return ArcadeDBAdapter(
+        graph_database_url=os.getenv("ARCADEDB_URL", "localhost"),
+        graph_database_username=os.getenv("ARCADEDB_USERNAME", "root"),
+        graph_database_password=os.getenv("ARCADEDB_PASSWORD", ""),
+    )
+
+
+@pytest.mark.asyncio
+async def test_health_check(adapter):
+    """Verify the adapter can connect to ArcadeDB."""
+    result = await adapter._sql("SELECT 1 AS ok")
+    assert result.get("result") is not None
+
+
+@pytest.mark.asyncio
+async def test_vector_storage_type_auto_detect(adapter):
+    """Verify auto-detection of vertex type casing."""
+    storage_type = await adapter._vector_storage_type()
+    assert storage_type.lower() == "vertex"

--- a/packages/hybrid/arcadedb/tests/test_embed_data_guard.py
+++ b/packages/hybrid/arcadedb/tests/test_embed_data_guard.py
@@ -1,0 +1,73 @@
+"""Unit tests for embed_data empty input guard.
+
+These tests verify that embed_data() handles empty lists and blank
+strings gracefully without calling the embedding API.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from cognee_community_hybrid_adapter_arcadedb.arcadedb_adapter import ArcadeDBAdapter
+
+
+def _make_adapter_with_mock_engine(mock_embed_fn):
+    """Create an ArcadeDBAdapter with a mocked embedding engine."""
+    adapter = object.__new__(ArcadeDBAdapter)
+    adapter.embedding_engine = AsyncMock()
+    adapter.embedding_engine.embed_text = mock_embed_fn
+    return adapter
+
+
+def test_empty_list_returns_empty():
+    mock_fn = AsyncMock(return_value=[])
+    adapter = _make_adapter_with_mock_engine(mock_fn)
+
+    result = asyncio.run(adapter.embed_data([]))
+
+    assert result == []
+    mock_fn.assert_not_called()
+
+
+def test_all_blank_strings():
+    mock_fn = AsyncMock(return_value=[])
+    adapter = _make_adapter_with_mock_engine(mock_fn)
+
+    result = asyncio.run(adapter.embed_data(["", "  ", "\n"]))
+
+    assert result == [[], [], []]
+    mock_fn.assert_not_called()
+
+
+def test_normal_input_passes_through():
+    expected = [[0.1, 0.2], [0.3, 0.4]]
+    mock_fn = AsyncMock(return_value=expected)
+    adapter = _make_adapter_with_mock_engine(mock_fn)
+
+    result = asyncio.run(adapter.embed_data(["hello", "world"]))
+
+    assert result == expected
+    mock_fn.assert_called_once_with(["hello", "world"])
+
+
+def test_mixed_blank_and_valid():
+    """Blank strings are skipped but output positions are preserved."""
+    mock_fn = AsyncMock(return_value=[[0.1, 0.2], [0.3, 0.4]])
+    adapter = _make_adapter_with_mock_engine(mock_fn)
+
+    result = asyncio.run(adapter.embed_data(["hello", "", "world", "  "]))
+
+    assert len(result) == 4
+    assert result[0] == [0.1, 0.2]  # "hello"
+    assert result[1] == []  # "" (blank)
+    assert result[2] == [0.3, 0.4]  # "world"
+    assert result[3] == []  # "  " (blank)
+    mock_fn.assert_called_once_with(["hello", "world"])
+
+
+def test_single_valid_input():
+    mock_fn = AsyncMock(return_value=[[0.5, 0.6]])
+    adapter = _make_adapter_with_mock_engine(mock_fn)
+
+    result = asyncio.run(adapter.embed_data(["test"]))
+
+    assert result == [[0.5, 0.6]]


### PR DESCRIPTION
## Summary

Upgrades the ArcadeDB adapter from **graph-only** to a **hybrid** adapter supporting both graph and vector operations in a single database.

Based on [PR#94](https://github.com/topoteretes/cognee-community/pull/94) by @lvca (ArcadeDB team) with additional fixes for Cognee 1.0+ compatibility and production reliability.

### Bug fixes

- **`index_data_points()` now delegates to `create_data_points()`** for proper vector embedding and storage. Without this fix, vectors are never populated on TextSummary/DocumentChunk nodes, making vector search return empty results across the entire pipeline.

### Cognee 1.0+ compatibility

- `get_neighborhood()` implementation for the new `GraphDBInterface` API (required abstract method in Cognee 1.0+)
- Tested against **Cognee 1.0.8** + **ArcadeDB 26.4.2**

### Reliability improvements

- **Auto-detection of Cypher type casing**: ArcadeDB 26.3.x creates Cypher types as `vertex` (lowercase), while 26.4+ uses `Vertex` (PascalCase). The adapter probes the schema and caches the correct casing.
- **Retry with backoff on HTTP 503**: ArcadeDB uses optimistic concurrency control — concurrent writes can transiently conflict with `ConcurrentModificationException`. The adapter retries up to 5 times with linear backoff.
- **Lazy database auto-creation**: Probes `GET /api/v1/exists/<db>` first (any DB user), only calls `POST /api/v1/server` (root required) if missing. From PR#94 commit `2b0b9f7`.
- **Bolt protocol with automatic HTTP fallback**: Verifies Bolt connectivity on first use, transparently falls back to HTTP Cypher for the session.

### Why?

ArcadeDB natively supports vector search with HNSW indexes. Rather than requiring a separate vector database (Qdrant, Milvus, etc.), Cognee users can now use ArcadeDB as a unified graph+vector store, simplifying infrastructure and keeping embeddings co-located with the knowledge graph.

## Implementation Details

- **Graph (Bolt)**: Binary protocol via `neo4j` async driver, auto-verified on first query
- **Graph (HTTP fallback)**: OpenCypher via HTTP API with parameterized queries
- **Vectors**: stored as `ARRAY_OF_FLOATS` properties on vertices
- **Index**: `CREATE INDEX ... LSM_VECTOR METADATA { dimensions: N, similarity: 'COSINE' }`
- **Search**: `SELECT expand(vectorNeighbors('Type[prop]', [vec], k))` returns results sorted by distance
- **Upsert**: node created via Cypher MERGE, vector properties set via SQL UPDATE

### ArcadeDB Setup

```bash
# HTTP only (simplest)
docker run -p 2480:2480 -e JAVA_OPTS="-Darcadedb.server.rootPassword=pwd" arcadedata/arcadedb:latest

# With Bolt (recommended)
docker run -p 2480:2480 -p 7687:7687   -e JAVA_OPTS="-Darcadedb.server.rootPassword=pwd     -Darcadedb.server.plugins=Bolt:com.arcadedb.bolt.BoltProtocolPlugin"   arcadedata/arcadedb:latest
```

## Test plan

- [x] **Bolt transport**: graph CRUD + vector ops (Bolt falls back to HTTP when unavailable)
- [x] **HTTP-only transport**: full cognify pipeline (add → cognify → search)
- [x] **Vector search**: `vectorNeighbors()` returns scored results with distance
- [x] **Full pipeline**: add → cognify → vector search → graph completion search
- [x] **Concurrent writes**: 503 retry handles ConcurrentModificationException
- [x] **Database auto-creation**: lazy probe + create on fresh ArcadeDB instance
- [x] **Type casing auto-detect**: works with both ArcadeDB 26.3.x (`vertex`) and 26.4+ (`Vertex`)
- [x] **Unit tests**: `embed_data()` empty/blank input guards (mock-based, no ArcadeDB required)

## Key differences from PR#94

| Area | Change |
|------|--------|
| Bug fix | `index_data_points` → `create_data_points` delegation |
| Cognee 1.0+ | `get_neighborhood()` implementation |
| Compatibility | Auto-detect Cypher type casing instead of hardcoding |
| Reliability | Retry on 503 ConcurrentModificationException |

## Credits

- Original adapter by @lvca (ArcadeDB team) — [PR#94](https://github.com/topoteretes/cognee-community/pull/94)
- Production fixes and Cognee 1.0+ compatibility by @AKC777
