### PR TITLE
feat: add CLIENT SETNAME for connection identification

### DIFF
--- a/packages/vector/valkey/cognee_community_vector_adapter_valkey/valkey_adapter.py
+++ b/packages/vector/valkey/cognee_community_vector_adapter_valkey/valkey_adapter.py
@@ -113,6 +113,7 @@ class ValkeyAdapter(VectorDBInterface):
 
         cfg = GlideClientConfiguration(
             [NodeAddress(self._host, self._port)],
+            client_name="cognee_vector_store_client",
             use_tls=False,
             request_timeout=5000,
             reconnect_strategy=BackoffStrategy(num_of_retries=3, factor=1000, exponent_base=2),


### PR DESCRIPTION
## Description

Adds `client_name="cognee_vector_store_client"` to `GlideClientConfiguration` in the Valkey adapter so the connection is identifiable via `CLIENT LIST` on the server.

Fixes #109

### Why

Connections from Cognee currently appear anonymous in `CLIENT LIST`. Setting `client_name` sends a `CLIENT SETNAME` command on connection, making it identifiable in:
- `CLIENT LIST` output
- Monitoring dashboards (e.g., Valkey Admin)
- CloudWatch metrics (ElastiCache)

### Changes

One-line addition to `valkey_adapter.py` — adds `client_name` parameter to the existing `GlideClientConfiguration` call.

### Risk

Zero-risk — `client_name` is a metadata-only option. No behavioral changes.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.