### PR TITLE
feat(vector): add ChromaDB community vector adapter

### DIFF
--- a/packages/vector/chromadb/README.md
+++ b/packages/vector/chromadb/README.md
@@ -1,0 +1,59 @@
+# ChromaDB Vector Database Adapter
+
+This is a community-contributed adapter for integrating [ChromaDB](https://www.trychroma.com/) with Cognee. It was previously bundled in cognee core and now lives here as a community package.
+
+## About ChromaDB
+
+ChromaDB is an open-source embedding database. This adapter talks to a ChromaDB server over its async HTTP client and stores Cognee data points as collections with cosine-distance vector search.
+
+## Installation
+
+```bash
+pip install cognee-community-vector-adapter-chromadb
+```
+
+or from source:
+
+```bash
+cd packages/vector/chromadb
+pip install .
+```
+
+## Usage
+
+Importing the `register` module registers the adapter with cognee via
+`use_vector_adapter("chromadb", ChromaDBAdapter)`:
+
+```python
+import cognee
+from cognee_community_vector_adapter_chromadb import register  # noqa: F401
+
+cognee.config.set_vector_db_config(
+    {
+        "vector_db_provider": "chromadb",
+        "vector_db_url": "http://localhost:3002",  # your ChromaDB server
+        "vector_db_key": "your-chroma-token",      # token auth credential
+    }
+)
+
+await cognee.add("Your data here")
+await cognee.cognify()
+results = await cognee.search("search query")
+```
+
+## Configuration
+
+| Setting | Description |
+|---|---|
+| `vector_db_provider` | Must be `"chromadb"`. |
+| `vector_db_url` | Host/URL of the ChromaDB server (`AsyncHttpClient` host). |
+| `vector_db_key` | Token used for ChromaDB token auth. |
+
+## Dependencies
+
+- `chromadb>=0.6,<0.7`
+- `cognee>=0.5.0`
+
+## License
+
+Apache 2.0, same as the main Cognee project.

--- a/packages/vector/chromadb/cognee_community_vector_adapter_chromadb/__init__.py
+++ b/packages/vector/chromadb/cognee_community_vector_adapter_chromadb/__init__.py
@@ -1,0 +1,3 @@
+from .chromadb_adapter import ChromaDBAdapter
+
+__all__ = ["ChromaDBAdapter"]

--- a/packages/vector/chromadb/cognee_community_vector_adapter_chromadb/chromadb_adapter.py
+++ b/packages/vector/chromadb/cognee_community_vector_adapter_chromadb/chromadb_adapter.py
@@ -1,0 +1,629 @@
+import json
+import asyncio
+from uuid import UUID
+from typing import List, Literal, Optional
+from chromadb import AsyncHttpClient, Settings
+from pydantic import BaseModel
+
+from cognee.shared.logging_utils import get_logger
+from cognee.modules.storage.utils import get_own_properties
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.engine.utils import parse_id
+from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
+
+from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
+from cognee.infrastructure.databases.vector.vector_db_interface import VectorDBInterface
+
+logger = get_logger("ChromaDBAdapter")
+
+
+class IndexSchema(DataPoint):
+    """
+    Define a schema for indexing textual data along with metadata.
+
+    Public methods:
+
+    - model_dump: Serialize the instance data into a format suitable for ChromaDB storage.
+
+    Instance variables:
+
+    - text: The text content to be indexed.
+    - metadata: A dictionary containing index-related fields.
+    """
+
+    text: str
+
+    metadata: dict = {"index_fields": ["text"]}
+
+    def model_dump(self):
+        """
+        Serialize the instance data for storage.
+
+        Invoke the superclass method and process the resulting data into a format compatible
+        with ChromaDB.
+
+        Returns:
+        --------
+
+            A dictionary containing serialized data processed for ChromaDB storage.
+        """
+        data = super().model_dump()
+        return process_data_for_chroma(data)
+
+
+def process_data_for_chroma(data):
+    """
+    Convert complex data types to a format suitable for ChromaDB storage.
+
+    This function processes various data types from the input dictionary, converting UUIDs
+    to strings, and serializing dictionaries and lists into JSON strings prefixed with the
+    key type. Other supported types (strings, integers, floats, booleans, and None) are
+    stored as-is. Unsupported types are converted to their string representation.
+
+    Parameters:
+    -----------
+
+        - data: A dictionary containing data with various types including potentially
+          complex structures.
+
+    Returns:
+    --------
+
+        A dictionary containing the processed key-value pairs suitable for ChromaDB storage.
+    """
+    processed_data = {}
+    for key, value in data.items():
+        if isinstance(value, UUID):
+            processed_data[key] = str(value)
+        elif isinstance(value, dict):
+            # Store dictionaries as JSON strings with special prefix
+            processed_data[f"{key}__dict"] = json.dumps(value)
+        elif isinstance(value, list):
+            # Store lists as JSON strings with special prefix
+            processed_data[f"{key}__list"] = json.dumps(value)
+        elif isinstance(value, (str, int, float, bool)):
+            processed_data[key] = value
+        else:
+            processed_data[key] = str(value)
+    return processed_data
+
+
+def restore_data_from_chroma(data):
+    """
+    Restore original data structure from ChromaDB storage format.
+
+    This function processes a data dictionary, identifies special keys that end with
+    '__dict' and '__list', and attempts to restore the original data structure by converting
+    JSON strings back into Python objects. If restoration fails, it logs an error and
+    retains the original value.
+
+    Parameters:
+    -----------
+
+        - data: A dictionary containing data stored in ChromaDB format, which includes
+          special keys indicating dictionary and list entries.
+
+    Returns:
+    --------
+
+        A dictionary representing the restored original data structure, with JSON strings
+        converted to their appropriate Python types.
+    """
+    restored_data = {}
+    dict_keys = []
+    list_keys = []
+
+    # First, identify all special keys
+    for key in data.keys():
+        if key.endswith("__dict"):
+            dict_keys.append(key)
+        elif key.endswith("__list"):
+            list_keys.append(key)
+        else:
+            restored_data[key] = data[key]
+
+    # Process dictionary fields
+    for key in dict_keys:
+        original_key = key[:-6]  # Remove '__dict' suffix
+        try:
+            restored_data[original_key] = json.loads(data[key])
+        except Exception as e:
+            logger.debug(f"Error restoring dictionary from JSON: {e}")
+            restored_data[key] = data[key]
+
+    # Process list fields
+    for key in list_keys:
+        original_key = key[:-6]  # Remove '__list' suffix
+        try:
+            restored_data[original_key] = json.loads(data[key])
+        except Exception as e:
+            logger.debug(f"Error restoring list from JSON: {e}")
+            restored_data[key] = data[key]
+
+    return restored_data
+
+
+class ChromaDBAdapter(VectorDBInterface):
+    """
+    Manage a connection to the ChromaDB and facilitate operations for embedding, searching,
+    and managing collections of data points.
+    """
+
+    name = "ChromaDB"
+    url: str
+    api_key: str
+    connection: AsyncHttpClient = None
+
+    def __init__(
+        self, url: Optional[str], api_key: Optional[str], embedding_engine: EmbeddingEngine
+    ):
+        self.embedding_engine = embedding_engine
+        self.url = url
+        self.api_key = api_key
+        self.VECTOR_DB_LOCK = asyncio.Lock()
+
+    async def get_connection(self) -> AsyncHttpClient:
+        """
+        Establish and return a connection to the ChromaDB if one doesn't already exist.
+
+        Returns:
+        --------
+
+            - AsyncHttpClient: Returns an instance of AsyncHttpClient for interacting with
+              ChromaDB.
+        """
+        if self.connection is None:
+            settings = Settings(
+                chroma_client_auth_provider="token", chroma_client_auth_credentials=self.api_key
+            )
+            self.connection = await AsyncHttpClient(host=self.url, settings=settings)
+
+        return self.connection
+
+    async def embed_data(self, data: list[str]) -> list[list[float]]:
+        """
+        Embed a list of text data into vector representations.
+
+        Parameters:
+        -----------
+
+            - data (list[str]): A list of strings to be embedded.
+
+        Returns:
+        --------
+
+            - list[list[float]]: Returns a list of lists containing the embedded vector
+              representations.
+        """
+        return await self.embedding_engine.embed_text(data)
+
+    async def has_collection(self, collection_name: str) -> bool:
+        """
+        Check if a collection with the specified name exists in the ChromaDB.
+
+        Parameters:
+        -----------
+
+            - collection_name (str): The name of the collection to check for.
+
+        Returns:
+        --------
+
+            - bool: Returns True if the collection exists, otherwise False.
+        """
+        collections = await self.get_collection_names()
+        return collection_name in collections
+
+    async def create_collection(self, collection_name: str, payload_schema=None):
+        """
+        Create a new collection in ChromaDB if it does not already exist.
+
+        Parameters:
+        -----------
+
+            - collection_name (str): The name of the collection to create.
+            - payload_schema: The schema for the payload; can be None. (default None)
+        """
+        async with self.VECTOR_DB_LOCK:
+            client = await self.get_connection()
+
+            if not await self.has_collection(collection_name):
+                await client.create_collection(
+                    name=collection_name, metadata={"hnsw:space": "cosine"}
+                )
+
+    async def get_collection(self, collection_name: str) -> AsyncHttpClient:
+        """
+        Retrieve a collection by its name from ChromaDB.
+
+        Parameters:
+        -----------
+
+            - collection_name (str): The name of the collection to retrieve.
+
+        Returns:
+        --------
+
+            - AsyncHttpClient: Returns an AsyncHttpClient representing the requested collection.
+        """
+        if not await self.has_collection(collection_name):
+            raise CollectionNotFoundError(f"Collection '{collection_name}' not found!")
+
+        client = await self.get_connection()
+        return await client.get_collection(collection_name)
+
+    async def create_data_points(self, collection_name: str, data_points: list[DataPoint]):
+        """
+        Create and upsert data points into the specified collection in ChromaDB.
+
+        Parameters:
+        -----------
+
+            - collection_name (str): The name of the collection where data points will be added.
+            - data_points (list[DataPoint]): A list of DataPoint instances to be added to the
+              collection.
+        """
+        await self.create_collection(collection_name)
+
+        collection = await self.get_collection(collection_name)
+
+        texts = [DataPoint.get_embeddable_data(data_point) for data_point in data_points]
+        embeddings = await self.embed_data(texts)
+        ids = [str(data_point.id) for data_point in data_points]
+
+        metadatas = []
+        for data_point in data_points:
+            metadata = get_own_properties(data_point)
+            metadatas.append(process_data_for_chroma(metadata))
+
+        await collection.upsert(
+            ids=ids, embeddings=embeddings, metadatas=metadatas, documents=texts
+        )
+
+    async def create_vector_index(self, index_name: str, index_property_name: str):
+        """
+        Create a vector index as a ChromaDB collection based on provided names.
+
+        Parameters:
+        -----------
+
+            - index_name (str): The base name for the vector index.
+            - index_property_name (str): The property name associated with the index.
+        """
+        await self.create_collection(f"{index_name}_{index_property_name}")
+
+    async def index_data_points(
+        self, index_name: str, index_property_name: str, data_points: list[DataPoint]
+    ):
+        """
+        Index the provided data points based on the specified index property in ChromaDB.
+
+        Parameters:
+        -----------
+
+            - index_name (str): The index name used for the data points.
+            - index_property_name (str): The property name to index data points by.
+            - data_points (list[DataPoint]): A list of DataPoint instances to be indexed.
+        """
+        await self.create_data_points(
+            f"{index_name}_{index_property_name}",
+            [
+                IndexSchema(
+                    id=data_point.id,
+                    text=getattr(data_point, data_point.metadata["index_fields"][0]),
+                )
+                for data_point in data_points
+            ],
+        )
+
+    async def retrieve(self, collection_name: str, data_point_ids: list[str]):
+        """
+        Retrieve data points by their IDs from a ChromaDB collection.
+
+        Parameters:
+        -----------
+
+            - collection_name (str): The name of the collection from which to retrieve data
+              points.
+            - data_point_ids (list[str]): A list of data point IDs to retrieve.
+
+        Returns:
+        --------
+
+            Returns a list of ScoredResult instances containing the retrieved data points and
+            their metadata.
+        """
+        try:
+            collection = await self.get_collection(collection_name)
+        except CollectionNotFoundError:
+            # If collection doesn't exist, return empty list (no items to retrieve)
+            return []
+
+        results = await collection.get(ids=data_point_ids, include=["metadatas"])
+
+        return [
+            ScoredResult(
+                id=parse_id(id),
+                payload=restore_data_from_chroma(metadata),
+                score=0,
+            )
+            for id, metadata in zip(results["ids"], results["metadatas"])
+        ]
+
+    @staticmethod
+    def _build_where_filter(
+        node_name: Optional[List[str]],
+        node_name_filter_operator: "Literal['OR', 'AND']",
+    ) -> Optional[dict]:
+        """Build a ChromaDB ``where`` filter dict from node_name constraints."""
+        if node_name_filter_operator not in ("OR", "AND"):
+            raise ValueError(
+                f"Unsupported node_name_filter_operator: {node_name_filter_operator!r}. "
+                "Expected 'OR' or 'AND'."
+            )
+        if not node_name:
+            return None
+        if len(node_name) == 1:
+            return {"belongs_to_set": {"$eq": node_name[0]}}
+        if node_name_filter_operator == "AND":
+            return {"$and": [{"belongs_to_set": {"$eq": name}} for name in node_name]}
+        return {"$or": [{"belongs_to_set": {"$eq": name}} for name in node_name]}
+
+    @staticmethod
+    def _build_include_list(include_payload: bool, with_vector: bool) -> List[str]:
+        """Build the ChromaDB ``include`` list based on caller requirements."""
+        include = ["distances"]
+        if include_payload:
+            include.append("metadatas")
+        if with_vector:
+            include.append("embeddings")
+        return include
+
+    async def search(
+        self,
+        collection_name: str,
+        query_text: str = None,
+        query_vector: List[float] = None,
+        limit: Optional[int] = 15,
+        with_vector: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: Literal["OR", "AND"] = "OR",
+    ):
+        """
+        Search for items in a collection using either a text or a vector query.
+
+        Parameters:
+        -----------
+
+            - collection_name (str): The name of the collection in which to perform the search.
+            - query_text (str): Text query used for search; can be None if query_vector is
+              provided. (default None)
+            - query_vector (List[float]): Vector query used for search; can be None if
+              query_text is provided. (default None)
+            - limit (int): The maximum number of results to return; defaults to 15. (default 15)
+            - with_vector (bool): Whether to include vectors in the results. (default False)
+            - include_payload (bool): When True, fetches metadatas from ChromaDB and populates
+              ``ScoredResult.payload``. When False (default), metadatas are omitted from the
+              query to reduce memory and network overhead; ``payload`` will be None.
+            - node_name (Optional[List[str]]): Filter results to nodes whose
+              ``belongs_to_set`` field matches one of the provided names.
+              No filter is applied when None. (default None)
+            - node_name_filter_operator (Literal["OR", "AND"]): Logical operator applied to
+              ``node_name`` entries. ``"OR"`` (default) accepts nodes matching any name;
+              ``"AND"`` requires all names to be present in ``belongs_to_set``.
+
+        Returns:
+        --------
+
+            Returns a list of ScoredResult instances representing the search results.
+        """
+        if query_text is None and query_vector is None:
+            raise MissingQueryParameterError()
+
+        if query_text and not query_vector:
+            query_vector = (await self.embedding_engine.embed_text([query_text]))[0]
+
+        try:
+            collection = await self.get_collection(collection_name)
+
+            if limit is None:
+                limit = await collection.count()
+
+            # If limit is still 0, no need to do the search, just return empty results
+            if limit <= 0:
+                return []
+
+            where_filter = self._build_where_filter(node_name, node_name_filter_operator)
+            include_list = self._build_include_list(include_payload, with_vector)
+
+            query_kwargs = {
+                "query_embeddings": [query_vector],
+                "include": include_list,
+                "n_results": limit,
+            }
+            if where_filter is not None:
+                query_kwargs["where"] = where_filter
+
+            results = await collection.query(**query_kwargs)
+
+            vector_list = []
+            metadatas = results.get("metadatas")
+            for i, (id, distance) in enumerate(zip(results["ids"][0], results["distances"][0])):
+                item = {
+                    "id": parse_id(id),
+                    "payload": restore_data_from_chroma(metadatas[0][i])
+                    if include_payload
+                    else None,
+                    "_distance": distance,
+                }
+
+                if with_vector and "embeddings" in results:
+                    item["vector"] = results["embeddings"][0][i]
+
+                vector_list.append(item)
+
+            # Return backend raw cosine distance as score (lower is better)
+            for i in range(len(vector_list)):
+                vector_list[i]["score"] = float(vector_list[i]["_distance"])
+
+            # Create and return ScoredResult objects
+            return [
+                ScoredResult(
+                    id=row["id"],
+                    payload=row["payload"],
+                    score=row["score"],
+                    vector=row.get("vector") if with_vector else None,
+                )
+                for row in vector_list
+            ]
+        except Exception as e:
+            logger.warning(f"Error in search: {str(e)}")
+            return []
+
+    async def batch_search(
+        self,
+        collection_name: str,
+        query_texts: List[str],
+        limit: int = 5,
+        with_vectors: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: Literal["OR", "AND"] = "OR",
+    ):
+        """
+        Perform multiple searches in a single request for efficiency, returning results for each
+        query.
+
+        Parameters:
+        -----------
+
+            - collection_name (str): The name of the collection in which to perform the
+              searches.
+            - query_texts (List[str]): A list of text queries to be searched.
+            - limit (int): The maximum number of results to return for each query; defaults to
+              5. (default 5)
+            - with_vectors (bool): Whether to include vectors in the results for each query.
+              (default False)
+            - include_payload (bool): Whether to include payload metadata in results.
+              (default False)
+            - node_name (Optional[List[str]]): Filter results to nodes matching these names.
+              (default None)
+            - node_name_filter_operator (Literal["OR", "AND"]): Logical operator for
+              node_name filter, ``"OR"`` or ``"AND"``. (default "OR")
+
+        Returns:
+        --------
+
+            Returns a list of lists of ScoredResult instances for each query's results.
+        """
+        query_vectors = await self.embed_data(query_texts)
+
+        collection = await self.get_collection(collection_name)
+
+        where_filter = self._build_where_filter(node_name, node_name_filter_operator)
+        include_list = self._build_include_list(include_payload, with_vectors)
+
+        query_kwargs = {
+            "query_embeddings": query_vectors,
+            "include": include_list,
+            "n_results": limit,
+        }
+        if where_filter is not None:
+            query_kwargs["where"] = where_filter
+
+        results = await collection.query(**query_kwargs)
+
+        all_results = []
+        metadatas = results.get("metadatas")
+        for i in range(len(query_texts)):
+            vector_list = []
+
+            for j, (id, distance) in enumerate(zip(results["ids"][i], results["distances"][i])):
+                item = {
+                    "id": parse_id(id),
+                    "payload": restore_data_from_chroma(metadatas[i][j])
+                    if include_payload
+                    else None,
+                    "_distance": distance,
+                }
+
+                if with_vectors and "embeddings" in results:
+                    item["vector"] = results["embeddings"][i][j]
+
+                vector_list.append(item)
+
+            query_results = []
+            for item in vector_list:
+                result = ScoredResult(
+                    id=item["id"],
+                    payload=item["payload"],
+                    score=float(item["_distance"]),
+                )
+
+                if with_vectors and "embeddings" in results:
+                    result.vector = item.get("vector")
+
+                query_results.append(result)
+
+            all_results.append(query_results)
+
+        return all_results
+
+    async def delete_data_points(self, collection_name: str, data_point_ids: list[str]):
+        """
+        Remove data points from a collection based on their IDs.
+
+        Parameters:
+        -----------
+
+            - collection_name (str): The name of the collection from which to delete data
+              points.
+            - data_point_ids (list[str]): A list of data point IDs to remove from the
+              collection.
+
+        Returns:
+        --------
+
+            Returns True upon successful deletion of the data points.
+        """
+        # Skip deletion if collection doesn't exist
+        if not await self.has_collection(collection_name):
+            return True
+
+        collection = await self.get_collection(collection_name)
+        await collection.delete(ids=data_point_ids)
+        return True
+
+    async def prune(self):
+        """
+        Delete all collections in the ChromaDB database.
+
+        Returns:
+        --------
+
+            Returns True upon successful deletion of all collections.
+        """
+        client = await self.get_connection()
+        collections = await client.list_collections()
+        for collection_name in collections:
+            await client.delete_collection(collection_name)
+        return True
+
+    async def get_collection_names(self):
+        """
+        Retrieve the names of all collections in the ChromaDB database.
+
+        Returns:
+        --------
+
+            Returns a list of collection names.
+        """
+        client = await self.get_connection()
+        return await client.list_collections()
+
+    async def run_migrations(self):
+        """Run ChromaDB adapter migrations (currently no-op)."""
+        return None

--- a/packages/vector/chromadb/cognee_community_vector_adapter_chromadb/register.py
+++ b/packages/vector/chromadb/cognee_community_vector_adapter_chromadb/register.py
@@ -1,0 +1,5 @@
+from cognee.infrastructure.databases.vector import use_vector_adapter
+
+from .chromadb_adapter import ChromaDBAdapter
+
+use_vector_adapter("chromadb", ChromaDBAdapter)

--- a/packages/vector/chromadb/pyproject.toml
+++ b/packages/vector/chromadb/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "cognee-community-vector-adapter-chromadb"
+version = "0.1.0"
+description = "ChromaDB vector database adapter for cognee"
+readme = "README.md"
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "chromadb>=0.6,<0.7",
+    # pypika 0.48.9's setup.py uses ast.Str, which Python 3.14 removed (it was
+    # deprecated since 3.8). chromadb only requires pypika>=0.48.9, so allow a
+    # newer pypika on 3.14.
+    "pypika==0.48.9 ; python_version < '3.14'",
+    "pypika>=0.50.0 ; python_version >= '3.14'",
+    "cognee>=0.5.0",
+    "starlette>=0.48.0",
+    "instructor>=1.11",
+]
+
+[project.optional-dependencies]
+dev = [
+    "mypy>=1.10,<2",
+]
+
+[tool.mypy]
+python_version = "3.12"
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+no_implicit_optional = true
+check_untyped_defs = true
+disallow_any_generics = true
+strict_equality = true
+exclude = ["^\\.venv/"]
+
+[[tool.mypy.overrides]]
+module = [
+  "chromadb.*",
+  "cognee.*",
+]
+ignore_missing_imports = true

--- a/packages/vector/chromadb/tests/test_chromadb.py
+++ b/packages/vector/chromadb/tests/test_chromadb.py
@@ -1,0 +1,204 @@
+import os
+import pathlib
+
+import cognee
+from cognee.shared.logging_utils import get_logger
+from cognee.infrastructure.files.storage import get_storage_config
+from cognee.modules.data.models import Data
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.search.types import SearchType
+from cognee.modules.search.operations import get_history
+
+# NOTE: Importing the register module lets cognee know it can use the ChromaDB vector adapter.
+# NOTE: The "noqa: F401" mark keeps the linter from flagging this as an unused import.
+from cognee_community_vector_adapter_chromadb import register  # noqa: F401
+
+logger = get_logger()
+
+# Shared sample documents live at packages/test_data (four levels up from this file).
+TEST_DATA_DIR = pathlib.Path(__file__).parent.parent.parent.parent / "test_data"
+
+
+async def test_local_file_deletion(data_text, file_location):
+    from sqlalchemy import select
+    import hashlib
+    from cognee.infrastructure.databases.relational import get_relational_engine
+
+    engine = get_relational_engine()
+
+    async with engine.get_async_session() as session:
+        # Get hash of data contents
+        encoded_text = data_text.encode("utf-8")
+        data_hash = hashlib.md5(encoded_text).hexdigest()
+        # Get data entry from database based on hash contents
+        data = (await session.scalars(select(Data).where(Data.content_hash == data_hash))).one()
+        assert os.path.isfile(data.raw_data_location.replace("file://", "")), (
+            f"Data location doesn't exist: {data.raw_data_location}"
+        )
+        # Test deletion of data along with local files created by cognee
+        await engine.delete_data_entity(data.id)
+        assert not os.path.exists(data.raw_data_location.replace("file://", "")), (
+            f"Data location still exists after deletion: {data.raw_data_location}"
+        )
+
+    async with engine.get_async_session() as session:
+        # Get data entry from database based on file path
+        data = (
+            await session.scalars(select(Data).where(Data.raw_data_location == file_location))
+        ).one()
+        assert os.path.isfile(data.raw_data_location.replace("file://", "")), (
+            f"Data location doesn't exist: {data.raw_data_location}"
+        )
+        # Test local files not created by cognee won't get deleted
+        await engine.delete_data_entity(data.id)
+        assert os.path.exists(data.raw_data_location.replace("file://", "")), (
+            f"Data location doesn't exists: {data.raw_data_location}"
+        )
+
+
+async def test_getting_of_documents(dataset_name_1):
+    # Test getting of documents for search per dataset
+    from cognee.modules.users.permissions.methods import get_document_ids_for_user
+
+    user = await get_default_user()
+    document_ids = await get_document_ids_for_user(user.id, [dataset_name_1])
+    assert len(document_ids) == 1, (
+        f"Number of expected documents doesn't match {len(document_ids)} != 1"
+    )
+
+    # Test getting of documents for search when no dataset is provided
+    user = await get_default_user()
+    document_ids = await get_document_ids_for_user(user.id)
+    assert len(document_ids) == 2, (
+        f"Number of expected documents doesn't match {len(document_ids)} != 2"
+    )
+
+
+async def test_vector_engine_search_none_limit():
+    file_path_quantum = os.path.join(TEST_DATA_DIR, "Quantum_computers.txt")
+    file_path_nlp = os.path.join(TEST_DATA_DIR, "Natural_language_processing.txt")
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await cognee.add(file_path_quantum)
+
+    await cognee.add(file_path_nlp)
+
+    await cognee.cognify()
+
+    query_text = "Tell me about Quantum computers"
+
+    from cognee.infrastructure.databases.vector import get_vector_engine
+
+    vector_engine = get_vector_engine()
+
+    collection_name = "Entity_name"
+
+    query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
+
+    result = await vector_engine.search(
+        collection_name=collection_name, query_vector=query_vector, limit=None, include_payload=True
+    )
+
+    # Check that we did not accidentally use any default value for limit
+    # in vector search along the way (like 5, 10, or 15)
+    assert len(result) > 15
+
+
+async def main():
+    cognee.config.set_vector_db_config(
+        {
+            "vector_db_url": os.getenv("CHROMADB_URL", "http://localhost:3002"),
+            "vector_db_key": os.getenv("CHROMADB_KEY", "test-token"),
+            "vector_db_provider": "chromadb",
+        }
+    )
+
+    data_directory_path = str(
+        pathlib.Path(
+            os.path.join(pathlib.Path(__file__).parent, ".data_storage/test_chromadb")
+        ).resolve()
+    )
+    cognee.config.data_root_directory(data_directory_path)
+    cognee_directory_path = str(
+        pathlib.Path(
+            os.path.join(pathlib.Path(__file__).parent, ".cognee_system/test_chromadb")
+        ).resolve()
+    )
+    cognee.config.system_root_directory(cognee_directory_path)
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    dataset_name_1 = "natural_language"
+    dataset_name_2 = "quantum"
+
+    explanation_file_path_nlp = os.path.join(TEST_DATA_DIR, "Natural_language_processing.txt")
+    await cognee.add([explanation_file_path_nlp], dataset_name_1)
+
+    explanation_file_path_quantum = os.path.join(TEST_DATA_DIR, "Quantum_computers.txt")
+    await cognee.add([explanation_file_path_quantum], dataset_name_2)
+
+    await cognee.cognify([dataset_name_2, dataset_name_1])
+
+    from cognee.infrastructure.databases.vector import get_vector_engine
+
+    await test_getting_of_documents(dataset_name_1)
+
+    vector_engine = get_vector_engine()
+    random_node = (await vector_engine.search("Entity_name", "Quantum computer"))[0]
+    random_node_name = random_node.payload["text"]
+
+    search_results = await cognee.search(
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
+    )
+    assert len(search_results) != 0, "The search results list is empty."
+    print("\n\nExtracted sentences are:\n")
+    for result in search_results:
+        print(f"{result}\n")
+
+    search_results = await cognee.search(
+        query_type=SearchType.CHUNKS, query_text=random_node_name, datasets=[dataset_name_2]
+    )
+    assert len(search_results) != 0, "The search results list is empty."
+    print("\n\nExtracted chunks are:\n")
+    for result in search_results:
+        print(f"{result}\n")
+
+    graph_completion = await cognee.search(
+        query_type=SearchType.GRAPH_COMPLETION,
+        query_text=random_node_name,
+        datasets=[dataset_name_2],
+    )
+    assert len(graph_completion) != 0, "Completion result is empty."
+    print("Completion result is:")
+    print(graph_completion)
+
+    search_results = await cognee.search(
+        query_type=SearchType.SUMMARIES, query_text=random_node_name
+    )
+    assert len(search_results) != 0, "Query related summaries don't exist."
+    print("\n\nExtracted summaries are:\n")
+    for result in search_results:
+        print(f"{result}\n")
+
+    user = await get_default_user()
+    history = await get_history(user.id)
+    assert len(history) == 8, "Search history is not correct."
+
+    await cognee.prune.prune_data()
+    data_root_directory = get_storage_config()["data_root_directory"]
+    assert not os.path.isdir(data_root_directory), "Local data files are not deleted"
+
+    await cognee.prune.prune_system(metadata=True)
+    tables_in_database = await vector_engine.get_collection_names()
+    assert len(tables_in_database) == 0, "ChromaDB database is not empty"
+
+    await test_vector_engine_search_none_limit()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
## What

Adds **ChromaDB** as a community vector adapter, moving it out of cognee core. Mirrors the existing `packages/vector/{milvus,qdrant,weaviate,azureaisearch}` layout. Importing the package's `register` module registers the adapter with cognee via `use_vector_adapter("chromadb", ChromaDBAdapter)`.

**Companion core PR** (removes ChromaDB from cognee core): topoteretes/cognee#2996

## Package

`packages/vector/chromadb/`
- `cognee_community_vector_adapter_chromadb/chromadb_adapter.py` — the adapter, ported **verbatim** from cognee core, with its two relative imports (`..embeddings.EmbeddingEngine`, `..vector_db_interface`) rewritten to absolute `cognee.*` imports.
- `register.py` — `use_vector_adapter("chromadb", ChromaDBAdapter)`.
- `__init__.py`, `pyproject.toml` (`chromadb>=0.6,<0.7` + `cognee`), `README.md`.
- `tests/test_chromadb.py` — the end-to-end test ported from core, importing `register` and reading the shared `packages/test_data` fixtures.

## Usage

```python
import cognee
from cognee_community_vector_adapter_chromadb import register  # noqa: F401

cognee.config.set_vector_db_config({
    "vector_db_provider": "chromadb",
    "vector_db_url": "http://localhost:3002",
    "vector_db_key": "your-chroma-token",
})
```

## Validation

Verified the registration path against cognee: before importing `register`, `"chromadb"` is absent from cognee's `supported_databases`; after import it's present and resolves to `ChromaDBAdapter` (name `ChromaDB`). All package modules compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)