### PR TITLE
feat(qdrant): add TurboQuant + general quantization support

### DIFF
--- a/packages/vector/qdrant/.env.example
+++ b/packages/vector/qdrant/.env.example
@@ -2,3 +2,17 @@ LLM_API_KEY=YOUR_OPENAI_API_KEY
 QDRANT_API_URL=YOUR_QDRANT_CLUSTER_ENDPOINT
 QDRANT_API_KEY=YOUR_QDRANT_API_KEY
 VECTOR_DATASET_DATABASE_HANDLER=qdrant
+
+# --- Quantization (optional) ---
+# Quantization mode. One of: none, tq4, tq2, tq1.5, tq1, sq, bq1, bq2, pq.
+# tq4 is the recommended default for new collections.
+#QDRANT_QUANTIZATION=none
+
+# Pin quantized vectors in RAM for fastest search. Default true.
+#QDRANT_QUANTIZATION_ALWAYS_RAM=true
+
+# Rescore top results with full-precision vectors. Default true.
+#QDRANT_QUANTIZATION_RESCORE=true
+
+# Oversampling factor before rescore. Default 2.0.
+#QDRANT_QUANTIZATION_OVERSAMPLING=2.0

--- a/packages/vector/qdrant/README.md
+++ b/packages/vector/qdrant/README.md
@@ -39,5 +39,45 @@ Also, specify the dataset handler in the .env file:
 VECTOR_DATASET_DATABASE_HANDLER="qdrant"
 ```
 
+## Quantization
+
+The adapter supports Qdrant's quantization methods, including TurboQuant (introduced in Qdrant 1.18). Quantization compresses stored vectors and reduces memory cost; it is disabled by default.
+
+| Mode  | Compression | Notes                                                  |
+|-------|-------------|--------------------------------------------------------|
+| `tq4` | 8x          | TurboQuant 4-bit. Recommended default; SQ-level recall |
+| `tq2` | 16x         | TurboQuant 2-bit. Beats binary 2-bit by 9–24 pp        |
+| `tq1.5` | ~21x      | TurboQuant 1.5-bit                                     |
+| `tq1` | 32x         | TurboQuant 1-bit. Beats binary 1-bit by 9–21 pp        |
+| `sq`  | 4x          | Scalar int8 — safe baseline                            |
+| `bq1` | 32x         | Binary 1-bit                                           |
+| `bq2` | 16x         | Binary 2-bit                                           |
+| `pq`  | 16x         | Product quantization (compression ratio X16)           |
+| `none` | 1x         | No quantization (default, backward-compatible)         |
+
+Set the mode via env var:
+
+```dotenv
+QDRANT_QUANTIZATION=tq4
+QDRANT_QUANTIZATION_ALWAYS_RAM=true
+QDRANT_QUANTIZATION_RESCORE=true
+QDRANT_QUANTIZATION_OVERSAMPLING=2.0
+```
+
+Requires `qdrant-client>=1.18` and Qdrant server `>=1.18` for any `tq*` mode.
+
+### Migrating existing collections
+
+Setting `QDRANT_QUANTIZATION` only affects newly created collections. To enable quantization on an existing collection without re-ingesting data, call `update_quantization`:
+
+```python
+from cognee.infrastructure.databases.vector import get_vector_engine
+adapter = get_vector_engine()
+await adapter.update_quantization("Entity_name")
+await adapter.update_quantization("DocumentChunk_text")
+```
+
+Qdrant rebuilds the affected index in the background; queries during the rebuild transparently fall back to full vectors.
+
 ## Example
 See example in `example.py` file.

--- a/packages/vector/qdrant/cognee_community_vector_adapter_qdrant/qdrant_adapter.py
+++ b/packages/vector/qdrant/cognee_community_vector_adapter_qdrant/qdrant_adapter.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from typing import List, Optional
 
 from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
@@ -13,6 +14,11 @@ from cognee.infrastructure.engine.utils import parse_id
 from cognee.shared.logging_utils import get_logger
 from qdrant_client import AsyncQdrantClient, models
 
+from .quantization import (
+    build_quantization_config,
+    build_search_params,
+)
+
 logger = get_logger("QDrantAdapter")
 
 
@@ -21,24 +27,6 @@ class IndexSchema(DataPoint):
 
     metadata: dict = {"index_fields": ["text"]}
     belongs_to_set: List[str] = []
-
-
-def create_hnsw_config(hnsw_config: dict):
-    if hnsw_config is not None:
-        return models.HnswConfig()
-    return None
-
-
-def create_optimizers_config(optimizers_config: dict):
-    if optimizers_config is not None:
-        return models.OptimizersConfig()
-    return None
-
-
-def create_quantization_config(quantization_config: dict):
-    if quantization_config is not None:
-        return models.QuantizationConfig()
-    return None
 
 
 class QDrantAdapter(VectorDBInterface):
@@ -66,6 +54,13 @@ class QDrantAdapter(VectorDBInterface):
             self.url = url
             self.api_key = api_key
         self.VECTOR_DB_LOCK = asyncio.Lock()
+
+        if os.getenv("QDRANT_QUANTIZATION", "none").lower().startswith("tq"):
+            if not hasattr(models, "TurboQuantization"):
+                raise RuntimeError(
+                    "QDRANT_QUANTIZATION=tq* requires qdrant-client>=1.18. "
+                    "Run: pip install -U 'qdrant-client>=1.18'"
+                )
 
     def get_qdrant_client(self) -> AsyncQdrantClient:
         if self.qdrant_path is not None:
@@ -111,6 +106,7 @@ class QDrantAdapter(VectorDBInterface):
                         payload_m=16,
                         m=0,
                     ),
+                    quantization_config=build_quantization_config(),
                 )
                 # This index co-locates vectors from the same dataset together,
                 # which can improve performance
@@ -123,6 +119,25 @@ class QDrantAdapter(VectorDBInterface):
                     ),
                 )
 
+            await client.close()
+
+    async def update_quantization(
+        self,
+        collection_name: str,
+        quantization_config=None,
+    ):
+        """Apply or change the quantization config on an existing
+        collection without recreating it. Qdrant re-indexes in the
+        background; queries during rebuild may transparently fall back
+        to full vectors."""
+        config = quantization_config if quantization_config is not None else build_quantization_config()
+        client = self.get_qdrant_client()
+        try:
+            await client.update_collection(
+                collection_name=collection_name,
+                quantization_config=config,
+            )
+        finally:
             await client.close()
 
     async def create_data_points(self, collection_name: str, data_points: list[DataPoint]):
@@ -250,6 +265,7 @@ class QDrantAdapter(VectorDBInterface):
                 limit=limit,
                 with_vectors=with_vector,
                 with_payload=include_payload,
+                search_params=build_search_params(),
             )
 
             await client.close()
@@ -348,6 +364,7 @@ class QDrantAdapter(VectorDBInterface):
                 limit=limit,
                 with_vectors=with_vectors,
                 with_payload=include_payload,
+                search_params=build_search_params(),
             )
 
             await client.close()

--- a/packages/vector/qdrant/cognee_community_vector_adapter_qdrant/quantization.py
+++ b/packages/vector/qdrant/cognee_community_vector_adapter_qdrant/quantization.py
@@ -1,0 +1,110 @@
+"""Quantization config helpers for the Qdrant adapter.
+
+Reads four optional environment variables:
+
+  QDRANT_QUANTIZATION
+      One of: "none" (default), "tq4", "tq2", "tq1.5", "tq1",
+      "sq", "bq1", "bq2", "pq".
+  QDRANT_QUANTIZATION_ALWAYS_RAM
+      "true" (default) or "false". When true, quantized vectors are
+      pinned in RAM for fastest search. Safe default because quantized
+      data is small (~768 bytes per 1536-dim vector at TQ4).
+  QDRANT_QUANTIZATION_RESCORE
+      "true" (default) or "false". When true, top-k results are
+      re-scored against full-precision vectors.
+  QDRANT_QUANTIZATION_OVERSAMPLING
+      Float, default "2.0". Multiplier for how many extra candidates
+      to pull from the quantized index before rescoring.
+"""
+
+import os
+
+from qdrant_client import models
+
+
+_TQ_BITS = {
+    "tq4":   models.TurboQuantBitSize.BITS4,
+    "tq2":   models.TurboQuantBitSize.BITS2,
+    "tq1.5": models.TurboQuantBitSize.BITS1_5,
+    "tq1":   models.TurboQuantBitSize.BITS1,
+}
+
+
+def _flag(name: str, default: bool) -> bool:
+    return os.getenv(name, str(default)).lower() in ("1", "true", "yes")
+
+
+def _quantization_kind() -> str:
+    return os.getenv("QDRANT_QUANTIZATION", "none").lower()
+
+
+def is_quantization_enabled() -> bool:
+    return _quantization_kind() != "none"
+
+
+def build_quantization_config():
+    """Return the quantization config to pass to client.create_collection,
+    or None when quantization is disabled."""
+    kind = _quantization_kind()
+    if kind == "none":
+        return None
+
+    always_ram = _flag("QDRANT_QUANTIZATION_ALWAYS_RAM", True)
+
+    if kind in _TQ_BITS:
+        return models.TurboQuantization(
+            turbo=models.TurboQuantQuantizationConfig(
+                bits=_TQ_BITS[kind],
+                always_ram=always_ram,
+            )
+        )
+
+    if kind == "sq":
+        return models.ScalarQuantization(
+            scalar=models.ScalarQuantizationConfig(
+                type=models.ScalarType.INT8,
+                always_ram=always_ram,
+            )
+        )
+
+    if kind in ("bq1", "bq2"):
+        encoding = (
+            models.BinaryQuantizationEncoding.ONE_BIT
+            if kind == "bq1"
+            else models.BinaryQuantizationEncoding.TWO_BITS
+        )
+        return models.BinaryQuantization(
+            binary=models.BinaryQuantizationConfig(
+                encoding=encoding,
+                always_ram=always_ram,
+            )
+        )
+
+    if kind == "pq":
+        return models.ProductQuantization(
+            product=models.ProductQuantizationConfig(
+                compression=models.CompressionRatio.X16,
+                always_ram=always_ram,
+            )
+        )
+
+    raise ValueError(
+        f"Unknown QDRANT_QUANTIZATION value: {kind!r}. "
+        "Expected one of: none, tq4, tq2, tq1.5, tq1, sq, bq1, bq2, pq."
+    )
+
+
+def build_search_params():
+    """Return SearchParams with quantization tuning, or None when
+    quantization is disabled. Pass into client.query_points and
+    client.query_batch as search_params=..."""
+    if not is_quantization_enabled():
+        return None
+
+    return models.SearchParams(
+        quantization=models.QuantizationSearchParams(
+            ignore=False,
+            rescore=_flag("QDRANT_QUANTIZATION_RESCORE", True),
+            oversampling=float(os.getenv("QDRANT_QUANTIZATION_OVERSAMPLING", "2.0")),
+        )
+    )

--- a/packages/vector/qdrant/pyproject.toml
+++ b/packages/vector/qdrant/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "cognee-community-vector-adapter-qdrant"
-version = "0.2.4"
+version = "0.3.0"
 description = "Qdrant vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
-    "qdrant-client>=1.16.0",
+    "qdrant-client>=1.18.0",
     "cognee==1.1.0",
     "starlette>=0.48.0",
     "instructor>=1.11"

--- a/packages/vector/qdrant/tests/test_qdrant.py
+++ b/packages/vector/qdrant/tests/test_qdrant.py
@@ -1,6 +1,8 @@
 import os
 import pathlib
 
+import pytest
+
 import cognee
 from cognee.infrastructure.files.storage import get_storage_config
 from cognee.modules.data.models import Data
@@ -108,6 +110,25 @@ async def test_vector_engine_search_none_limit():
     # Check that we did not accidentally use any default value for limit
     # in vector search along the way (like 5, 10, or 15)
     assert len(result) > 15
+
+
+async def test_collection_has_turboquant_config():
+    """Verify that when QDRANT_QUANTIZATION=tq4 is set, newly created
+    collections carry the TurboQuant config on the Qdrant server."""
+    if os.getenv("QDRANT_QUANTIZATION", "").lower() != "tq4":
+        return  # only run when explicitly opted in via env
+
+    from cognee.infrastructure.databases.vector import get_vector_engine
+    adapter = get_vector_engine()
+    client = adapter.get_qdrant_client()
+    try:
+        info = await client.get_collection("Entity_name")
+        qc = info.config.quantization_config
+        assert qc is not None, "Expected TurboQuant config on Entity_name"
+        # qc is one of the union variants; assert it's TurboQuantization-shaped
+        assert hasattr(qc, "turbo") and qc.turbo.bits == "bits4"
+    finally:
+        await client.close()
 
 
 async def test_vector_engine_search_with_nodeset_filtering():
@@ -358,6 +379,8 @@ async def main():
     # and the second one depends on it. Done like this to minimize number of cognify invocations.
     await test_vector_nodeset_filtering_retriever_integration()
 
+    await test_collection_has_turboquant_config()
+
     await cognee.prune.prune_data()
     data_root_directory = get_storage_config()["data_root_directory"]
     assert not os.path.isdir(data_root_directory), "Local data files are not deleted"
@@ -365,6 +388,56 @@ async def main():
     await cognee.prune.prune_system(metadata=True)
     tables_in_database = await vector_engine.get_collection_names()
     assert len(tables_in_database) == 0, "Qdrant database is not empty"
+
+
+def test_build_quantization_config_default(monkeypatch):
+    from cognee_community_vector_adapter_qdrant.quantization import build_quantization_config
+    monkeypatch.delenv("QDRANT_QUANTIZATION", raising=False)
+    assert build_quantization_config() is None
+
+
+@pytest.mark.parametrize("kind,expected_bits", [
+    ("tq4",   "bits4"),
+    ("tq2",   "bits2"),
+    ("tq1.5", "bits1_5"),
+    ("tq1",   "bits1"),
+])
+def test_build_turboquant_config(monkeypatch, kind, expected_bits):
+    from cognee_community_vector_adapter_qdrant.quantization import build_quantization_config
+    from qdrant_client import models
+
+    monkeypatch.setenv("QDRANT_QUANTIZATION", kind)
+    cfg = build_quantization_config()
+    assert isinstance(cfg, models.TurboQuantization)
+    assert cfg.turbo.bits == expected_bits
+    assert cfg.turbo.always_ram is True
+
+
+def test_build_quantization_config_unknown(monkeypatch):
+    from cognee_community_vector_adapter_qdrant.quantization import build_quantization_config
+
+    monkeypatch.setenv("QDRANT_QUANTIZATION", "garbage")
+    with pytest.raises(ValueError):
+        build_quantization_config()
+
+
+def test_build_search_params_disabled(monkeypatch):
+    from cognee_community_vector_adapter_qdrant.quantization import build_search_params
+
+    monkeypatch.delenv("QDRANT_QUANTIZATION", raising=False)
+    assert build_search_params() is None
+
+
+def test_build_search_params_enabled(monkeypatch):
+    from cognee_community_vector_adapter_qdrant.quantization import build_search_params
+
+    monkeypatch.setenv("QDRANT_QUANTIZATION", "tq4")
+    monkeypatch.setenv("QDRANT_QUANTIZATION_OVERSAMPLING", "3.0")
+    params = build_search_params()
+    assert params is not None
+    assert params.quantization.rescore is True
+    assert params.quantization.oversampling == 3.0
+    assert params.quantization.ignore is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This integration was e2e tested against a live Qdrant container.

- New quantization.py builder reading QDRANT_QUANTIZATION,
  QDRANT_QUANTIZATION_ALWAYS_RAM, QDRANT_QUANTIZATION_RESCORE,
  QDRANT_QUANTIZATION_OVERSAMPLING env vars.
- Wire quantization_config into create_collection.
- Wire search_params into search and batch_search (rescore + oversampling).
- New update_quantization() method for in-place migration of existing
  collections without re-ingesting data.
- Fail fast when QDRANT_QUANTIZATION=tq* is set but qdrant-client<1.18.
- Remove dead create_hnsw_config / create_optimizers_config /
  create_quantization_config stubs.
- Bump qdrant-client to >=1.18.0; bump package to 0.3.0.