### PR TITLE
feat: add TurboPuffer graph adapter (test-driven skeleton)

### DIFF
--- a/packages/graph/turbopuffer/README.md
+++ b/packages/graph/turbopuffer/README.md
@@ -1,0 +1,87 @@
+# cognee-community-graph-adapter-turbopuffer
+
+A community **graph** database adapter for [cognee](https://github.com/topoteretes/cognee)
+backed by [TurboPuffer](https://turbopuffer.com).
+
+TurboPuffer is a vector/document store with no native graph traversal or query
+language, so this adapter **emulates a graph** on two TurboPuffer namespaces per
+dataset — exactly as the core Postgres graph adapter emulates one on relational
+tables. All traversal is done client-side with single-hop edge queries.
+
+## Storage model
+
+Per dataset, namespace-prefixed by `database_name`:
+
+- `{database_name}_graph_node` — one doc per node: `id`, `name`, `type`
+  (the DataPoint class name), `belongs_to_set` (string[]), and a non-filterable
+  `properties` JSON blob holding all remaining fields (so large `text` is kept
+  in full).
+- `{database_name}_graph_edge` — one doc per edge: a deterministic `uuid5` id
+  (TurboPuffer caps ids at 64 bytes), `source_id`, `target_id`,
+  `relationship_name`, denormalized endpoint identity
+  (`source_name`/`source_type`/`target_name`/`target_type`), and the full edge
+  `properties` JSON blob.
+
+## Install
+
+```bash
+uv pip install -e cognee-community/packages/graph/turbopuffer
+# or, from the package directory:
+uv pip install -e .
+```
+
+## Configure & use
+
+```python
+import cognee
+from cognee_community_graph_adapter_turbopuffer import register
+
+register()  # registers the "turbopuffer" graph provider + dataset handler
+cognee.config.set_graph_database_provider("turbopuffer")
+
+# Environment:
+#   TURBOPUFFER_API_KEY   (required)
+#   TURBOPUFFER_REGION    (required by the SDK; e.g. gcp-us-central1)
+
+await cognee.add("Alice followed the White Rabbit.")
+await cognee.cognify()
+results = await cognee.search("Who does Alice meet?")
+```
+
+For multi-tenant **backend access control**, also select the graph dataset
+handler:
+
+```bash
+GRAPH_DATABASE_PROVIDER=turbopuffer
+GRAPH_DATASET_DATABASE_HANDLER=turbopuffer_graph
+```
+
+(The handler is registered under `turbopuffer_graph` so it does not collide with
+the TurboPuffer *vector* adapter's `turbopuffer` handler.)
+
+## Supported vs. not (v1)
+
+**Supported:** CRUD, single-hop reads (`get_neighbors`, `get_connections`,
+`get_edges`), `get_neighborhood(depth=1)`, `get_graph_data`,
+`get_filtered_graph_data`, `get_nodeset_subgraph` (OR + client-side AND),
+`get_graph_metrics` (counts + mean degree), `get_triplets_batch` (offset
+pagination via deterministic cursor scan), `remove_belongs_to_set_tags`,
+`delete_graph`, per-dataset isolation.
+
+**Not in v1:** multi-hop BFS (`get_neighborhood(depth>=2)`) and raw Cypher
+(`query`) raise `NotImplementedError`. Connectivity-dependent metrics
+(connected components, diameter, clustering) return the `-1` sentinel, matching
+the Postgres adapter.
+
+## Examples & tests
+
+```bash
+# build the Alice graph and query it
+GRAPH_DATABASE_PROVIDER=turbopuffer python examples/example.py
+python examples/inspect_graph.py --raw       # inspect node/edge namespaces
+python examples/export_graph.py               # dump nodes.json / edges.json
+
+# tests (see tests/README.md for tiers)
+./run_tests.sh integration                    # live per-method + isolation
+./run_tests.sh e2e                            # full add->cognify->search on Alice
+```

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/TurbopufferGraphDatasetDatabaseHandler.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/TurbopufferGraphDatasetDatabaseHandler.py
@@ -41,7 +41,7 @@ class TurbopufferGraphDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
             "graph_database_url": graph_config.graph_database_url,
             "graph_database_name": graph_db_name,
             "graph_database_key": graph_config.graph_database_key,
-            "graph_dataset_database_handler": "turbopuffer",
+            "graph_dataset_database_handler": "turbopuffer_graph",
         }
 
     @classmethod

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/TurbopufferGraphDatasetDatabaseHandler.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/TurbopufferGraphDatasetDatabaseHandler.py
@@ -1,23 +1,56 @@
-"""Per-dataset isolation handler for the TurboPuffer graph adapter — SKELETON.
+"""Per-dataset isolation handler for the TurboPuffer graph adapter.
 
-Graph analog of the vector adapter's TurbopufferDatasetDatabaseHandler. cognee
-persists the returned mapping in its DatasetDatabase table, then constructs the
-adapter with ``database_name=<dataset graph db name>`` so each dataset's nodes
-and edges live in their own namespace prefix.
+Graph analog of the vector adapter's TurbopufferDatasetDatabaseHandler, matching
+cognee's DatasetDatabaseHandlerInterface. With backend access control enabled,
+cognee calls create_dataset() to mint per-dataset connection info (persisted in
+the DatasetDatabase table) and delete_dataset() on teardown. Each dataset maps to
+its own namespace prefix (graph_database_name), so datasets are isolated at the
+TurboPuffer namespace level.
 """
 
-from typing import Any, Dict
+from typing import Optional
+from uuid import UUID
+
+from cognee.infrastructure.databases.dataset_database_handler import (
+    DatasetDatabaseHandlerInterface,
+)
+from cognee.infrastructure.databases.graph.config import get_graph_config
+from cognee.infrastructure.databases.graph.get_graph_engine import create_graph_engine
+from cognee.modules.users.models import DatasetDatabase, User
 
 
-class TurbopufferGraphDatasetDatabaseHandler:
-    async def create_dataset(self, dataset_id: Any) -> Dict[str, str]:
-        # Each dataset's graph lives under its own namespace prefix.
-        return {"graph_database_name": str(dataset_id)}
+class TurbopufferGraphDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
+    """Handler for per-dataset TurboPuffer graph namespaces."""
 
-    async def delete_dataset(self, dataset_id: Any, **kwargs: Any) -> None:
-        # Drop both namespaces for this dataset by delegating to the adapter's
-        # delete_graph(), bound to the dataset's namespace prefix.
-        from .turbopuffer_graph_adapter import TurbopufferGraphAdapter
+    @classmethod
+    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        graph_config = get_graph_config()
 
-        adapter = TurbopufferGraphAdapter(database_name=str(dataset_id), **kwargs)
-        await adapter.delete_graph()
+        if graph_config.graph_database_provider != "turbopuffer":
+            raise ValueError(
+                "TurbopufferGraphDatasetDatabaseHandler can only be used "
+                "with the turbopuffer graph database provider."
+            )
+
+        # The dataset id becomes the namespace prefix; namespaces are created
+        # lazily on first write, so there is nothing to provision here.
+        graph_db_name = f"{dataset_id}"
+
+        return {
+            "graph_database_provider": "turbopuffer",
+            "graph_database_url": graph_config.graph_database_url,
+            "graph_database_name": graph_db_name,
+            "graph_database_key": graph_config.graph_database_key,
+            "graph_dataset_database_handler": "turbopuffer",
+        }
+
+    @classmethod
+    async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
+        engine = create_graph_engine(
+            graph_database_provider="turbopuffer",
+            graph_file_path="",
+            graph_database_name=dataset_database.graph_database_name,
+            graph_database_url=dataset_database.graph_database_url,
+            graph_database_key=dataset_database.graph_database_key,
+        )
+        await engine.delete_graph()

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/TurbopufferGraphDatasetDatabaseHandler.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/TurbopufferGraphDatasetDatabaseHandler.py
@@ -1,0 +1,20 @@
+"""Per-dataset isolation handler for the TurboPuffer graph adapter — SKELETON.
+
+Graph analog of the vector adapter's TurbopufferDatasetDatabaseHandler. cognee
+persists the returned mapping in its DatasetDatabase table, then constructs the
+adapter with ``database_name=<dataset graph db name>`` so each dataset's nodes
+and edges live in their own namespace prefix.
+"""
+
+from typing import Any, Dict
+
+
+class TurbopufferGraphDatasetDatabaseHandler:
+    async def create_dataset(self, dataset_id: Any) -> Dict[str, str]:
+        # Each dataset's graph lives under its own namespace prefix.
+        return {"graph_database_name": str(dataset_id)}
+
+    async def delete_dataset(self, dataset_id: Any, **kwargs: Any) -> None:
+        # Drop both namespaces for this dataset by delegating to the adapter's
+        # delete_graph(); implemented alongside the adapter.
+        raise NotImplementedError

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/TurbopufferGraphDatasetDatabaseHandler.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/TurbopufferGraphDatasetDatabaseHandler.py
@@ -16,5 +16,8 @@ class TurbopufferGraphDatasetDatabaseHandler:
 
     async def delete_dataset(self, dataset_id: Any, **kwargs: Any) -> None:
         # Drop both namespaces for this dataset by delegating to the adapter's
-        # delete_graph(); implemented alongside the adapter.
-        raise NotImplementedError
+        # delete_graph(), bound to the dataset's namespace prefix.
+        from .turbopuffer_graph_adapter import TurbopufferGraphAdapter
+
+        adapter = TurbopufferGraphAdapter(database_name=str(dataset_id), **kwargs)
+        await adapter.delete_graph()

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/__init__.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/__init__.py
@@ -1,6 +1,6 @@
 """TurboPuffer graph adapter for cognee (community package)."""
 
-from .turbopuffer_graph_adapter import TurbopufferGraphAdapter
 from .register import register
+from .turbopuffer_graph_adapter import TurbopufferGraphAdapter
 
 __all__ = ["TurbopufferGraphAdapter", "register"]

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/__init__.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/__init__.py
@@ -1,0 +1,6 @@
+"""TurboPuffer graph adapter for cognee (community package)."""
+
+from .turbopuffer_graph_adapter import TurbopufferGraphAdapter
+from .register import register
+
+__all__ = ["TurbopufferGraphAdapter", "register"]

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/register.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/register.py
@@ -1,12 +1,20 @@
 """Register the TurboPuffer graph adapter with cognee under the "turbopuffer"
-graph provider name. Call ``register()`` before
+graph provider name, plus its per-dataset database handler (for backend access
+control / multi-tenant mode). Call ``register()`` before
 ``cognee.config.set_graph_database_provider("turbopuffer")``.
 """
 
+from cognee.infrastructure.databases.dataset_database_handler import (
+    use_dataset_database_handler,
+)
 from cognee.infrastructure.databases.graph.use_graph_adapter import use_graph_adapter
 
 from .turbopuffer_graph_adapter import TurbopufferGraphAdapter
+from .TurbopufferGraphDatasetDatabaseHandler import TurbopufferGraphDatasetDatabaseHandler
 
 
 def register() -> None:
     use_graph_adapter("turbopuffer", TurbopufferGraphAdapter)
+    use_dataset_database_handler(
+        "turbopuffer", TurbopufferGraphDatasetDatabaseHandler, "turbopuffer"
+    )

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/register.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/register.py
@@ -15,6 +15,10 @@ from .TurbopufferGraphDatasetDatabaseHandler import TurbopufferGraphDatasetDatab
 
 def register() -> None:
     use_graph_adapter("turbopuffer", TurbopufferGraphAdapter)
+    # Register under a graph-specific handler key so it does not collide with the
+    # TurboPuffer *vector* adapter, which registers its own handler under
+    # "turbopuffer". The third argument is the graph_database_provider this
+    # handler serves. Select it with GRAPH_DATASET_DATABASE_HANDLER=turbopuffer_graph.
     use_dataset_database_handler(
-        "turbopuffer", TurbopufferGraphDatasetDatabaseHandler, "turbopuffer"
+        "turbopuffer_graph", TurbopufferGraphDatasetDatabaseHandler, "turbopuffer"
     )

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/register.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/register.py
@@ -1,0 +1,12 @@
+"""Register the TurboPuffer graph adapter with cognee under the "turbopuffer"
+graph provider name. Call ``register()`` before
+``cognee.config.set_graph_database_provider("turbopuffer")``.
+"""
+
+from cognee.infrastructure.databases.graph.use_graph_adapter import use_graph_adapter
+
+from .turbopuffer_graph_adapter import TurbopufferGraphAdapter
+
+
+def register() -> None:
+    use_graph_adapter("turbopuffer", TurbopufferGraphAdapter)

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/serialization.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/serialization.py
@@ -1,0 +1,151 @@
+"""Serialization helpers for the TurboPuffer graph adapter.
+
+Ported from the TurboPuffer vector adapter so the graph adapter encodes node and
+edge attributes into TurboPuffer-compatible scalar/array values, infers a stable
+write schema, and respects the 4096-byte filterable-attribute limit.
+"""
+
+from datetime import datetime
+from typing import List, Union, get_args, get_origin
+from uuid import UUID
+
+# TurboPuffer filterable attribute size limit is 4096 bytes. Larger string
+# attributes are truncated so writes do not get rejected.
+_MAX_ATTR_BYTES = 4096
+
+
+def _serialize_value(value):
+    """Recursively serialize complex types to turbopuffer-compatible values."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    elif isinstance(value, UUID):
+        return str(value)
+    elif isinstance(value, dict):
+        return str({k: _serialize_value(v) for k, v in value.items()})
+    elif isinstance(value, list):
+        # Keep lists as native arrays for ContainsAny filtering support.
+        serialized = [_serialize_value(v) for v in value]
+        # Only keep as list if all elements are strings.
+        if all(isinstance(v, str) for v in serialized):
+            return serialized
+        return str(serialized)
+    return value
+
+
+def _truncate_large_values(payload: dict) -> dict:
+    """Truncate string values exceeding turbopuffer's filterable attribute limit."""
+    result = {}
+    for key, value in payload.items():
+        if isinstance(value, str) and len(value.encode("utf-8")) > _MAX_ATTR_BYTES:
+            encoded = value.encode("utf-8")[: _MAX_ATTR_BYTES - 3]
+            result[key] = encoded.decode("utf-8", errors="ignore") + "..."
+        else:
+            result[key] = value
+    return result
+
+
+def _strip_optional(annotation):
+    origin = get_origin(annotation)
+    if origin is Union:
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _annotation_to_turbopuffer_type(annotation):
+    annotation = _strip_optional(annotation)
+    origin = get_origin(annotation)
+
+    if origin in (list, List):
+        args = get_args(annotation)
+        if len(args) != 1:
+            return None
+        item_type = _strip_optional(args[0])
+        if item_type is str:
+            return "[]string"
+        if item_type is int:
+            return "[]int"
+        if item_type is float:
+            return "[]float"
+        if item_type is bool:
+            return "[]bool"
+        if item_type is UUID:
+            return "[]uuid"
+        if item_type is datetime:
+            return "[]datetime"
+        return None
+
+    if annotation is bool:
+        return "bool"
+    if annotation is int:
+        return "int"
+    if annotation is float:
+        return "float"
+    if annotation is str:
+        return "string"
+    if annotation is UUID:
+        return "uuid"
+    if annotation is datetime:
+        return "datetime"
+
+    return None
+
+
+def _infer_turbopuffer_attribute_type(value):
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        if all(isinstance(item, str) for item in value):
+            return "[]string"
+        if all(isinstance(item, bool) for item in value):
+            return "[]bool"
+        if all(isinstance(item, int) and not isinstance(item, bool) for item in value):
+            return "[]int"
+        if all(isinstance(item, (int, float)) and not isinstance(item, bool) for item in value):
+            return "[]float"
+    return None
+
+
+def _merge_turbopuffer_types(existing_type: str, new_type: str) -> str:
+    if existing_type == new_type:
+        return existing_type
+
+    # Promote numeric types to avoid int schemas rejecting float values later.
+    if {existing_type, new_type} == {"int", "float"}:
+        return "float"
+    if {existing_type, new_type} == {"[]int", "[]float"}:
+        return "[]float"
+
+    # Keep existing type if no safe merge is known.
+    return existing_type
+
+
+def _build_row_schema(rows: list[dict]) -> dict:
+    """Infer a TurboPuffer write schema from row values alone.
+
+    The graph adapter writes plain dict rows (not DataPoint instances), so the
+    schema is inferred from the actual values, widening numeric types when a
+    field appears with mixed int/float values across rows.
+    """
+    schema: dict = {}
+    for row in rows:
+        for key, value in row.items():
+            if key in ("id", "vector"):
+                continue
+            if value is None:
+                continue
+            inferred_type = _infer_turbopuffer_attribute_type(value)
+            if inferred_type is None:
+                continue
+            if key not in schema:
+                schema[key] = inferred_type
+            else:
+                schema[key] = _merge_turbopuffer_types(schema[key], inferred_type)
+    return schema

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/serialization.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/serialization.py
@@ -32,11 +32,21 @@ def _serialize_value(value):
     return value
 
 
-def _truncate_large_values(payload: dict) -> dict:
-    """Truncate string values exceeding turbopuffer's filterable attribute limit."""
+def _truncate_large_values(payload: dict, skip_keys=()) -> dict:
+    """Truncate string values exceeding turbopuffer's filterable attribute limit.
+
+    Keys in ``skip_keys`` are left intact — used for non-filterable blob columns
+    (e.g. the JSON ``properties`` payload) which must not be clamped to 4096 bytes
+    or their content (e.g. a DocumentChunk's text) would be corrupted.
+    """
+    skip = set(skip_keys)
     result = {}
     for key, value in payload.items():
-        if isinstance(value, str) and len(value.encode("utf-8")) > _MAX_ATTR_BYTES:
+        if (
+            key not in skip
+            and isinstance(value, str)
+            and len(value.encode("utf-8")) > _MAX_ATTR_BYTES
+        ):
             encoded = value.encode("utf-8")[: _MAX_ATTR_BYTES - 3]
             result[key] = encoded.decode("utf-8", errors="ignore") + "..."
         else:
@@ -127,17 +137,26 @@ def _merge_turbopuffer_types(existing_type: str, new_type: str) -> str:
     return existing_type
 
 
-def _build_row_schema(rows: list[dict]) -> dict:
+def _build_row_schema(rows: list[dict], non_filterable=()) -> dict:
     """Infer a TurboPuffer write schema from row values alone.
 
     The graph adapter writes plain dict rows (not DataPoint instances), so the
     schema is inferred from the actual values, widening numeric types when a
     field appears with mixed int/float values across rows.
+
+    Keys in ``non_filterable`` are declared as non-filterable string columns so
+    they are exempt from the 4096-byte filterable-attribute limit and can hold
+    large blobs (e.g. the JSON ``properties`` payload) without truncation.
     """
+    non_filterable = set(non_filterable)
     schema: dict = {}
     for row in rows:
         for key, value in row.items():
             if key in ("id", "vector"):
+                continue
+            if key in non_filterable:
+                # Non-filterable string blob: no 4096-byte limit, never filtered.
+                schema[key] = {"type": "string", "filterable": False}
                 continue
             if value is None:
                 continue

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
@@ -280,7 +280,8 @@ class TurbopufferGraphAdapter(GraphDBInterface):
             "belongs_to_set": belongs_to_set,
             "properties": self._serialize_properties(extra),
         }
-        return _truncate_large_values(row)
+        # Never truncate the properties blob (non-filterable; holds e.g. chunk text).
+        return _truncate_large_values(row, skip_keys={"properties"})
 
     async def add_nodes(self, nodes: Union[List[Tuple[str, Dict]], List[DataPoint]]) -> None:
         if not nodes:
@@ -290,7 +291,7 @@ class TurbopufferGraphAdapter(GraphDBInterface):
         # Deduplicate by id (last wins) so a single write batch never conflicts.
         rows = list({r["id"]: r for r in rows}.values())
 
-        schema = _build_row_schema(rows)
+        schema = _build_row_schema(rows, non_filterable={"properties"})
         await asyncio.to_thread(
             self._node_namespace().write,
             upsert_rows=rows,
@@ -347,12 +348,12 @@ class TurbopufferGraphAdapter(GraphDBInterface):
                 "target_type": tgt_type or "",
                 "properties": self._serialize_properties(raw_props),
             }
-            rows.append(_truncate_large_values(row))
+            rows.append(_truncate_large_values(row, skip_keys={"properties"}))
 
         # Deduplicate by edge id (last wins) within the batch.
         rows = list({r["id"]: r for r in rows}.values())
 
-        schema = _build_row_schema(rows)
+        schema = _build_row_schema(rows, non_filterable={"properties"})
         await asyncio.to_thread(
             self._edge_namespace().write,
             upsert_rows=rows,

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
@@ -125,6 +125,7 @@ class TurbopufferGraphAdapter(GraphDBInterface):
             "id": str(row.id),
             "name": extra.get("name", ""),
             "type": extra.get("type", ""),
+            "belongs_to_set": list(extra.get("belongs_to_set") or []),
         }
         node.update(cls._parse_properties(extra.get("properties")))
         return node
@@ -390,6 +391,85 @@ class TurbopufferGraphAdapter(GraphDBInterface):
                 if not self._is_namespace_missing(error):
                     raise
 
+    async def remove_belongs_to_set_tags(
+        self,
+        tags: List[str],
+        node_ids: Optional[List[str]] = None,
+    ) -> None:
+        """Strip the given tags from node `belongs_to_set` arrays AND delete the
+        stale `belongs_to_set` edges to surviving NodeSet nodes named in `tags`.
+
+        Mirrors the Neo4j adapter so a deleted NodeSet/dataset leaves no stale
+        membership behind. Scoped to `node_ids` when provided."""
+        if not tags:
+            return None
+        if node_ids is not None and not node_ids:
+            return None
+        tagset = {str(t) for t in tags}
+
+        # 1) Candidate nodes carrying any of the tags (scoped to node_ids if given).
+        if node_ids is not None:
+            candidates = await self._query_by_ids(
+                self._node_namespace(), [str(n) for n in node_ids]
+            )
+        else:
+            candidates = await self._query_all(
+                self._node_namespace(),
+                filters=("belongs_to_set", "ContainsAny", list(tagset)),
+            )
+
+        # 2) Strip tags from belongs_to_set and re-upsert only the changed nodes.
+        updated_rows = []
+        for row in candidates:
+            extra = row.model_extra or {}
+            current = extra.get("belongs_to_set") or []
+            if not isinstance(current, list):
+                current = [current]
+            remaining = [str(t) for t in current if str(t) not in tagset]
+            if len(remaining) == len(current):
+                continue  # this node didn't carry any of the tags
+            updated_rows.append(
+                {
+                    "id": str(row.id),
+                    "name": extra.get("name", "") or "",
+                    "type": extra.get("type", "") or "",
+                    "belongs_to_set": remaining,
+                    "properties": extra.get("properties", "") or "{}",
+                }
+            )
+        if updated_rows:
+            schema = _build_row_schema(updated_rows, non_filterable={"properties"})
+            await asyncio.to_thread(
+                self._node_namespace().write, upsert_rows=updated_rows, schema=schema
+            )
+
+        # 3) Delete stale belongs_to_set edges to surviving NodeSet nodes named in tags.
+        nodeset_rows = await self._query_all(
+            self._node_namespace(),
+            filters=("And", (("type", "Eq", "NodeSet"), ("name", "In", list(tagset)))),
+        )
+        nodeset_ids = [str(r.id) for r in nodeset_rows]
+        if not nodeset_ids:
+            return None
+        edge_rows = await self._query_all(
+            self._edge_namespace(),
+            filters=(
+                "And",
+                (
+                    ("relationship_name", "Eq", "belongs_to_set"),
+                    ("target_id", "In", nodeset_ids),
+                ),
+            ),
+        )
+        scope = {str(n) for n in node_ids} if node_ids is not None else None
+        edge_ids = [
+            str(r.id)
+            for r in edge_rows
+            if scope is None or str((r.model_extra or {}).get("source_id")) in scope
+        ]
+        await self._delete_ids(self._edge_namespace(), edge_ids)
+        return None
+
     # --- point reads -------------------------------------------------------
 
     async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
@@ -435,36 +515,65 @@ class TurbopufferGraphAdapter(GraphDBInterface):
             )
         return edges
 
+    async def _hydrate_node_map(self, ids) -> Dict[str, Dict[str, Any]]:
+        """Fetch full node payloads for the given ids -> {id: merged node dict}."""
+        unique = [str(i) for i in dict.fromkeys(str(i) for i in ids)]
+        if not unique:
+            return {}
+        node_rows = await self._query_by_ids(self._node_namespace(), unique)
+        return {str(row.id): self._node_dict_from_row(row) for row in node_rows}
+
     async def get_neighbors(self, node_id: str) -> List[Dict[str, Any]]:
         nid = str(node_id)
         rows = await self._edges_touching([nid])
-        neighbors: Dict[str, Dict[str, Any]] = {}
+
+        # Collect each neighbor id (dedup, preserve order) + a denormalized fallback.
+        ordered: List[str] = []
+        seen = set()
+        fallback: Dict[str, Tuple[Any, Any]] = {}
         for row in rows:
             extra = row.model_extra or {}
             source_id = str(extra.get("source_id"))
             target_id = str(extra.get("target_id"))
             if source_id == nid:
-                neighbors[target_id] = self._node_dict_from_endpoint(
-                    target_id, extra.get("target_name"), extra.get("target_type")
-                )
+                other, name, type_ = target_id, extra.get("target_name"), extra.get("target_type")
             else:
-                neighbors[source_id] = self._node_dict_from_endpoint(
-                    source_id, extra.get("source_name"), extra.get("source_type")
-                )
-        return list(neighbors.values())
+                other, name, type_ = source_id, extra.get("source_name"), extra.get("source_type")
+            fallback.setdefault(other, (name, type_))
+            if other not in seen:
+                seen.add(other)
+                ordered.append(other)
+
+        # Hydrate full node payloads; fall back to denormalized edge fields if a
+        # node row is missing.
+        full = await self._hydrate_node_map(ordered)
+        return [
+            full.get(i) or self._node_dict_from_endpoint(i, *fallback.get(i, ("", "")))
+            for i in ordered
+        ]
 
     async def get_connections(
         self, node_id: Union[str, Any]
     ) -> List[Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]]:
         rows = await self._edges_touching([str(node_id)])
+
+        endpoint_ids = set()
+        for row in rows:
+            extra = row.model_extra or {}
+            endpoint_ids.add(str(extra.get("source_id")))
+            endpoint_ids.add(str(extra.get("target_id")))
+        full = await self._hydrate_node_map(endpoint_ids)
+
         connections = []
         for row in rows:
             extra = row.model_extra or {}
-            src = self._node_dict_from_endpoint(
-                extra.get("source_id"), extra.get("source_name"), extra.get("source_type")
+            source_id = str(extra.get("source_id"))
+            target_id = str(extra.get("target_id"))
+            src = full.get(source_id) or self._node_dict_from_endpoint(
+                source_id, extra.get("source_name"), extra.get("source_type")
             )
-            tgt = self._node_dict_from_endpoint(
-                extra.get("target_id"), extra.get("target_name"), extra.get("target_type")
+            tgt = full.get(target_id) or self._node_dict_from_endpoint(
+                target_id, extra.get("target_name"), extra.get("target_type")
             )
             edge = {"relationship_name": extra.get("relationship_name")}
             edge.update(self._parse_properties(extra.get("properties")))
@@ -704,14 +813,12 @@ class TurbopufferGraphAdapter(GraphDBInterface):
         raise NotImplementedError("TurboPuffer has no query language; Cypher is unsupported.")
 
     async def get_triplets_batch(self, offset: int, limit: int) -> List[Dict[str, Any]]:
-        if offset != 0:
-            raise NotImplementedError(
-                "TurboPuffer is cursor-paginated, not offset-paginated; nonzero offset "
-                "is unsupported in v1."
-            )
-
+        # Edges are cursor-scanned in deterministic id order, so offset/limit
+        # slicing is stable across paginated calls (cognee's triplet-embedding
+        # memify paginates by increasing offset). Cost is O(offset + limit).
+        offset = max(offset, 0)
         edge_rows = await self._query_all(self._edge_namespace())
-        edge_rows = edge_rows[: max(limit, 0)]
+        edge_rows = edge_rows[offset : offset + max(limit, 0)] if limit >= 0 else edge_rows[offset:]
         if not edge_rows:
             return []
 

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
@@ -25,6 +25,7 @@ All TurboPuffer SDK calls are synchronous; they are wrapped in
 
 import asyncio
 import json
+import uuid
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import turbopuffer
@@ -42,6 +43,12 @@ logger = get_logger("TurbopufferGraphAdapter")
 
 # TurboPuffer caps a single query at 10,000 returned rows; we page/chunk below it.
 _MAX_QUERY_ROWS = 10000
+
+# Fixed namespace for deterministic edge ids. TurboPuffer caps string ids at 64
+# bytes; "{source}__{rel}__{target}" with UUID endpoints (83+ bytes) overflows it,
+# so the composite key is hashed into a uuid5 (36 bytes). source_id, target_id and
+# relationship_name are stored as attributes, so nothing ever parses the edge id.
+_EDGE_ID_NAMESPACE = uuid.UUID("8f6e0a1c-7b2d-5e44-9a3f-1c2d3e4f5a6b")
 
 # Core node attributes stored as first-class TurboPuffer columns. Everything else
 # is folded into the JSON ``properties`` attribute.
@@ -91,7 +98,8 @@ class TurbopufferGraphAdapter(GraphDBInterface):
 
     @staticmethod
     def _edge_id(source_id: str, relationship_name: str, target_id: str) -> str:
-        return f"{source_id}__{relationship_name}__{target_id}"
+        # Deterministic, fixed-length (<=64 byte) id; see _EDGE_ID_NAMESPACE.
+        return str(uuid.uuid5(_EDGE_ID_NAMESPACE, f"{source_id}__{relationship_name}__{target_id}"))
 
     @staticmethod
     def _serialize_properties(props: Optional[Dict[str, Any]]) -> str:

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
@@ -126,6 +126,22 @@ class TurbopufferGraphAdapter(GraphDBInterface):
         """Build a node dict from denormalized endpoint identity on an edge row."""
         return {"id": str(node_id), "name": name or "", "type": type_ or ""}
 
+    @staticmethod
+    def _is_namespace_missing(error: Exception) -> bool:
+        """TurboPuffer creates namespaces lazily on first write, so reads/deletes
+        against a not-yet-written namespace return 404. We treat that as empty."""
+        msg = str(error).lower()
+        return "404" in msg or "not found" in msg or "not_found" in msg
+
+    async def _safe_query(self, namespace, **kwargs):
+        """Run namespace.query, returning None if the namespace doesn't exist yet."""
+        try:
+            return await asyncio.to_thread(namespace.query, **kwargs)
+        except Exception as error:
+            if self._is_namespace_missing(error):
+                return None
+            raise
+
     async def _query_all(self, namespace, filters=None) -> List[Any]:
         """Cursor-scan a namespace deterministically (rank_by id asc), returning rows."""
         rows: List[Any] = []
@@ -147,7 +163,9 @@ class TurbopufferGraphAdapter(GraphDBInterface):
             if effective is not None:
                 kwargs["filters"] = effective
 
-            response = await asyncio.to_thread(namespace.query, **kwargs)
+            response = await self._safe_query(namespace, **kwargs)
+            if response is None:  # namespace not created yet -> empty
+                break
             page = response.rows or []
             rows.extend(page)
             if len(page) < _MAX_QUERY_ROWS:
@@ -163,12 +181,14 @@ class TurbopufferGraphAdapter(GraphDBInterface):
             chunk = unique_ids[start : start + _MAX_QUERY_ROWS]
             if not chunk:
                 continue
-            response = await asyncio.to_thread(
-                namespace.query,
+            response = await self._safe_query(
+                namespace,
                 filters=("id", "In", chunk),
                 top_k=len(chunk),
                 include_attributes=True,
             )
+            if response is None:  # namespace not created yet -> no matches
+                continue
             rows.extend(response.rows or [])
         return rows
 
@@ -352,8 +372,14 @@ class TurbopufferGraphAdapter(GraphDBInterface):
     async def _delete_ids(self, namespace, ids: List[str]) -> None:
         for start in range(0, len(ids), _MAX_QUERY_ROWS):
             chunk = ids[start : start + _MAX_QUERY_ROWS]
-            if chunk:
+            if not chunk:
+                continue
+            try:
                 await asyncio.to_thread(namespace.write, deletes=chunk)
+            except Exception as error:
+                # Deleting from a namespace that was never written is a no-op.
+                if not self._is_namespace_missing(error):
+                    raise
 
     # --- point reads -------------------------------------------------------
 

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
@@ -1,12 +1,9 @@
-"""TurboPuffer graph adapter — v1 SKELETON (test-driven).
+"""TurboPuffer graph adapter — v1.
 
-This is the red-phase skeleton: it satisfies the GraphDBInterface contract well
-enough to be instantiated and import-checked, and it pins the v1 boundaries that
-the tests assert (no multi-hop BFS, no Cypher, no random-offset pagination).
-
-Every data method raises NotImplementedError until implemented. The design that
-each method will follow is documented inline so implementation is a fill-in-the-
-blanks exercise against the test suite.
+Implements the GraphDBInterface contract on top of TurboPuffer's namespace API.
+TurboPuffer is a vector/document store with no graph traversal or query language,
+so this adapter models the graph as two document namespaces per dataset and
+performs all traversal client-side with single-hop edge queries.
 
 Storage model (per dataset, namespace-prefixed by ``database_name``):
   - ``{database_name}_graph_node``: one doc per node. Attributes: id, name, type,
@@ -16,12 +13,39 @@ Storage model (per dataset, namespace-prefixed by ``database_name``):
     endpoint identity source_name/source_type/target_name/target_type, and
     properties (json string). The endpoint denormalization makes single-hop reads
     (get_neighbors / get_connections / get_edges) one query with zero hydration.
+
+Resolved SDK unknowns (TurboPuffer SDK 2.3.0):
+  - Vectorless writes ARE allowed: RowParam.vector is optional, so node/edge docs
+    are written WITHOUT any vector at all.
+  - Row-level delete signature is ``ns.write(deletes=[id1, id2, ...])``.
+
+All TurboPuffer SDK calls are synchronous; they are wrapped in
+``asyncio.to_thread`` exactly like the vector adapter does.
 """
 
+import asyncio
+import json
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
+import turbopuffer
 from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface
 from cognee.infrastructure.engine import DataPoint
+from cognee.modules.storage.utils import JSONEncoder
+from cognee.shared.logging_utils import get_logger
+
+from .serialization import (
+    _build_row_schema,
+    _truncate_large_values,
+)
+
+logger = get_logger("TurbopufferGraphAdapter")
+
+# TurboPuffer caps a single query at 10,000 returned rows; we page/chunk below it.
+_MAX_QUERY_ROWS = 10000
+
+# Core node attributes stored as first-class TurboPuffer columns. Everything else
+# is folded into the JSON ``properties`` attribute.
+_NODE_CORE_KEYS = {"id", "name", "type"}
 
 
 class TurbopufferGraphAdapter(GraphDBInterface):
@@ -46,18 +70,127 @@ class TurbopufferGraphAdapter(GraphDBInterface):
 
     # --- helpers -----------------------------------------------------------
 
+    def _get_client(self) -> turbopuffer.Turbopuffer:
+        if self._client is None:
+            kwargs: Dict[str, Any] = {}
+            if self.api_key:
+                kwargs["api_key"] = self.api_key
+            if self.region:
+                kwargs["region"] = self.region
+            self._client = turbopuffer.Turbopuffer(**kwargs)
+        return self._client
+
     def _namespace_name(self, collection_name: str) -> str:
         return f"{self.database_name}_{collection_name}"
 
     def _node_namespace(self):
-        raise NotImplementedError
+        return self._get_client().namespace(self._namespace_name("graph_node"))
 
     def _edge_namespace(self):
-        raise NotImplementedError
+        return self._get_client().namespace(self._namespace_name("graph_edge"))
 
     @staticmethod
     def _edge_id(source_id: str, relationship_name: str, target_id: str) -> str:
         return f"{source_id}__{relationship_name}__{target_id}"
+
+    @staticmethod
+    def _serialize_properties(props: Optional[Dict[str, Any]]) -> str:
+        return json.dumps(props or {}, cls=JSONEncoder)
+
+    @staticmethod
+    def _parse_properties(raw: Any) -> Dict[str, Any]:
+        if not raw:
+            return {}
+        if isinstance(raw, dict):
+            return raw
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except (TypeError, ValueError):
+            return {}
+
+    @classmethod
+    def _node_dict_from_row(cls, row) -> Dict[str, Any]:
+        """Build a merged node dict ({id, name, type, **properties}) from a row."""
+        extra = row.model_extra or {}
+        node = {
+            "id": str(row.id),
+            "name": extra.get("name", ""),
+            "type": extra.get("type", ""),
+        }
+        node.update(cls._parse_properties(extra.get("properties")))
+        return node
+
+    @staticmethod
+    def _node_dict_from_endpoint(node_id: Any, name: Any, type_: Any) -> Dict[str, Any]:
+        """Build a node dict from denormalized endpoint identity on an edge row."""
+        return {"id": str(node_id), "name": name or "", "type": type_ or ""}
+
+    async def _query_all(self, namespace, filters=None) -> List[Any]:
+        """Cursor-scan a namespace deterministically (rank_by id asc), returning rows."""
+        rows: List[Any] = []
+        cursor: Optional[str] = None
+        while True:
+            page_filter = ("id", "Gt", cursor) if cursor is not None else None
+            if filters is not None and page_filter is not None:
+                effective = ("And", (filters, page_filter))
+            elif filters is not None:
+                effective = filters
+            else:
+                effective = page_filter
+
+            kwargs: Dict[str, Any] = {
+                "rank_by": ("id", "asc"),
+                "top_k": _MAX_QUERY_ROWS,
+                "include_attributes": True,
+            }
+            if effective is not None:
+                kwargs["filters"] = effective
+
+            response = await asyncio.to_thread(namespace.query, **kwargs)
+            page = response.rows or []
+            rows.extend(page)
+            if len(page) < _MAX_QUERY_ROWS:
+                break
+            cursor = str(page[-1].id)
+        return rows
+
+    async def _query_by_ids(self, namespace, ids: List[str]) -> List[Any]:
+        """Fetch rows for the given ids, chunked under the per-query row ceiling."""
+        rows: List[Any] = []
+        unique_ids = list(dict.fromkeys(str(i) for i in ids))
+        for start in range(0, len(unique_ids), _MAX_QUERY_ROWS):
+            chunk = unique_ids[start : start + _MAX_QUERY_ROWS]
+            if not chunk:
+                continue
+            response = await asyncio.to_thread(
+                namespace.query,
+                filters=("id", "In", chunk),
+                top_k=len(chunk),
+                include_attributes=True,
+            )
+            rows.extend(response.rows or [])
+        return rows
+
+    async def _edges_touching(self, node_ids: List[str]) -> List[Any]:
+        """All edge rows where source_id or target_id is in node_ids.
+
+        Chunks the id set so the ``In`` filter never exceeds the per-query
+        ceiling (e.g. deleting >10k nodes at once)."""
+        ids = list(dict.fromkeys(str(i) for i in node_ids))
+        if not ids:
+            return []
+        rows: List[Any] = []
+        seen_edge_ids: set = set()
+        for start in range(0, len(ids), _MAX_QUERY_ROWS):
+            chunk = ids[start : start + _MAX_QUERY_ROWS]
+            filters = ("Or", (("source_id", "In", chunk), ("target_id", "In", chunk)))
+            for row in await self._query_all(self._edge_namespace(), filters=filters):
+                # An edge between two in-set nodes can surface in two chunks; dedup.
+                if str(row.id) not in seen_edge_ids:
+                    seen_edge_ids.add(str(row.id))
+                    rows.append(row)
+        return rows
 
     # --- lifecycle ---------------------------------------------------------
 
@@ -66,23 +199,75 @@ class TurbopufferGraphAdapter(GraphDBInterface):
         return None
 
     async def is_empty(self) -> bool:
-        # query(node_ns, rank_by=("id","asc"), top_k=1) -> rows empty?
-        raise NotImplementedError
+        ns = self._node_namespace()
+        try:
+            response = await asyncio.to_thread(
+                ns.query,
+                rank_by=("id", "asc"),
+                top_k=1,
+            )
+        except Exception:
+            # Namespace does not exist yet -> empty graph.
+            return True
+        return not (response.rows or [])
 
     async def delete_graph(self) -> None:
-        # node_ns.delete_all(); edge_ns.delete_all()
-        raise NotImplementedError
+        for ns in (self._node_namespace(), self._edge_namespace()):
+            try:
+                await asyncio.to_thread(ns.delete_all)
+            except Exception as error:
+                # delete_all on a non-existent namespace is a no-op for us.
+                logger.debug("delete_all on %s ignored: %s", ns.id, error)
 
     # --- writes ------------------------------------------------------------
 
     async def add_node(
         self, node: Union[DataPoint, str], properties: Optional[Dict[str, Any]] = None
     ) -> None:
-        raise NotImplementedError
+        if isinstance(node, str):
+            props = dict(properties or {})
+            props.setdefault("id", node)
+            await self.add_nodes([(node, props)])
+        else:
+            await self.add_nodes([node])
+
+    def _node_row(self, node: Union[Tuple[str, Dict], DataPoint]) -> Dict[str, Any]:
+        if isinstance(node, tuple):
+            props = {**(node[1] or {}), "id": node[0]}
+        elif hasattr(node, "model_dump"):
+            props = node.model_dump()
+        else:
+            props = vars(node)
+
+        extra = {k: v for k, v in props.items() if k not in _NODE_CORE_KEYS}
+        belongs_to_set = extra.pop("belongs_to_set", None) or []
+        if not isinstance(belongs_to_set, list):
+            belongs_to_set = [belongs_to_set]
+        belongs_to_set = [str(v) for v in belongs_to_set]
+
+        row = {
+            "id": str(props.get("id", "")),
+            "name": str(props.get("name", "") or ""),
+            "type": str(props.get("type", "") or ""),
+            "belongs_to_set": belongs_to_set,
+            "properties": self._serialize_properties(extra),
+        }
+        return _truncate_large_values(row)
 
     async def add_nodes(self, nodes: Union[List[Tuple[str, Dict]], List[DataPoint]]) -> None:
-        # node_ns.write(upsert_rows=[serialize(n) for n in nodes], schema=...)
-        raise NotImplementedError
+        if not nodes:
+            return
+
+        rows = [self._node_row(node) for node in nodes]
+        # Deduplicate by id (last wins) so a single write batch never conflicts.
+        rows = list({r["id"]: r for r in rows}.values())
+
+        schema = _build_row_schema(rows)
+        await asyncio.to_thread(
+            self._node_namespace().write,
+            upsert_rows=rows,
+            schema=schema,
+        )
 
     async def add_edge(
         self,
@@ -91,57 +276,165 @@ class TurbopufferGraphAdapter(GraphDBInterface):
         relationship_name: str,
         properties: Optional[Dict[str, Any]] = None,
     ) -> None:
-        raise NotImplementedError
+        await self.add_edges(
+            [(str(source_id), str(target_id), relationship_name, properties or {})]
+        )
 
     async def add_edges(
         self, edges: Union[List, List[Tuple[str, str, str, Optional[Dict[str, Any]]]]]
     ) -> None:
-        # Denormalize endpoint name/type onto each edge doc (look up from the
-        # node batch, or via get_nodes when not co-present), then
-        # edge_ns.write(upsert_rows=...).
-        raise NotImplementedError
+        if not edges:
+            return
+
+        # Collect endpoint ids so we can denormalize name/type onto each edge doc.
+        endpoint_ids = set()
+        for edge in edges:
+            endpoint_ids.add(str(edge[0]))
+            endpoint_ids.add(str(edge[1]))
+
+        node_rows = await self._query_by_ids(self._node_namespace(), list(endpoint_ids))
+        identity: Dict[str, Tuple[str, str]] = {}
+        for row in node_rows:
+            extra = row.model_extra or {}
+            identity[str(row.id)] = (extra.get("name", ""), extra.get("type", ""))
+
+        rows = []
+        for edge in edges:
+            source_id = str(edge[0])
+            target_id = str(edge[1])
+            relationship_name = str(edge[2])
+            raw_props = edge[3] if len(edge) > 3 and edge[3] else {}
+
+            src_name, src_type = identity.get(source_id, ("", ""))
+            tgt_name, tgt_type = identity.get(target_id, ("", ""))
+
+            row = {
+                "id": self._edge_id(source_id, relationship_name, target_id),
+                "source_id": source_id,
+                "target_id": target_id,
+                "relationship_name": relationship_name,
+                "source_name": src_name or "",
+                "source_type": src_type or "",
+                "target_name": tgt_name or "",
+                "target_type": tgt_type or "",
+                "properties": self._serialize_properties(raw_props),
+            }
+            rows.append(_truncate_large_values(row))
+
+        # Deduplicate by edge id (last wins) within the batch.
+        rows = list({r["id"]: r for r in rows}.values())
+
+        schema = _build_row_schema(rows)
+        await asyncio.to_thread(
+            self._edge_namespace().write,
+            upsert_rows=rows,
+            schema=schema,
+        )
 
     # --- deletes -----------------------------------------------------------
 
     async def delete_node(self, node_id: str) -> None:
-        raise NotImplementedError
+        await self.delete_nodes([node_id])
 
     async def delete_nodes(self, node_ids: List[str]) -> None:
-        # node_ns.write(deletes=node_ids); then query touching edges
-        # ("Or", source_id In ids, target_id In ids) and edge_ns.write(deletes=...).
-        raise NotImplementedError
+        if not node_ids:
+            return
+        ids = [str(i) for i in node_ids]
+
+        # Delete the node docs (chunked under the per-request ceiling).
+        await self._delete_ids(self._node_namespace(), ids)
+
+        # Manual cascade: delete every edge touching any deleted node.
+        touching = await self._edges_touching(ids)
+        edge_ids = [str(row.id) for row in touching]
+        await self._delete_ids(self._edge_namespace(), edge_ids)
+
+    async def _delete_ids(self, namespace, ids: List[str]) -> None:
+        for start in range(0, len(ids), _MAX_QUERY_ROWS):
+            chunk = ids[start : start + _MAX_QUERY_ROWS]
+            if chunk:
+                await asyncio.to_thread(namespace.write, deletes=chunk)
 
     # --- point reads -------------------------------------------------------
 
     async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
-        raise NotImplementedError
+        results = await self.get_nodes([node_id])
+        return results[0] if results else None
 
     async def get_nodes(self, node_ids: List[str]) -> List[Dict[str, Any]]:
-        # node_ns.query(filters=("id","In",node_ids), include_attributes=True),
-        # chunked to <=10000 ids per query.
-        raise NotImplementedError
+        if not node_ids:
+            return []
+        rows = await self._query_by_ids(self._node_namespace(), node_ids)
+        return [self._node_dict_from_row(row) for row in rows]
 
     async def has_edge(self, source_id: str, target_id: str, relationship_name: str) -> bool:
-        raise NotImplementedError
+        result = await self.has_edges([(str(source_id), str(target_id), relationship_name)])
+        return len(result) > 0
 
     async def has_edges(self, edges: List) -> List:
-        # edge_ns.query(filters=("id","In",[edge_id(...) ...])) -> intersect.
-        raise NotImplementedError
+        if not edges:
+            return []
+        wanted = [(str(s), str(t), str(r)) for (s, t, r) in edges]
+        edge_ids = [self._edge_id(s, r, t) for (s, t, r) in wanted]
+        rows = await self._query_by_ids(self._edge_namespace(), edge_ids)
+        present = {str(row.id) for row in rows}
+        return [
+            (s, t, r) for (s, t, r), eid in zip(wanted, edge_ids, strict=False) if eid in present
+        ]
 
     # --- single-hop reads --------------------------------------------------
 
     async def get_edges(self, node_id: str) -> List:
-        # edge_ns.query(("Or", source_id Eq, target_id Eq), include_attributes=True)
-        raise NotImplementedError
+        # Returns EdgeData tuples: (source_id, target_id, relationship_name, properties).
+        rows = await self._edges_touching([str(node_id)])
+        edges = []
+        for row in rows:
+            extra = row.model_extra or {}
+            edges.append(
+                (
+                    str(extra.get("source_id")),
+                    str(extra.get("target_id")),
+                    extra.get("relationship_name"),
+                    self._parse_properties(extra.get("properties")),
+                )
+            )
+        return edges
 
     async def get_neighbors(self, node_id: str) -> List[Dict[str, Any]]:
-        raise NotImplementedError
+        nid = str(node_id)
+        rows = await self._edges_touching([nid])
+        neighbors: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            extra = row.model_extra or {}
+            source_id = str(extra.get("source_id"))
+            target_id = str(extra.get("target_id"))
+            if source_id == nid:
+                neighbors[target_id] = self._node_dict_from_endpoint(
+                    target_id, extra.get("target_name"), extra.get("target_type")
+                )
+            else:
+                neighbors[source_id] = self._node_dict_from_endpoint(
+                    source_id, extra.get("source_name"), extra.get("source_type")
+                )
+        return list(neighbors.values())
 
     async def get_connections(
         self, node_id: Union[str, Any]
     ) -> List[Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]]:
-        # One edge query; assemble (source, rel, target) from denormalized attrs.
-        raise NotImplementedError
+        rows = await self._edges_touching([str(node_id)])
+        connections = []
+        for row in rows:
+            extra = row.model_extra or {}
+            src = self._node_dict_from_endpoint(
+                extra.get("source_id"), extra.get("source_name"), extra.get("source_type")
+            )
+            tgt = self._node_dict_from_endpoint(
+                extra.get("target_id"), extra.get("target_name"), extra.get("target_type")
+            )
+            edge = {"relationship_name": extra.get("relationship_name")}
+            edge.update(self._parse_properties(extra.get("properties")))
+            connections.append((src, edge, tgt))
+        return connections
 
     async def get_neighborhood(
         self,
@@ -154,30 +447,221 @@ class TurbopufferGraphAdapter(GraphDBInterface):
                 "TurboPuffer graph adapter v1 supports single-hop neighborhood only "
                 "(depth=1); multi-hop BFS is not implemented."
             )
-        # depth==1: one edge query around seeds + node hydration.
-        raise NotImplementedError
+        if not node_ids:
+            return [], []
+
+        seeds = [str(i) for i in node_ids]
+        edge_rows = await self._edges_touching(seeds)
+
+        nodes: Dict[str, Dict[str, Any]] = {}
+        edges: List[Tuple[str, str, str, Dict[str, Any]]] = []
+        for row in edge_rows:
+            extra = row.model_extra or {}
+            relationship_name = extra.get("relationship_name")
+            if edge_types and relationship_name not in edge_types:
+                continue
+            source_id = str(extra.get("source_id"))
+            target_id = str(extra.get("target_id"))
+            nodes.setdefault(
+                source_id,
+                {"name": extra.get("source_name", ""), "type": extra.get("source_type", "")},
+            )
+            nodes.setdefault(
+                target_id,
+                {"name": extra.get("target_name", ""), "type": extra.get("target_type", "")},
+            )
+            edges.append(
+                (
+                    source_id,
+                    target_id,
+                    relationship_name,
+                    self._parse_properties(extra.get("properties")),
+                )
+            )
+
+        # Seeds are always part of the neighborhood even if they have no edges.
+        missing_seeds = [s for s in seeds if s not in nodes]
+        if missing_seeds:
+            seed_rows = await self._query_by_ids(self._node_namespace(), missing_seeds)
+            for row in seed_rows:
+                node = self._node_dict_from_row(row)
+                node.pop("id", None)
+                nodes[str(row.id)] = node
+
+        return [(nid, data) for nid, data in nodes.items()], edges
 
     # --- whole-graph reads -------------------------------------------------
 
     async def get_graph_data(self) -> Tuple[List, List]:
-        # Cursor scan: query(rank_by=("id","asc"), filters=("id","Gt",cursor), top_k=10000)
-        raise NotImplementedError
+        node_rows = await self._query_all(self._node_namespace())
+        nodes = []
+        for row in node_rows:
+            extra = row.model_extra or {}
+            data = {"name": extra.get("name", ""), "type": extra.get("type", "")}
+            data.update(self._parse_properties(extra.get("properties")))
+            nodes.append((str(row.id), data))
+
+        if not nodes:
+            return [], []
+
+        edge_rows = await self._query_all(self._edge_namespace())
+        edges = []
+        for row in edge_rows:
+            extra = row.model_extra or {}
+            edges.append(
+                (
+                    str(extra.get("source_id")),
+                    str(extra.get("target_id")),
+                    extra.get("relationship_name"),
+                    self._parse_properties(extra.get("properties")),
+                )
+            )
+        return nodes, edges
 
     async def get_filtered_graph_data(
         self, attribute_filters: List[Dict[str, List[Union[str, int]]]]
     ) -> Tuple[List, List]:
-        raise NotImplementedError
+        if not attribute_filters:
+            return await self.get_graph_data()
+
+        allowed = {"id", "name", "type"}
+        and_filters = []
+        for filter_dict in attribute_filters:
+            for attr, values in filter_dict.items():
+                if attr not in allowed:
+                    raise ValueError(f"Invalid filter attribute: {attr!r}")
+                and_filters.append((attr, "In", [str(v) for v in values]))
+
+        node_filter = and_filters[0] if len(and_filters) == 1 else ("And", tuple(and_filters))
+        node_rows = await self._query_all(self._node_namespace(), filters=node_filter)
+
+        nodes = []
+        node_ids = set()
+        for row in node_rows:
+            extra = row.model_extra or {}
+            data = {"name": extra.get("name", ""), "type": extra.get("type", "")}
+            data.update(self._parse_properties(extra.get("properties")))
+            nodes.append((str(row.id), data))
+            node_ids.add(str(row.id))
+
+        if not node_ids:
+            return [], []
+
+        edge_rows = await self._query_all(self._edge_namespace())
+        edges = []
+        for row in edge_rows:
+            extra = row.model_extra or {}
+            source_id = str(extra.get("source_id"))
+            target_id = str(extra.get("target_id"))
+            if source_id in node_ids and target_id in node_ids:
+                edges.append(
+                    (
+                        source_id,
+                        target_id,
+                        extra.get("relationship_name"),
+                        self._parse_properties(extra.get("properties")),
+                    )
+                )
+        return nodes, edges
 
     async def get_nodeset_subgraph(
         self, node_type: Type[Any], node_name: List[str], node_name_filter_operator: str = "OR"
     ) -> Tuple[List, List]:
-        # OR: type Eq + name In; AND: client-side intersection of 1-hop expansions.
-        raise NotImplementedError
+        label = node_type.__name__
+
+        primary_filter = (
+            "And",
+            (("type", "Eq", label), ("name", "In", [str(n) for n in node_name])),
+        )
+        primary_rows = await self._query_all(self._node_namespace(), filters=primary_filter)
+        primary_ids = {str(row.id) for row in primary_rows}
+
+        if not primary_ids:
+            return [], []
+
+        # Single-hop expansion around the primary nodes.
+        edge_rows = await self._edges_touching(list(primary_ids))
+
+        # Map each neighbor to the set of primaries it connects to.
+        neighbor_to_primaries: Dict[str, set] = {}
+        for row in edge_rows:
+            extra = row.model_extra or {}
+            source_id = str(extra.get("source_id"))
+            target_id = str(extra.get("target_id"))
+            if source_id in primary_ids:
+                primary, neighbor = source_id, target_id
+            else:
+                primary, neighbor = target_id, source_id
+            if neighbor in primary_ids:
+                continue
+            neighbor_to_primaries.setdefault(neighbor, set()).add(primary)
+
+        if node_name_filter_operator == "AND":
+            neighbor_ids = {
+                n
+                for n, primaries in neighbor_to_primaries.items()
+                if len(primaries) == len(primary_ids)
+            }
+        else:
+            neighbor_ids = set(neighbor_to_primaries.keys())
+
+        all_ids = primary_ids | neighbor_ids
+
+        node_rows = await self._query_by_ids(self._node_namespace(), list(all_ids))
+        nodes = []
+        for row in node_rows:
+            extra = row.model_extra or {}
+            data = {"name": extra.get("name", ""), "type": extra.get("type", "")}
+            data.update(self._parse_properties(extra.get("properties")))
+            nodes.append((str(row.id), data))
+
+        edges = []
+        all_edge_rows = await self._edges_touching(list(all_ids))
+        for row in all_edge_rows:
+            extra = row.model_extra or {}
+            source_id = str(extra.get("source_id"))
+            target_id = str(extra.get("target_id"))
+            if source_id in all_ids and target_id in all_ids:
+                edges.append(
+                    (
+                        source_id,
+                        target_id,
+                        extra.get("relationship_name"),
+                        self._parse_properties(extra.get("properties")),
+                    )
+                )
+        return nodes, edges
 
     async def get_graph_metrics(self, include_optional: bool = False) -> Dict[str, Any]:
-        # num_nodes/num_edges/mean_degree from scans; connectivity-dependent
-        # fields return the -1 sentinel (no traversal in v1).
-        raise NotImplementedError
+        node_rows = await self._query_all(self._node_namespace())
+        num_nodes = len(node_rows)
+
+        edge_rows = await self._query_all(self._edge_namespace()) if num_nodes else []
+        num_edges = len(edge_rows)
+
+        mean_degree = (2 * num_edges) / num_nodes if num_nodes else 0.0
+        edge_density = num_edges / (num_nodes * (num_nodes - 1)) if num_nodes > 1 else 0
+
+        num_selfloops = 0
+        for row in edge_rows:
+            extra = row.model_extra or {}
+            if str(extra.get("source_id")) == str(extra.get("target_id")):
+                num_selfloops += 1
+
+        metrics: Dict[str, Any] = {
+            "num_nodes": num_nodes,
+            "num_edges": num_edges,
+            "mean_degree": mean_degree,
+            "edge_density": edge_density,
+            # Connectivity-dependent metrics require traversal not done in v1.
+            "num_connected_components": -1,
+            "sizes_of_connected_components": [],
+            "num_selfloops": num_selfloops if include_optional else -1,
+            "diameter": -1,
+            "avg_shortest_path_length": -1,
+            "avg_clustering": -1,
+        }
+        return metrics
 
     # --- unsupported in v1 -------------------------------------------------
 
@@ -190,4 +674,49 @@ class TurbopufferGraphAdapter(GraphDBInterface):
                 "TurboPuffer is cursor-paginated, not offset-paginated; nonzero offset "
                 "is unsupported in v1."
             )
-        raise NotImplementedError
+
+        edge_rows = await self._query_all(self._edge_namespace())
+        edge_rows = edge_rows[: max(limit, 0)]
+        if not edge_rows:
+            return []
+
+        # Hydrate endpoints so triplet nodes carry their full property payload.
+        endpoint_ids = set()
+        for row in edge_rows:
+            extra = row.model_extra or {}
+            endpoint_ids.add(str(extra.get("source_id")))
+            endpoint_ids.add(str(extra.get("target_id")))
+
+        node_rows = await self._query_by_ids(self._node_namespace(), list(endpoint_ids))
+        node_lookup = {str(row.id): self._node_dict_from_row(row) for row in node_rows}
+
+        triplets = []
+        for row in edge_rows:
+            extra = row.model_extra or {}
+            source_id = str(extra.get("source_id"))
+            target_id = str(extra.get("target_id"))
+
+            start_node = node_lookup.get(
+                source_id,
+                self._node_dict_from_endpoint(
+                    source_id, extra.get("source_name"), extra.get("source_type")
+                ),
+            )
+            end_node = node_lookup.get(
+                target_id,
+                self._node_dict_from_endpoint(
+                    target_id, extra.get("target_name"), extra.get("target_type")
+                ),
+            )
+
+            rel = {"relationship_name": extra.get("relationship_name")}
+            rel.update(self._parse_properties(extra.get("properties")))
+
+            triplets.append(
+                {
+                    "start_node": start_node,
+                    "relationship_properties": rel,
+                    "end_node": end_node,
+                }
+            )
+        return triplets

--- a/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
+++ b/packages/graph/turbopuffer/cognee_community_graph_adapter_turbopuffer/turbopuffer_graph_adapter.py
@@ -1,0 +1,193 @@
+"""TurboPuffer graph adapter — v1 SKELETON (test-driven).
+
+This is the red-phase skeleton: it satisfies the GraphDBInterface contract well
+enough to be instantiated and import-checked, and it pins the v1 boundaries that
+the tests assert (no multi-hop BFS, no Cypher, no random-offset pagination).
+
+Every data method raises NotImplementedError until implemented. The design that
+each method will follow is documented inline so implementation is a fill-in-the-
+blanks exercise against the test suite.
+
+Storage model (per dataset, namespace-prefixed by ``database_name``):
+  - ``{database_name}_graph_node``: one doc per node. Attributes: id, name, type,
+    belongs_to_set (string[]), degree (int), properties (json string).
+  - ``{database_name}_graph_edge``: one doc per edge. id = f"{src}__{rel}__{tgt}";
+    attributes: source_id, target_id, relationship_name, plus DENORMALIZED
+    endpoint identity source_name/source_type/target_name/target_type, and
+    properties (json string). The endpoint denormalization makes single-hop reads
+    (get_neighbors / get_connections / get_edges) one query with zero hydration.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
+
+from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface
+from cognee.infrastructure.engine import DataPoint
+
+
+class TurbopufferGraphAdapter(GraphDBInterface):
+    def __init__(
+        self,
+        graph_database_url: str = "",
+        graph_database_username: str = "",
+        graph_database_password: str = "",
+        graph_database_port: str = "",
+        graph_database_key: str = "",
+        database_name: Optional[str] = None,
+        graph_database_name: Optional[str] = None,
+        graph_database_host: str = "",
+        **kwargs: Any,
+    ) -> None:
+        # cognee's factory passes the per-dataset name as ``database_name``; an
+        # explicit ``graph_database_name`` wins if both are given.
+        self.database_name = graph_database_name or database_name or "cognee_graph"
+        self.api_key = graph_database_key
+        self.region = graph_database_url  # TurboPuffer region travels in the url slot
+        self._client = None  # lazy
+
+    # --- helpers -----------------------------------------------------------
+
+    def _namespace_name(self, collection_name: str) -> str:
+        return f"{self.database_name}_{collection_name}"
+
+    def _node_namespace(self):
+        raise NotImplementedError
+
+    def _edge_namespace(self):
+        raise NotImplementedError
+
+    @staticmethod
+    def _edge_id(source_id: str, relationship_name: str, target_id: str) -> str:
+        return f"{source_id}__{relationship_name}__{target_id}"
+
+    # --- lifecycle ---------------------------------------------------------
+
+    async def initialize(self) -> None:
+        # No-op: TurboPuffer namespaces are created on first write.
+        return None
+
+    async def is_empty(self) -> bool:
+        # query(node_ns, rank_by=("id","asc"), top_k=1) -> rows empty?
+        raise NotImplementedError
+
+    async def delete_graph(self) -> None:
+        # node_ns.delete_all(); edge_ns.delete_all()
+        raise NotImplementedError
+
+    # --- writes ------------------------------------------------------------
+
+    async def add_node(
+        self, node: Union[DataPoint, str], properties: Optional[Dict[str, Any]] = None
+    ) -> None:
+        raise NotImplementedError
+
+    async def add_nodes(self, nodes: Union[List[Tuple[str, Dict]], List[DataPoint]]) -> None:
+        # node_ns.write(upsert_rows=[serialize(n) for n in nodes], schema=...)
+        raise NotImplementedError
+
+    async def add_edge(
+        self,
+        source_id: str,
+        target_id: str,
+        relationship_name: str,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        raise NotImplementedError
+
+    async def add_edges(
+        self, edges: Union[List, List[Tuple[str, str, str, Optional[Dict[str, Any]]]]]
+    ) -> None:
+        # Denormalize endpoint name/type onto each edge doc (look up from the
+        # node batch, or via get_nodes when not co-present), then
+        # edge_ns.write(upsert_rows=...).
+        raise NotImplementedError
+
+    # --- deletes -----------------------------------------------------------
+
+    async def delete_node(self, node_id: str) -> None:
+        raise NotImplementedError
+
+    async def delete_nodes(self, node_ids: List[str]) -> None:
+        # node_ns.write(deletes=node_ids); then query touching edges
+        # ("Or", source_id In ids, target_id In ids) and edge_ns.write(deletes=...).
+        raise NotImplementedError
+
+    # --- point reads -------------------------------------------------------
+
+    async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        raise NotImplementedError
+
+    async def get_nodes(self, node_ids: List[str]) -> List[Dict[str, Any]]:
+        # node_ns.query(filters=("id","In",node_ids), include_attributes=True),
+        # chunked to <=10000 ids per query.
+        raise NotImplementedError
+
+    async def has_edge(self, source_id: str, target_id: str, relationship_name: str) -> bool:
+        raise NotImplementedError
+
+    async def has_edges(self, edges: List) -> List:
+        # edge_ns.query(filters=("id","In",[edge_id(...) ...])) -> intersect.
+        raise NotImplementedError
+
+    # --- single-hop reads --------------------------------------------------
+
+    async def get_edges(self, node_id: str) -> List:
+        # edge_ns.query(("Or", source_id Eq, target_id Eq), include_attributes=True)
+        raise NotImplementedError
+
+    async def get_neighbors(self, node_id: str) -> List[Dict[str, Any]]:
+        raise NotImplementedError
+
+    async def get_connections(
+        self, node_id: Union[str, Any]
+    ) -> List[Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]]:
+        # One edge query; assemble (source, rel, target) from denormalized attrs.
+        raise NotImplementedError
+
+    async def get_neighborhood(
+        self,
+        node_ids: List[str],
+        depth: int = 1,
+        edge_types: Optional[List[str]] = None,
+    ) -> Tuple[List, List]:
+        if depth != 1:
+            raise NotImplementedError(
+                "TurboPuffer graph adapter v1 supports single-hop neighborhood only "
+                "(depth=1); multi-hop BFS is not implemented."
+            )
+        # depth==1: one edge query around seeds + node hydration.
+        raise NotImplementedError
+
+    # --- whole-graph reads -------------------------------------------------
+
+    async def get_graph_data(self) -> Tuple[List, List]:
+        # Cursor scan: query(rank_by=("id","asc"), filters=("id","Gt",cursor), top_k=10000)
+        raise NotImplementedError
+
+    async def get_filtered_graph_data(
+        self, attribute_filters: List[Dict[str, List[Union[str, int]]]]
+    ) -> Tuple[List, List]:
+        raise NotImplementedError
+
+    async def get_nodeset_subgraph(
+        self, node_type: Type[Any], node_name: List[str], node_name_filter_operator: str = "OR"
+    ) -> Tuple[List, List]:
+        # OR: type Eq + name In; AND: client-side intersection of 1-hop expansions.
+        raise NotImplementedError
+
+    async def get_graph_metrics(self, include_optional: bool = False) -> Dict[str, Any]:
+        # num_nodes/num_edges/mean_degree from scans; connectivity-dependent
+        # fields return the -1 sentinel (no traversal in v1).
+        raise NotImplementedError
+
+    # --- unsupported in v1 -------------------------------------------------
+
+    async def query(self, query: str, params: Optional[dict] = None) -> List[Any]:
+        raise NotImplementedError("TurboPuffer has no query language; Cypher is unsupported.")
+
+    async def get_triplets_batch(self, offset: int, limit: int) -> List[Dict[str, Any]]:
+        if offset != 0:
+            raise NotImplementedError(
+                "TurboPuffer is cursor-paginated, not offset-paginated; nonzero offset "
+                "is unsupported in v1."
+            )
+        raise NotImplementedError

--- a/packages/graph/turbopuffer/examples/example.py
+++ b/packages/graph/turbopuffer/examples/example.py
@@ -1,0 +1,71 @@
+"""Run the Alice in Wonderland pipeline against a graph backend.
+
+Backend is chosen by GRAPH_DATABASE_PROVIDER:
+  - "turbopuffer": uses this adapter (requires it to be IMPLEMENTED, plus
+    TURBOPUFFER_API_KEY / TURBOPUFFER_REGION). Until the adapter is implemented
+    this will raise NotImplementedError during cognify.
+  - anything else / unset: uses cognee's default backend (Ladybug) so you can
+    see the full flow + graph shape today.
+
+Usage:
+    # default backend (works now)
+    python examples/example.py
+
+    # turbopuffer (works once the adapter is implemented)
+    GRAPH_DATABASE_PROVIDER=turbopuffer TURBOPUFFER_API_KEY=... \
+    TURBOPUFFER_REGION=gcp-us-east4 python examples/example.py
+"""
+
+import asyncio
+import os
+import pathlib
+
+import cognee
+from cognee.modules.search.types import SearchType
+
+ALICE_CANDIDATES = [
+    pathlib.Path(__file__).parents[1] / "tests" / "data" / "alice_in_wonderland.txt",
+    pathlib.Path(__file__).parents[6] / "notebooks" / "data" / "alice_in_wonderland.txt",
+    pathlib.Path(__file__).parents[6]
+    / "examples" / "demos" / "simple_document_qa" / "data" / "alice_in_wonderland.txt",
+]
+
+
+def resolve_alice() -> str:
+    env = os.getenv("ALICE_DATA_PATH")
+    if env and pathlib.Path(env).is_file():
+        return env
+    for c in ALICE_CANDIDATES:
+        if c.is_file():
+            return str(c.resolve())
+    raise FileNotFoundError("Set ALICE_DATA_PATH to alice_in_wonderland.txt")
+
+
+async def main():
+    provider = os.getenv("GRAPH_DATABASE_PROVIDER", "").lower()
+    if provider == "turbopuffer":
+        from cognee_community_graph_adapter_turbopuffer import register
+
+        register()
+        cognee.config.set_graph_database_provider("turbopuffer")
+        print(">> graph backend: turbopuffer")
+    else:
+        print(">> graph backend: default (ladybug)")
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    dataset = "wonderland"
+    await cognee.add([resolve_alice()], dataset)
+    await cognee.cognify([dataset])
+
+    results = await cognee.search(
+        query_type=SearchType.GRAPH_COMPLETION, query_text="Who does Alice meet?"
+    )
+    print("\n=== GRAPH_COMPLETION ===")
+    for r in results:
+        print(r)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/graph/turbopuffer/examples/example.py
+++ b/packages/graph/turbopuffer/examples/example.py
@@ -27,7 +27,11 @@ ALICE_CANDIDATES = [
     pathlib.Path(__file__).parents[1] / "tests" / "data" / "alice_in_wonderland.txt",
     pathlib.Path(__file__).parents[5] / "notebooks" / "data" / "alice_in_wonderland.txt",
     pathlib.Path(__file__).parents[5]
-    / "examples" / "demos" / "simple_document_qa" / "data" / "alice_in_wonderland.txt",
+    / "examples"
+    / "demos"
+    / "simple_document_qa"
+    / "data"
+    / "alice_in_wonderland.txt",
 ]
 
 

--- a/packages/graph/turbopuffer/examples/example.py
+++ b/packages/graph/turbopuffer/examples/example.py
@@ -25,8 +25,8 @@ from cognee.modules.search.types import SearchType
 
 ALICE_CANDIDATES = [
     pathlib.Path(__file__).parents[1] / "tests" / "data" / "alice_in_wonderland.txt",
-    pathlib.Path(__file__).parents[6] / "notebooks" / "data" / "alice_in_wonderland.txt",
-    pathlib.Path(__file__).parents[6]
+    pathlib.Path(__file__).parents[5] / "notebooks" / "data" / "alice_in_wonderland.txt",
+    pathlib.Path(__file__).parents[5]
     / "examples" / "demos" / "simple_document_qa" / "data" / "alice_in_wonderland.txt",
 ]
 

--- a/packages/graph/turbopuffer/examples/export_graph.py
+++ b/packages/graph/turbopuffer/examples/export_graph.py
@@ -1,0 +1,71 @@
+"""Export the TurboPuffer graph (nodes + edges) to JSON files for inspection.
+
+Writes nodes.json and edges.json with each record's filterable attributes plus
+the full `properties` blob expanded back into nested JSON (not a string), so the
+payload is human-readable and diffable against other graph backends.
+
+Usage:
+    # uses the default single-tenant prefix written by example.py
+    python examples/export_graph.py
+
+    # custom dataset prefix / output dir / row cap
+    python examples/export_graph.py --db cognee_graph --out ./turbopuffer_graph_dump --limit 5000
+
+Reads TURBOPUFFER_API_KEY and TURBOPUFFER_REGION from the environment.
+"""
+
+import argparse
+import json
+import os
+
+import turbopuffer
+
+
+def _export(client, namespace_name: str, out_path: str, limit: int) -> int:
+    rows = (
+        client.namespace(namespace_name)
+        .query(rank_by=("id", "asc"), top_k=limit, include_attributes=True)
+        .rows
+        or []
+    )
+    records = []
+    for row in rows:
+        record = dict(row.model_extra or {})
+        record["id"] = str(row.id)
+        if isinstance(record.get("properties"), str):
+            try:
+                record["properties"] = json.loads(record["properties"])
+            except (TypeError, ValueError):
+                pass
+        records.append(record)
+    with open(out_path, "w", encoding="utf-8") as handle:
+        json.dump(records, handle, indent=2, ensure_ascii=False)
+    return len(records)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", default="cognee_graph", help="dataset namespace prefix")
+    parser.add_argument("--out", default="turbopuffer_graph_dump", help="output directory")
+    parser.add_argument("--limit", type=int, default=10000, help="max rows per namespace")
+    args = parser.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    client = turbopuffer.Turbopuffer(
+        api_key=os.environ["TURBOPUFFER_API_KEY"],
+        region=os.getenv("TURBOPUFFER_REGION", "gcp-us-central1"),
+    )
+
+    for collection, fname in (("graph_node", "nodes.json"), ("graph_edge", "edges.json")):
+        ns = f"{args.db}_{collection}"
+        path = os.path.join(args.out, fname)
+        try:
+            n = _export(client, ns, path, args.limit)
+            print(f"wrote {n} records from {ns} -> {path}")
+        except Exception as error:
+            print(f"skip {ns}: {error}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/graph/turbopuffer/examples/inspect_graph.py
+++ b/packages/graph/turbopuffer/examples/inspect_graph.py
@@ -1,0 +1,84 @@
+"""Inspect the knowledge graph after running the pipeline.
+
+Two views:
+  1. Backend-agnostic (via cognee's graph engine): counts, metrics, a sample of
+     nodes/edges. Works for ANY configured graph backend.
+  2. Raw TurboPuffer (optional): lists the *_graph_node / *_graph_edge namespaces
+     and dumps a sample of rows straight from TurboPuffer. Only relevant when the
+     turbopuffer backend is in use.
+
+Run the same backend selection as example.py (GRAPH_DATABASE_PROVIDER, keys).
+
+    python examples/inspect_graph.py
+    GRAPH_DATABASE_PROVIDER=turbopuffer TURBOPUFFER_API_KEY=... \
+    TURBOPUFFER_REGION=gcp-us-east4 python examples/inspect_graph.py --raw
+"""
+
+import asyncio
+import os
+import sys
+
+import cognee
+
+
+async def inspect_via_cognee():
+    provider = os.getenv("GRAPH_DATABASE_PROVIDER", "").lower()
+    if provider == "turbopuffer":
+        from cognee_community_graph_adapter_turbopuffer import register
+
+        register()
+        cognee.config.set_graph_database_provider("turbopuffer")
+
+    from cognee.infrastructure.databases.graph import get_graph_engine
+
+    engine = await get_graph_engine()
+
+    nodes, edges = await engine.get_graph_data()
+    print(f"\n=== graph via cognee ({provider or 'default'}) ===")
+    print(f"nodes: {len(nodes)}   edges: {len(edges)}")
+
+    print("\n-- sample nodes --")
+    for node_id, props in nodes[:10]:
+        print(f"  {node_id}  name={props.get('name')!r}  type={props.get('type')!r}")
+
+    print("\n-- sample edges --")
+    for edge in edges[:10]:
+        # EdgeData is (source_id, target_id, relationship_name, properties)
+        print(f"  {edge[0]} --{edge[2]}--> {edge[1]}")
+
+    print("\n-- metrics --")
+    metrics = await engine.get_graph_metrics(include_optional=True)
+    for k, v in metrics.items():
+        print(f"  {k}: {v}")
+
+
+async def inspect_raw_turbopuffer():
+    """Dump rows straight from TurboPuffer namespaces (filter-only lookup)."""
+    import turbopuffer
+
+    client = turbopuffer.Turbopuffer(
+        api_key=os.environ["TURBOPUFFER_API_KEY"],
+        region=os.getenv("TURBOPUFFER_REGION", "gcp-us-east4"),
+    )
+
+    print("\n=== raw TurboPuffer namespaces ===")
+    for ns_handle in client.namespaces():
+        name = getattr(ns_handle, "id", None) or getattr(ns_handle, "name", str(ns_handle))
+        if not (name.endswith("_graph_node") or name.endswith("_graph_edge")):
+            continue
+        ns = client.namespace(name)
+        resp = ns.query(rank_by=("id", "asc"), top_k=10, include_attributes=True)
+        rows = resp.rows or []
+        print(f"\n-- {name}  (showing {len(rows)}) --")
+        for row in rows:
+            print(f"  id={row.id}  {row.model_extra}")
+
+
+async def main():
+    await inspect_via_cognee()
+    if "--raw" in sys.argv:
+        await inspect_raw_turbopuffer()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/graph/turbopuffer/examples/reset_namespaces.py
+++ b/packages/graph/turbopuffer/examples/reset_namespaces.py
@@ -1,0 +1,82 @@
+"""Delete TurboPuffer namespaces so the example can rebuild from a clean slate.
+
+By default deletes ONLY cognee-generated namespaces (graph + vector + this repo's
+test/debug prefixes) in the configured region. Pass --all to delete every
+namespace in the region instead.
+
+Usage:
+    python examples/reset_namespaces.py            # cognee/test namespaces only
+    python examples/reset_namespaces.py --all       # everything in the region
+    python examples/reset_namespaces.py --dry-run    # list, delete nothing
+
+Reads TURBOPUFFER_API_KEY and TURBOPUFFER_REGION from the environment.
+"""
+
+import os
+import sys
+
+import turbopuffer
+
+# Namespace name fragments that identify cognee-generated data.
+_GRAPH_SUFFIXES = ("_graph_node", "_graph_edge")
+# cognee vector collections are "{db}_{Model}_{field}"; these are the field tails.
+_VECTOR_SUFFIXES = (
+    "_text",
+    "_name",
+    "_relationship_name",
+)
+# Prefixes used by this package's tests / debugging sessions.
+_TEST_PREFIXES = ("tpuf_graph_test_", "tpuf_iso_", "tpuf_bigstr_", "dbg_", "edgedbg_")
+
+
+def _is_cognee_namespace(name: str) -> bool:
+    if name.endswith(_GRAPH_SUFFIXES):
+        return True
+    if name.endswith(_VECTOR_SUFFIXES):
+        return True
+    if name.startswith(_TEST_PREFIXES):
+        return True
+    return False
+
+
+def main() -> int:
+    delete_all = "--all" in sys.argv
+    dry_run = "--dry-run" in sys.argv
+
+    region = os.getenv("TURBOPUFFER_REGION", "gcp-us-central1")
+    client = turbopuffer.Turbopuffer(
+        api_key=os.environ["TURBOPUFFER_API_KEY"],
+        region=region,
+    )
+
+    names = []
+    for ns in client.namespaces():
+        names.append(getattr(ns, "id", None) or str(ns))
+
+    targets = names if delete_all else [n for n in names if _is_cognee_namespace(n)]
+    skipped = [n for n in names if n not in targets]
+
+    print(f"region={region}  total namespaces={len(names)}  to delete={len(targets)}")
+    if skipped and not delete_all:
+        print(f"skipping {len(skipped)} non-cognee namespaces: {skipped}")
+
+    for name in targets:
+        if dry_run:
+            print(f"  [dry-run] would delete {name}")
+            continue
+        try:
+            client.namespace(name).delete_all()
+            print(f"  deleted {name}")
+        except Exception as error:
+            msg = str(error).lower()
+            if "404" in msg or "not found" in msg:
+                print(f"  already gone {name}")
+            else:
+                print(f"  ERROR deleting {name}: {error}")
+
+    print("done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/graph/turbopuffer/pyproject.toml
+++ b/packages/graph/turbopuffer/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "cognee-community-graph-adapter-turbopuffer"
+version = "0.1.0"
+description = "TurboPuffer graph adapter for cognee (graph emulated on TurboPuffer namespaces + attributes)"
+readme = "README.md"
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "cognee>=0.5.5",
+    "turbopuffer>=0.5.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_graph_adapter_turbopuffer"]

--- a/packages/graph/turbopuffer/reset_and_run.sh
+++ b/packages/graph/turbopuffer/reset_and_run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Wipe stale cognee namespaces from TurboPuffer, then rebuild the Alice graph
+# by running the example end-to-end.
+#
+# Usage:
+#   ./reset_and_run.sh            # delete cognee/test namespaces, then run example
+#   ./reset_and_run.sh --all      # delete ALL namespaces in the region first
+#
+# Prereqs: <repo>/.env with LLM_API_KEY + TURBOPUFFER_API_KEY; <repo>/.venv set up.
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$PKG_DIR/../../../.." && pwd)"
+
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  set -a; source "$REPO_ROOT/.env"; set +a
+fi
+if [[ -f "$REPO_ROOT/.venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/.venv/bin/activate"
+fi
+
+# Required so the example uses this adapter; region defaults to the community default.
+export TURBOPUFFER_REGION="${TURBOPUFFER_REGION:-gcp-us-central1}"
+export GRAPH_DATABASE_PROVIDER=turbopuffer
+export ENABLE_BACKEND_ACCESS_CONTROL=false
+# Make the Alice corpus discoverable even if the package isn't beside the repo data.
+export ALICE_DATA_PATH="${ALICE_DATA_PATH:-$REPO_ROOT/notebooks/data/alice_in_wonderland.txt}"
+
+cd "$PKG_DIR"
+
+echo "==> 1/2 deleting old TurboPuffer namespaces (region=$TURBOPUFFER_REGION)"
+python examples/reset_namespaces.py "$@"
+
+echo
+echo "==> 2/2 running example (add -> cognify -> search) on Alice in Wonderland"
+python examples/example.py

--- a/packages/graph/turbopuffer/run_tests.sh
+++ b/packages/graph/turbopuffer/run_tests.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Run the TurboPuffer graph adapter tests.
+#
+# Usage:
+#   ./run_tests.sh             # contract + live integration + isolation (no LLM)
+#   ./run_tests.sh e2e         # also run the Alice in Wonderland end-to-end (uses LLM)
+#   ./run_tests.sh contract    # registration/boundary tests only (no network)
+#
+# Prereqs:
+#   - cognee repo .env contains LLM_API_KEY and TURBOPUFFER_API_KEY
+#   - the venv at <repo>/.venv exists and has the package installed:
+#       uv pip install -e cognee-community/packages/graph/turbopuffer
+#
+set -euo pipefail
+
+# --- locate the repo root (../../../.. from this package) and load config -----
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$PKG_DIR/../../../.." && pwd)"
+
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  set -a; source "$REPO_ROOT/.env"; set +a
+else
+  echo "WARNING: $REPO_ROOT/.env not found; relying on already-exported env vars." >&2
+fi
+
+# activate venv if present
+if [[ -f "$REPO_ROOT/.venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/.venv/bin/activate"
+fi
+
+# TurboPuffer region: default to the community-package default if unset.
+export TURBOPUFFER_REGION="${TURBOPUFFER_REGION:-gcp-us-central1}"
+
+# rtk (the shell hook) collapses pytest output; prefer "rtk proxy" if available.
+RUN="python -m pytest"
+if command -v rtk >/dev/null 2>&1; then
+  RUN="rtk proxy python -m pytest"
+fi
+
+cd "$PKG_DIR"
+
+mode="${1:-integration}"
+echo ">> mode=$mode  region=$TURBOPUFFER_REGION  key=${TURBOPUFFER_API_KEY:0:4}****"
+
+case "$mode" in
+  contract)
+    $RUN tests/test_registration.py -q
+    ;;
+  integration)
+    # Live per-method + isolation tests (TurboPuffer only, no LLM cost).
+    COGNEE_TURBOPUFFER_GRAPH_TESTS=1 \
+      $RUN tests/test_registration.py tests/test_adapter_methods.py tests/test_dataset_isolation.py -q
+    ;;
+  e2e)
+    # Everything above PLUS the Alice in Wonderland full pipeline (uses LLM_API_KEY).
+    # The pipeline runs in single-tenant mode; multi-tenant (access-control) mode
+    # needs the dataset handler selected via graph_dataset_database_handler.
+    ENABLE_BACKEND_ACCESS_CONTROL=false \
+    COGNEE_TURBOPUFFER_GRAPH_TESTS=1 COGNEE_TURBOPUFFER_GRAPH_E2E=1 \
+      $RUN tests/ -q -s
+    ;;
+  *)
+    echo "Unknown mode: $mode  (use: contract | integration | e2e)" >&2
+    exit 2
+    ;;
+esac

--- a/packages/graph/turbopuffer/tests/README.md
+++ b/packages/graph/turbopuffer/tests/README.md
@@ -1,0 +1,58 @@
+# TurboPuffer graph adapter — test plan
+
+These tests are the **specification** for the adapter (written test-first). They
+mirror the existing cognee graph-adapter tests so the TurboPuffer adapter is held
+to the same behavior:
+
+| This suite | Mirrors |
+|---|---|
+| `test_adapter_methods.py` | `cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py` (per-method contract) |
+| `test_registration.py` | `cognee-community/packages/graph/pggraph/tests/test_pggraph.py` (register + factory-shape) |
+| `test_e2e_alice.py` | `cognee/tests/e2e/postgres/test_graphdb_shared.py` (full add→cognify→search) |
+| `test_dataset_isolation.py` | namespace-level per-dataset isolation (vector adapter handler analog) |
+
+## Tiers & how to run
+
+```bash
+# Unit/contract only (no network): construction, registration, signatures
+pytest tests/test_registration.py
+
+# Integration (real TurboPuffer namespace): per-method behavior + isolation
+COGNEE_TURBOPUFFER_GRAPH_TESTS=1 TURBOPUFFER_API_KEY=... pytest tests/test_adapter_methods.py tests/test_dataset_isolation.py
+
+# End-to-end (Alice in Wonderland, real LLM + TurboPuffer)
+COGNEE_TURBOPUFFER_GRAPH_E2E=1 TURBOPUFFER_API_KEY=... LLM_API_KEY=... \
+  pytest tests/test_e2e_alice.py
+# or as a script:
+python tests/test_e2e_alice.py
+```
+
+`alice_in_wonderland.txt` is resolved from `ALICE_DATA_PATH`, then a package-local
+`tests/data/` copy, then the repo's `notebooks/data/` and demos copies.
+
+## v1 scope pinned by these tests
+
+**Implemented** (single-query or paginated-scan; no traversal):
+`is_empty`, `add_node(s)`, `get_node(s)`, `delete_node(s)` (+ manual edge cascade),
+`add_edge(s)`, `has_edge(s)`, `get_edges`, `get_neighbors`, `get_connections`,
+`get_neighborhood(depth=1)`, `get_graph_data`, `get_filtered_graph_data`,
+`get_nodeset_subgraph` (OR + client-side AND), `get_graph_metrics` (counts +
+mean degree), `get_triplets_batch(offset=0)`, `delete_graph`.
+
+**Explicitly NOT in v1** (asserted to raise `NotImplementedError`):
+- `get_neighborhood(depth>=2)` — multi-hop BFS
+- `query(...)` — Cypher (no query language on TurboPuffer)
+- `get_triplets_batch(offset>0)` — cursor pagination only, no random offset
+- connectivity-dependent metrics (`num_connected_components`, `diameter`,
+  `avg_shortest_path_length`, `avg_clustering`) return the `-1` sentinel
+
+## Stored metadata the tests assume (denormalized for single-query reads)
+
+- **Node doc**: `id`, `name`, `type`, `belongs_to_set[]`, `degree`, `properties` (json)
+- **Edge doc**: `id = "{src}__{rel}__{tgt}"`, `source_id`, `target_id`,
+  `relationship_name`, **denormalized** `source_name/source_type/target_name/target_type`,
+  `properties` (json)
+
+The edge endpoint-identity denormalization is what lets `get_neighbors`/
+`get_connections`/`get_edges` resolve in a single query with no hydration round-trip.
+```

--- a/packages/graph/turbopuffer/tests/conftest.py
+++ b/packages/graph/turbopuffer/tests/conftest.py
@@ -1,0 +1,107 @@
+"""Shared fixtures and helpers for the TurboPuffer graph adapter tests.
+
+Test tiers (gated by env vars so CI can run the cheap ones without a network):
+
+  - Unit/contract  (no gate): construction, registration, signatures. Run always.
+  - Integration    (COGNEE_TURBOPUFFER_GRAPH_TESTS=1 + TURBOPUFFER_API_KEY):
+                    per-method behavior against a real TurboPuffer namespace.
+  - E2E            (COGNEE_TURBOPUFFER_GRAPH_E2E=1 + TURBOPUFFER_API_KEY + LLM_API_KEY):
+                    full add -> cognify -> search pipeline on Alice in Wonderland.
+
+The demo graph (test_kg.json) is the Wonderland fixture used by the integration
+tier so per-method assertions stay deterministic (no LLM involved).
+"""
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+TESTS_DIR = Path(__file__).parent
+DEMO_KG_PATH = TESTS_DIR / "test_kg.json"
+
+# Make the package importable when running from source without `pip install -e`.
+PACKAGE_ROOT = TESTS_DIR.parent
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+# --- env gates -------------------------------------------------------------
+
+INTEGRATION = os.getenv("COGNEE_TURBOPUFFER_GRAPH_TESTS", "").lower() in ("1", "true", "yes")
+E2E = os.getenv("COGNEE_TURBOPUFFER_GRAPH_E2E", "").lower() in ("1", "true", "yes")
+HAS_TPUF_KEY = bool(os.getenv("TURBOPUFFER_API_KEY"))
+HAS_LLM_KEY = bool(os.getenv("LLM_API_KEY"))
+
+requires_turbopuffer = pytest.mark.skipif(
+    not (INTEGRATION and HAS_TPUF_KEY),
+    reason="Set COGNEE_TURBOPUFFER_GRAPH_TESTS=1 and TURBOPUFFER_API_KEY to run integration tests",
+)
+requires_e2e = pytest.mark.skipif(
+    not (E2E and HAS_TPUF_KEY and HAS_LLM_KEY),
+    reason="Set COGNEE_TURBOPUFFER_GRAPH_E2E=1, TURBOPUFFER_API_KEY and LLM_API_KEY to run e2e",
+)
+
+# --- demo graph helpers ----------------------------------------------------
+
+
+def load_demo_kg() -> dict:
+    return json.loads(DEMO_KG_PATH.read_text(encoding="utf-8"))
+
+
+def demo_node_tuples() -> list[tuple[str, dict]]:
+    """Nodes in the (node_id, properties) form accepted by add_nodes."""
+    kg = load_demo_kg()
+    return [
+        (n["id"], {"name": n["name"], "type": n["type"], "description": n["description"]})
+        for n in kg["nodes"]
+    ]
+
+
+def demo_edge_tuples() -> list[tuple[str, str, str, dict]]:
+    """Edges in the (source, target, relationship_name, properties) form."""
+    kg = load_demo_kg()
+    return [
+        (e["source_node_id"], e["target_node_id"], e["relationship_name"], {})
+        for e in kg["edges"]
+    ]
+
+
+# --- adapter fixtures ------------------------------------------------------
+
+
+def _make_adapter(database_name: str):
+    """Construct a TurbopufferGraphAdapter the way cognee's factory does:
+    keyword args including ``database_name`` (the per-dataset prefix)."""
+    from cognee_community_graph_adapter_turbopuffer import TurbopufferGraphAdapter
+
+    return TurbopufferGraphAdapter(
+        graph_database_url=os.getenv("TURBOPUFFER_REGION", ""),
+        graph_database_username="",
+        graph_database_password="",
+        graph_database_port="",
+        graph_database_key=os.getenv("TURBOPUFFER_API_KEY", ""),
+        database_name=database_name,
+    )
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    """A fresh, isolated adapter bound to a unique namespace prefix.
+
+    Each test gets its own ``database_name`` so parallel/repeat runs never
+    collide, and the graph is dropped on teardown.
+    """
+    db_name = f"tpuf_graph_test_{uuid.uuid4().hex[:8]}"
+    inst = _make_adapter(db_name)
+    await inst.initialize()
+    try:
+        yield inst
+    finally:
+        try:
+            await inst.delete_graph()
+        except Exception:
+            pass

--- a/packages/graph/turbopuffer/tests/conftest.py
+++ b/packages/graph/turbopuffer/tests/conftest.py
@@ -65,8 +65,7 @@ def demo_edge_tuples() -> list[tuple[str, str, str, dict]]:
     """Edges in the (source, target, relationship_name, properties) form."""
     kg = load_demo_kg()
     return [
-        (e["source_node_id"], e["target_node_id"], e["relationship_name"], {})
-        for e in kg["edges"]
+        (e["source_node_id"], e["target_node_id"], e["relationship_name"], {}) for e in kg["edges"]
     ]
 
 

--- a/packages/graph/turbopuffer/tests/test_access_control.py
+++ b/packages/graph/turbopuffer/tests/test_access_control.py
@@ -1,0 +1,92 @@
+"""Backend access-control (multi-tenant) test for the TurboPuffer graph adapter.
+
+Exercises the real cognee path that the dataset handler exists for: with
+ENABLE_BACKEND_ACCESS_CONTROL=true and GRAPH_DATASET_DATABASE_HANDLER=turbopuffer_graph,
+cognee creates a per-dataset graph database (its own namespace prefix) via
+TurbopufferGraphDatasetDatabaseHandler.create_dataset, writes there during
+cognify, and prunes it on cleanup.
+
+Verifies: two datasets land in two distinct, isolated graph namespaces, each
+populated, and pruning removes them. Requires TURBOPUFFER_API_KEY + LLM_API_KEY
+and COGNEE_TURBOPUFFER_GRAPH_E2E=1.
+"""
+
+import os
+
+import pytest
+from conftest import requires_e2e
+
+
+def _graph_namespaces(prefixes=None):
+    """Return {namespace_name: row_count} for graph_node namespaces, optionally
+    filtered to those whose prefix is in `prefixes`."""
+    import turbopuffer
+
+    client = turbopuffer.Turbopuffer(
+        api_key=os.environ["TURBOPUFFER_API_KEY"],
+        region=os.getenv("TURBOPUFFER_REGION", "gcp-us-central1"),
+    )
+    out = {}
+    for ns in client.namespaces():
+        name = getattr(ns, "id", None) or str(ns)
+        if not name.endswith("_graph_node"):
+            continue
+        if prefixes is not None and not any(name.startswith(p) for p in prefixes):
+            continue
+        rows = client.namespace(name).query(rank_by=("id", "asc"), top_k=2000).rows or []
+        out[name] = len(rows)
+    return out
+
+
+@requires_e2e
+@pytest.mark.asyncio
+async def test_backend_access_control_isolates_datasets():
+    os.environ["ENABLE_BACKEND_ACCESS_CONTROL"] = "true"
+
+    import cognee
+    from cognee.infrastructure.databases.graph.config import get_graph_config
+    from cognee_community_graph_adapter_turbopuffer import register
+
+    register()
+
+    graph_config = get_graph_config()
+    prev_provider = graph_config.graph_database_provider
+    prev_handler = graph_config.graph_dataset_database_handler
+
+    cognee.config.set_graph_database_provider("turbopuffer")
+    graph_config.graph_dataset_database_handler = "turbopuffer_graph"
+
+    ds_a, ds_b = "acl_alice", "acl_rabbit"
+    new_ns: dict = {}
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+
+        before = set(_graph_namespaces())
+
+        await cognee.add("Alice fell down the rabbit hole into Wonderland.", ds_a)
+        await cognee.add("The White Rabbit checked his pocket watch nervously.", ds_b)
+        await cognee.cognify([ds_a, ds_b])
+
+        after = _graph_namespaces()
+        new_ns = {n: c for n, c in after.items() if n not in before}
+
+        # Access control routes each dataset to its own per-dataset namespace,
+        # each independently populated (isolation).
+        assert len(new_ns) >= 2, f"expected >=2 per-dataset graph namespaces, got {new_ns}"
+        assert all(count > 0 for count in new_ns.values()), new_ns
+
+        # GRAPH_COMPLETION still works under access control.
+        from cognee.modules.search.types import SearchType
+
+        results = await cognee.search(query_type=SearchType.GRAPH_COMPLETION, query_text="Alice")
+        assert results is not None
+    finally:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+        graph_config.graph_database_provider = prev_provider
+        graph_config.graph_dataset_database_handler = prev_handler
+
+    # Prune removed every per-dataset namespace this test created.
+    remaining = set(_graph_namespaces())
+    assert not (set(new_ns) & remaining), f"namespaces survived prune: {set(new_ns) & remaining}"

--- a/packages/graph/turbopuffer/tests/test_adapter_methods.py
+++ b/packages/graph/turbopuffer/tests/test_adapter_methods.py
@@ -9,8 +9,7 @@ These run against a real TurboPuffer namespace (integration tier).
 """
 
 import pytest
-
-from conftest import demo_node_tuples, demo_edge_tuples, requires_turbopuffer
+from conftest import demo_edge_tuples, demo_node_tuples, requires_turbopuffer
 
 pytestmark = [pytest.mark.asyncio, requires_turbopuffer]
 
@@ -107,9 +106,7 @@ async def test_large_node_property_not_truncated(adapter):
     non-filterable `properties` blob and must not be clamped/corrupted."""
     big_text = "wonderland " * 1200  # ~13KB, well over 4096 bytes
 
-    await adapter.add_nodes(
-        [("chunk1", {"name": "", "type": "DocumentChunk", "text": big_text})]
-    )
+    await adapter.add_nodes([("chunk1", {"name": "", "type": "DocumentChunk", "text": big_text})])
     node = await adapter.get_node("chunk1")
     assert node is not None
     assert node["text"] == big_text  # full content preserved, not truncated
@@ -165,6 +162,18 @@ async def test_get_neighbors(adapter):
     neighbor_ids = {n["id"] for n in neighbors}
     assert "WhiteRabbit" in neighbor_ids
     assert "MadHatter" in neighbor_ids
+
+
+async def test_get_neighbors_returns_full_node_payload(adapter):
+    """Neighbors must carry their full node payload (e.g. `description`), not just
+    id/name/type derived from denormalized edge fields."""
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    neighbors = await adapter.get_neighbors("Alice")
+    rabbit = next(n for n in neighbors if n["id"] == "WhiteRabbit")
+    assert rabbit["name"] == "White Rabbit"
+    assert "description" in rabbit and rabbit["description"]  # hydrated from node row
 
 
 async def test_get_connections_returns_triples(adapter):
@@ -288,8 +297,12 @@ async def test_get_graph_metrics_traversal_fields_are_sentinel(adapter):
     await adapter.add_edges(demo_edge_tuples())
 
     metrics = await adapter.get_graph_metrics(include_optional=True)
-    for field in ("num_connected_components", "diameter", "avg_shortest_path_length",
-                  "avg_clustering"):
+    for field in (
+        "num_connected_components",
+        "diameter",
+        "avg_shortest_path_length",
+        "avg_clustering",
+    ):
         if field in metrics:
             assert metrics[field] == -1
 
@@ -310,14 +323,69 @@ async def test_get_triplets_batch_sequential(adapter):
         assert "end_node" in t
 
 
-async def test_get_triplets_batch_arbitrary_offset_raises(adapter):
-    """TurboPuffer is cursor-paginated, not offset-paginated. A nonzero offset
-    cannot be served efficiently, so v1 rejects it rather than scanning O(offset)."""
+async def test_get_triplets_batch_offset_pagination(adapter):
+    """Offset pagination must be deterministic and non-overlapping (cognee's
+    triplet-embedding memify paginates by increasing offset)."""
     await adapter.add_nodes(demo_node_tuples())
-    await adapter.add_edges(demo_edge_tuples())
+    edges = demo_edge_tuples()
+    await adapter.add_edges(edges)
 
-    with pytest.raises(NotImplementedError):
-        await adapter.get_triplets_batch(offset=5, limit=10)
+    page1 = await adapter.get_triplets_batch(offset=0, limit=2)
+    page2 = await adapter.get_triplets_batch(offset=2, limit=2)
+    rest = await adapter.get_triplets_batch(offset=4, limit=100)
+
+    assert len(page1) == 2
+    assert len(page2) == 2
+
+    def key(t):
+        return (
+            t["start_node"]["id"],
+            t["relationship_properties"]["relationship_name"],
+            t["end_node"]["id"],
+        )
+
+    seen = [key(t) for t in page1 + page2 + rest]
+    assert len(seen) == len(edges)  # full coverage
+    assert len(set(seen)) == len(edges)  # no overlap across pages
+
+    # Past the end -> empty.
+    assert await adapter.get_triplets_batch(offset=len(edges) + 10, limit=10) == []
+
+
+# --- belongs_to_set reconciliation -----------------------------------------
+
+
+async def test_remove_belongs_to_set_tags(adapter):
+    """Stripping a tag must remove it from node belongs_to_set AND delete the
+    stale belongs_to_set edge to the matching NodeSet node."""
+    await adapter.add_nodes(
+        [
+            ("Alice", {"name": "Alice", "type": "Entity", "belongs_to_set": ["ds1", "ds2"]}),
+            ("ns_ds1", {"name": "ds1", "type": "NodeSet"}),
+        ]
+    )
+    await adapter.add_edge("Alice", "ns_ds1", "belongs_to_set", {})
+
+    await adapter.remove_belongs_to_set_tags(["ds1"])
+
+    node = await adapter.get_node("Alice")
+    assert node["belongs_to_set"] == ["ds2"]  # ds1 stripped, ds2 kept
+    # stale membership edge removed
+    assert await adapter.has_edge("Alice", "ns_ds1", "belongs_to_set") is False
+
+
+async def test_remove_belongs_to_set_tags_scoped_to_node_ids(adapter):
+    """With node_ids given, only those nodes are detagged."""
+    await adapter.add_nodes(
+        [
+            ("A", {"name": "A", "type": "Entity", "belongs_to_set": ["ds1"]}),
+            ("B", {"name": "B", "type": "Entity", "belongs_to_set": ["ds1"]}),
+        ]
+    )
+    await adapter.remove_belongs_to_set_tags(["ds1"], node_ids=["A"])
+
+    assert (await adapter.get_node("A"))["belongs_to_set"] == []
+    assert (await adapter.get_node("B"))["belongs_to_set"] == ["ds1"]  # untouched
 
 
 # --- unsupported surface ---------------------------------------------------

--- a/packages/graph/turbopuffer/tests/test_adapter_methods.py
+++ b/packages/graph/turbopuffer/tests/test_adapter_methods.py
@@ -101,6 +101,20 @@ async def test_add_and_has_edge(adapter):
     assert await adapter.has_edge("Alice", "WhiteRabbit", "loathes") is False
 
 
+async def test_large_node_property_not_truncated(adapter):
+    """A node property bigger than TurboPuffer's 4096-byte filterable-attribute
+    limit (e.g. a DocumentChunk's text) must round-trip intact — it lives in the
+    non-filterable `properties` blob and must not be clamped/corrupted."""
+    big_text = "wonderland " * 1200  # ~13KB, well over 4096 bytes
+
+    await adapter.add_nodes(
+        [("chunk1", {"name": "", "type": "DocumentChunk", "text": big_text})]
+    )
+    node = await adapter.get_node("chunk1")
+    assert node is not None
+    assert node["text"] == big_text  # full content preserved, not truncated
+
+
 async def test_add_edges_with_uuid_ids(adapter):
     """Real cognee node ids are UUIDs; the synthetic edge id must stay within
     TurboPuffer's 64-byte id limit (regression: "{src}__{rel}__{tgt}" with two

--- a/packages/graph/turbopuffer/tests/test_adapter_methods.py
+++ b/packages/graph/turbopuffer/tests/test_adapter_methods.py
@@ -101,6 +101,26 @@ async def test_add_and_has_edge(adapter):
     assert await adapter.has_edge("Alice", "WhiteRabbit", "loathes") is False
 
 
+async def test_add_edges_with_uuid_ids(adapter):
+    """Real cognee node ids are UUIDs; the synthetic edge id must stay within
+    TurboPuffer's 64-byte id limit (regression: "{src}__{rel}__{tgt}" with two
+    UUIDs is 83 bytes and 400s)."""
+    import uuid
+
+    s, t = str(uuid.uuid4()), str(uuid.uuid4())
+    await adapter.add_nodes(
+        [
+            (s, {"name": "Alice", "type": "Entity"}),
+            (t, {"name": "White Rabbit", "type": "Entity"}),
+        ]
+    )
+    await adapter.add_edge(s, t, "follows", {})
+
+    assert await adapter.has_edge(s, t, "follows") is True
+    edges = await adapter.get_edges(s)
+    assert any(e[0] == s and e[1] == t and e[2] == "follows" for e in edges)
+
+
 async def test_add_edges_batch_and_has_edges(adapter):
     await adapter.add_nodes(demo_node_tuples())
     edges = demo_edge_tuples()

--- a/packages/graph/turbopuffer/tests/test_adapter_methods.py
+++ b/packages/graph/turbopuffer/tests/test_adapter_methods.py
@@ -197,30 +197,39 @@ async def test_get_filtered_graph_data_by_type(adapter):
 # --- nodeset subgraph ------------------------------------------------------
 
 
-async def test_get_nodeset_subgraph_or(adapter):
-    from cognee.modules.engine.models import NodeSet  # type used by the retriever
+# get_nodeset_subgraph matches nodes whose `type` == node_type.__name__ (the
+# Postgres/Neo4j contract). The demo nodes are type "Person", so the probe type
+# must be named "Person".
+class Person:
+    pass
 
+
+async def test_get_nodeset_subgraph_or(adapter):
     await adapter.add_nodes(demo_node_tuples())
     await adapter.add_edges(demo_edge_tuples())
 
+    # node_name matches the node NAME (not id); demo names have spaces.
     nodes, edges = await adapter.get_nodeset_subgraph(
-        node_type=NodeSet, node_name=["Alice", "MadHatter"], node_name_filter_operator="OR"
+        node_type=Person, node_name=["Alice", "Mad Hatter"], node_name_filter_operator="OR"
     )
     node_ids = {n[0] for n in nodes}
+    # Both named primaries are returned (by id), plus their 1-hop neighbors.
     assert {"Alice", "MadHatter"} <= node_ids
 
 
 async def test_get_nodeset_subgraph_and(adapter):
-    from cognee.modules.engine.models import NodeSet
-
     await adapter.add_nodes(demo_node_tuples())
     await adapter.add_edges(demo_edge_tuples())
 
-    # AND mode: only neighbors connected to ALL named primaries (client-side intersection).
+    # AND mode: keep only neighbors connected to ALL named primaries.
+    # QueenOfHearts is the sole node linked to both Alice (summons->Alice) and
+    # WhiteRabbit (serves->QueenOfHearts); MadHatter links to Alice only.
     nodes, edges = await adapter.get_nodeset_subgraph(
-        node_type=NodeSet, node_name=["Alice"], node_name_filter_operator="AND"
+        node_type=Person, node_name=["Alice", "White Rabbit"], node_name_filter_operator="AND"
     )
-    assert isinstance(nodes, list)
+    node_ids = {n[0] for n in nodes}
+    assert {"Alice", "WhiteRabbit", "QueenOfHearts"} <= node_ids
+    assert "MadHatter" not in node_ids
 
 
 # --- metrics: counts real, traversal-dependent ones are -1 -----------------

--- a/packages/graph/turbopuffer/tests/test_adapter_methods.py
+++ b/packages/graph/turbopuffer/tests/test_adapter_methods.py
@@ -1,0 +1,300 @@
+"""Per-method contract tests for TurbopufferGraphAdapter.
+
+Mirrors cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py so the
+TurboPuffer graph adapter is held to the same behavior as the reference adapters,
+plus the v1-specific boundaries (no multi-hop BFS, no Cypher, no random-offset
+pagination, traversal-dependent metrics return -1).
+
+These run against a real TurboPuffer namespace (integration tier).
+"""
+
+import pytest
+
+from conftest import demo_node_tuples, demo_edge_tuples, requires_turbopuffer
+
+pytestmark = [pytest.mark.asyncio, requires_turbopuffer]
+
+
+# --- is_empty --------------------------------------------------------------
+
+
+async def test_is_empty_on_fresh_db(adapter):
+    assert await adapter.is_empty() is True
+
+
+async def test_not_empty_after_add(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    assert await adapter.is_empty() is False
+
+
+# --- nodes: add / get / delete --------------------------------------------
+
+
+async def test_add_and_get_node(adapter):
+    nodes = demo_node_tuples()
+    await adapter.add_nodes([nodes[0]])  # Alice
+
+    result = await adapter.get_node("Alice")
+    assert result is not None
+    assert result["id"] == "Alice"
+    assert result["name"] == "Alice"
+    assert result["type"] == "Person"
+
+
+async def test_get_node_missing_returns_none(adapter):
+    assert await adapter.get_node("Nonexistent") is None
+
+
+async def test_add_and_get_nodes(adapter):
+    nodes = demo_node_tuples()
+    await adapter.add_nodes(nodes)
+
+    ids = [n[0] for n in nodes]
+    results = await adapter.get_nodes(ids)
+    assert {r["id"] for r in results} == set(ids)
+
+
+async def test_add_nodes_is_idempotent_last_wins(adapter):
+    await adapter.add_nodes([("Alice", {"name": "Alice", "type": "Person", "description": "v1"})])
+    await adapter.add_nodes([("Alice", {"name": "Alice", "type": "Person", "description": "v2"})])
+
+    result = await adapter.get_node("Alice")
+    assert result["description"] == "v2"
+    # Upsert dedup: still a single node.
+    nodes, _ = await adapter.get_graph_data()
+    assert len([n for n in nodes if n[0] == "Alice"]) == 1
+
+
+async def test_delete_node(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.delete_node("CheshireCat")
+    assert await adapter.get_node("CheshireCat") is None
+
+
+async def test_delete_nodes_clears_graph(adapter):
+    nodes = demo_node_tuples()
+    await adapter.add_nodes(nodes)
+    await adapter.delete_nodes([n[0] for n in nodes])
+    assert await adapter.is_empty() is True
+
+
+async def test_delete_node_cascades_to_touching_edges(adapter):
+    """No FK in TurboPuffer — the adapter must manually delete edges that
+    reference a deleted node (both as source and as target)."""
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    # MadHatter is source of (MadHatter->CheshireCat) and target of (Alice->MadHatter).
+    await adapter.delete_node("MadHatter")
+
+    assert await adapter.has_edge("Alice", "MadHatter", "meets") is False
+    assert await adapter.has_edge("MadHatter", "CheshireCat", "knows") is False
+
+
+# --- edges: add / has ------------------------------------------------------
+
+
+async def test_add_and_has_edge(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edge("Alice", "WhiteRabbit", "follows", {})
+    assert await adapter.has_edge("Alice", "WhiteRabbit", "follows") is True
+    assert await adapter.has_edge("Alice", "WhiteRabbit", "loathes") is False
+
+
+async def test_add_edges_batch_and_has_edges(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    edges = demo_edge_tuples()
+    await adapter.add_edges(edges)
+
+    check = [(s, t, r) for (s, t, r, _) in edges]
+    existing = await adapter.has_edges(check)
+    assert len(existing) == len(edges)
+
+
+# --- single-hop reads ------------------------------------------------------
+
+
+async def test_get_edges(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    edges = await adapter.get_edges("Alice")
+    # Alice: out follows->WhiteRabbit, meets->MadHatter; in summons<-QueenOfHearts
+    assert len(edges) >= 2
+
+
+async def test_get_neighbors(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    neighbors = await adapter.get_neighbors("Alice")
+    neighbor_ids = {n["id"] for n in neighbors}
+    assert "WhiteRabbit" in neighbor_ids
+    assert "MadHatter" in neighbor_ids
+
+
+async def test_get_connections_returns_triples(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    connections = await adapter.get_connections("Alice")
+    assert len(connections) >= 1
+    for conn in connections:
+        assert len(conn) == 3  # (source_node, relationship_info, target_node)
+        source_node, rel_info, target_node = conn
+        assert "id" in source_node and "id" in target_node
+
+
+# --- neighborhood: depth=1 only (NO BFS in v1) -----------------------------
+
+
+async def test_get_neighborhood_depth1_ok(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    nodes, edges = await adapter.get_neighborhood(["Alice"], depth=1)
+    node_ids = {n[0] for n in nodes}
+    # Seed + direct neighbors present.
+    assert "Alice" in node_ids
+    assert {"WhiteRabbit", "MadHatter"} & node_ids
+    assert len(edges) >= 1
+
+
+async def test_get_neighborhood_depth2_raises(adapter):
+    """v1 explicitly does not implement multi-hop BFS."""
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    with pytest.raises(NotImplementedError):
+        await adapter.get_neighborhood(["Alice"], depth=2)
+
+
+# --- whole-graph reads -----------------------------------------------------
+
+
+async def test_get_graph_data(adapter):
+    nodes = demo_node_tuples()
+    edges = demo_edge_tuples()
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(edges)
+
+    got_nodes, got_edges = await adapter.get_graph_data()
+    assert len(got_nodes) == len(nodes)
+    assert len(got_edges) == len(edges)
+
+
+async def test_get_filtered_graph_data_by_type(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    persons, _ = await adapter.get_filtered_graph_data([{"type": ["Person"]}])
+    assert {n[0] for n in persons} == {"Alice", "WhiteRabbit", "QueenOfHearts", "MadHatter"}
+
+    animals, _ = await adapter.get_filtered_graph_data([{"type": ["Animal"]}])
+    assert {n[0] for n in animals} == {"CheshireCat"}
+
+
+# --- nodeset subgraph ------------------------------------------------------
+
+
+async def test_get_nodeset_subgraph_or(adapter):
+    from cognee.modules.engine.models import NodeSet  # type used by the retriever
+
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    nodes, edges = await adapter.get_nodeset_subgraph(
+        node_type=NodeSet, node_name=["Alice", "MadHatter"], node_name_filter_operator="OR"
+    )
+    node_ids = {n[0] for n in nodes}
+    assert {"Alice", "MadHatter"} <= node_ids
+
+
+async def test_get_nodeset_subgraph_and(adapter):
+    from cognee.modules.engine.models import NodeSet
+
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    # AND mode: only neighbors connected to ALL named primaries (client-side intersection).
+    nodes, edges = await adapter.get_nodeset_subgraph(
+        node_type=NodeSet, node_name=["Alice"], node_name_filter_operator="AND"
+    )
+    assert isinstance(nodes, list)
+
+
+# --- metrics: counts real, traversal-dependent ones are -1 -----------------
+
+
+async def test_get_graph_metrics_counts(adapter):
+    nodes = demo_node_tuples()
+    edges = demo_edge_tuples()
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(edges)
+
+    metrics = await adapter.get_graph_metrics()
+    assert metrics["num_nodes"] == len(nodes)
+    assert metrics["num_edges"] == len(edges)
+
+
+async def test_get_graph_metrics_traversal_fields_are_sentinel(adapter):
+    """Connectivity-dependent metrics need traversal we don't do in v1 — they
+    must return the -1 sentinel, exactly like the Postgres adapter does for
+    diameter/clustering."""
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    metrics = await adapter.get_graph_metrics(include_optional=True)
+    for field in ("num_connected_components", "diameter", "avg_shortest_path_length",
+                  "avg_clustering"):
+        if field in metrics:
+            assert metrics[field] == -1
+
+
+# --- triplets: sequential ok, random offset rejected -----------------------
+
+
+async def test_get_triplets_batch_sequential(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    edges = demo_edge_tuples()
+    await adapter.add_edges(edges)
+
+    triplets = await adapter.get_triplets_batch(offset=0, limit=10)
+    assert len(triplets) == len(edges)
+    for t in triplets:
+        assert "start_node" in t
+        assert "relationship_properties" in t
+        assert "end_node" in t
+
+
+async def test_get_triplets_batch_arbitrary_offset_raises(adapter):
+    """TurboPuffer is cursor-paginated, not offset-paginated. A nonzero offset
+    cannot be served efficiently, so v1 rejects it rather than scanning O(offset)."""
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+
+    with pytest.raises(NotImplementedError):
+        await adapter.get_triplets_batch(offset=5, limit=10)
+
+
+# --- unsupported surface ---------------------------------------------------
+
+
+async def test_raw_query_raises(adapter):
+    """No query language on TurboPuffer -> Cypher path is unsupported."""
+    with pytest.raises(NotImplementedError):
+        await adapter.query("MATCH (n) RETURN n", {})
+
+
+# --- lifecycle -------------------------------------------------------------
+
+
+async def test_delete_graph_empties_both_namespaces(adapter):
+    await adapter.add_nodes(demo_node_tuples())
+    await adapter.add_edges(demo_edge_tuples())
+    assert await adapter.is_empty() is False
+
+    await adapter.delete_graph()
+    assert await adapter.is_empty() is True
+    # edges gone too
+    assert await adapter.has_edge("Alice", "WhiteRabbit", "follows") is False

--- a/packages/graph/turbopuffer/tests/test_dataset_isolation.py
+++ b/packages/graph/turbopuffer/tests/test_dataset_isolation.py
@@ -1,0 +1,53 @@
+"""Per-dataset isolation: writes to one dataset must never be visible from
+another. Isolation is at the TurboPuffer namespace level (each dataset gets its
+own ``{database_name}_graph_node`` / ``_graph_edge`` namespaces), so this is the
+graph analog of the vector adapter's dataset handler guarantee.
+"""
+
+import uuid
+
+import pytest
+
+from conftest import demo_node_tuples, demo_edge_tuples, requires_turbopuffer
+from conftest import _make_adapter
+
+pytestmark = [pytest.mark.asyncio, requires_turbopuffer]
+
+
+async def test_two_datasets_are_isolated():
+    a = _make_adapter(f"tpuf_iso_a_{uuid.uuid4().hex[:8]}")
+    b = _make_adapter(f"tpuf_iso_b_{uuid.uuid4().hex[:8]}")
+    await a.initialize()
+    await b.initialize()
+    try:
+        await a.add_nodes(demo_node_tuples())
+        await a.add_edges(demo_edge_tuples())
+
+        # b shares no data with a.
+        assert await b.is_empty() is True
+        assert await b.get_node("Alice") is None
+        assert await b.has_edge("Alice", "WhiteRabbit", "follows") is False
+
+        # a still intact.
+        assert await a.get_node("Alice") is not None
+    finally:
+        await a.delete_graph()
+        await b.delete_graph()
+
+
+async def test_delete_graph_does_not_affect_other_dataset():
+    a = _make_adapter(f"tpuf_iso_c_{uuid.uuid4().hex[:8]}")
+    b = _make_adapter(f"tpuf_iso_d_{uuid.uuid4().hex[:8]}")
+    await a.initialize()
+    await b.initialize()
+    try:
+        await a.add_nodes(demo_node_tuples())
+        await b.add_nodes(demo_node_tuples())
+
+        await a.delete_graph()
+
+        assert await a.is_empty() is True
+        assert await b.is_empty() is False  # b untouched
+    finally:
+        await a.delete_graph()
+        await b.delete_graph()

--- a/packages/graph/turbopuffer/tests/test_dataset_isolation.py
+++ b/packages/graph/turbopuffer/tests/test_dataset_isolation.py
@@ -7,9 +7,7 @@ graph analog of the vector adapter's dataset handler guarantee.
 import uuid
 
 import pytest
-
-from conftest import demo_node_tuples, demo_edge_tuples, requires_turbopuffer
-from conftest import _make_adapter
+from conftest import _make_adapter, demo_edge_tuples, demo_node_tuples, requires_turbopuffer
 
 pytestmark = [pytest.mark.asyncio, requires_turbopuffer]
 

--- a/packages/graph/turbopuffer/tests/test_e2e_alice.py
+++ b/packages/graph/turbopuffer/tests/test_e2e_alice.py
@@ -1,0 +1,179 @@
+"""End-to-end pipeline test for the TurboPuffer graph adapter on Alice in Wonderland.
+
+Faithfully mirrors cognee/tests/e2e/postgres/test_graphdb_shared.py
+(``run_graph_db_test``) but:
+  - uses the TurboPuffer graph provider,
+  - loads ``alice_in_wonderland.txt`` as the source document,
+  - keeps the default vector backend (LanceDB) so this isolates the graph adapter.
+
+It walks the entire flow that production uses:
+  prune -> add(alice) -> assert graph empty before cognify -> cognify
+  -> assert graph populated -> vector lookup -> GRAPH_COMPLETION / CHUNKS /
+  SUMMARIES searches -> search-history accounting -> node_set filtering via
+  GraphCompletionRetriever -> prune -> assert empty.
+
+Requires TURBOPUFFER_API_KEY, LLM_API_KEY and COGNEE_TURBOPUFFER_GRAPH_E2E=1.
+"""
+
+import asyncio
+import os
+import shutil
+import pathlib
+
+import pytest
+
+from conftest import requires_e2e
+
+# Candidate locations for the Alice corpus (package-local first, then repo copies).
+_ALICE_CANDIDATES = [
+    pathlib.Path(__file__).parent / "data" / "alice_in_wonderland.txt",
+    pathlib.Path(__file__).parents[5] / "notebooks" / "data" / "alice_in_wonderland.txt",
+    pathlib.Path(__file__).parents[5]
+    / "examples" / "demos" / "simple_document_qa" / "data" / "alice_in_wonderland.txt",
+]
+
+
+def _resolve_alice_path() -> str:
+    env = os.getenv("ALICE_DATA_PATH")
+    if env and pathlib.Path(env).is_file():
+        return env
+    for c in _ALICE_CANDIDATES:
+        if c.is_file():
+            return str(c.resolve())
+    raise FileNotFoundError(
+        "alice_in_wonderland.txt not found. Set ALICE_DATA_PATH to point at it."
+    )
+
+
+async def run_alice_pipeline(provider: str = "turbopuffer"):
+    """Full add -> cognify -> search pipeline against the given graph provider."""
+    import cognee
+    from cognee_community_graph_adapter_turbopuffer import register
+    from cognee.infrastructure.files.storage import get_storage_config
+    from cognee.modules.engine.models import NodeSet
+    from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
+    from cognee.modules.search.types import SearchType
+    from cognee.modules.search.operations import get_history
+    from cognee.modules.users.methods import get_default_user
+    from cognee.infrastructure.databases.graph.config import get_graph_config
+    from cognee.base_config import get_base_config
+
+    register()  # make "turbopuffer" graph provider resolvable
+
+    base = pathlib.Path(__file__).parent
+    data_dir = str((base / f".data_storage/test_{provider}").resolve())
+    system_dir = str((base / f".cognee_system/test_{provider}").resolve())
+
+    graph_config = get_graph_config()
+    base_config = get_base_config()
+    prev_provider = graph_config.graph_database_provider
+    prev_data_root = base_config.data_root_directory
+    prev_system_root = base_config.system_root_directory
+
+    try:
+        cognee.config.set_graph_database_provider(provider)
+        cognee.config.data_root_directory(data_dir)
+        cognee.config.system_root_directory(system_dir)
+
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+
+        dataset_name = "wonderland"
+        alice_path = _resolve_alice_path()
+
+        from cognee.infrastructure.databases.graph import get_graph_engine
+
+        graph_engine = await get_graph_engine()
+
+        await cognee.add([alice_path], dataset_name)
+
+        # Graph empty before cognify.
+        assert await graph_engine.is_empty(), f"{provider}: graph should be empty before cognify"
+
+        # Full knowledge-graph construction (LLM extraction -> graph + vector).
+        await cognee.cognify([dataset_name])
+
+        assert not await graph_engine.is_empty(), (
+            f"{provider}: graph should not be empty after cognify"
+        )
+
+        # Pick a real node name out of the vector index to query the graph with.
+        from cognee.infrastructure.databases.vector import get_vector_engine
+
+        vector_engine = get_vector_engine()
+        random_node = (
+            await vector_engine.search("Entity_name", "Alice", include_payload=True)
+        )[0]
+        random_node_name = random_node.payload["text"]
+
+        # GRAPH_COMPLETION exercises the graph adapter's traversal/connection path.
+        results = await cognee.search(
+            query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
+        )
+        assert len(results) != 0, f"{provider}: GRAPH_COMPLETION returned no results"
+
+        # CHUNKS + SUMMARIES confirm overall pipeline integrity (vector path).
+        results = await cognee.search(query_type=SearchType.CHUNKS, query_text=random_node_name)
+        assert len(results) != 0, f"{provider}: CHUNKS returned no results"
+
+        results = await cognee.search(query_type=SearchType.SUMMARIES, query_text=random_node_name)
+        assert len(results) != 0, f"{provider}: SUMMARIES returned no results"
+
+        # 3 searches x (query + result) = 6 history rows.
+        user = await get_default_user()
+        history = await get_history(user.id)
+        assert len(history) == 6, f"{provider}: expected 6 history entries, got {len(history)}"
+
+        # node_set filtering through the retriever (exercises get_nodeset_subgraph).
+        await cognee.add(
+            ["The Cheshire Cat grinned at Alice from the tree."],
+            dataset_name,
+            node_set=["first"],
+        )
+        await cognee.cognify([dataset_name])
+
+        retriever = GraphCompletionRetriever(node_type=NodeSet, node_name=["first"])
+        objects = await retriever.get_retrieved_objects("What is in the context?")
+        context_nonempty = await retriever.get_context_from_objects(
+            query="What is in the context?", retrieved_objects=objects
+        )
+
+        retriever = GraphCompletionRetriever(node_type=NodeSet, node_name=["nonexistent"])
+        objects = await retriever.get_retrieved_objects("What is in the context?")
+        context_empty = await retriever.get_context_from_objects(
+            query="What is in the context?", retrieved_objects=objects
+        )
+
+        assert isinstance(context_nonempty, str) and context_nonempty != "", (
+            f"{provider}: expected non-empty context for existing node_set"
+        )
+        assert context_empty == "", (
+            f"{provider}: expected empty context for nonexistent node_set, got {context_empty!r}"
+        )
+
+        # Prune removes local data + empties the graph.
+        await cognee.prune.prune_data()
+        data_root = get_storage_config()["data_root_directory"]
+        assert not os.path.isdir(data_root), f"{provider}: local data files not deleted"
+
+        await cognee.prune.prune_system(metadata=True)
+        assert await graph_engine.is_empty(), f"{provider}: graph should be empty after prune"
+
+    finally:
+        cognee.config.set_graph_database_provider(prev_provider)
+        cognee.config.data_root_directory(prev_data_root)
+        cognee.config.system_root_directory(prev_system_root)
+        for path in (data_dir, system_dir):
+            if os.path.exists(path):
+                shutil.rmtree(path)
+
+
+@requires_e2e
+@pytest.mark.asyncio
+async def test_alice_full_pipeline():
+    await run_alice_pipeline("turbopuffer")
+
+
+if __name__ == "__main__":
+    # Allow running as a standalone script, like cognee's e2e entry points.
+    asyncio.run(run_alice_pipeline("turbopuffer"))

--- a/packages/graph/turbopuffer/tests/test_e2e_alice.py
+++ b/packages/graph/turbopuffer/tests/test_e2e_alice.py
@@ -17,11 +17,10 @@ Requires TURBOPUFFER_API_KEY, LLM_API_KEY and COGNEE_TURBOPUFFER_GRAPH_E2E=1.
 
 import asyncio
 import os
-import shutil
 import pathlib
+import shutil
 
 import pytest
-
 from conftest import requires_e2e
 
 # Candidate locations for the Alice corpus (package-local first, then repo copies).
@@ -29,7 +28,11 @@ _ALICE_CANDIDATES = [
     pathlib.Path(__file__).parent / "data" / "alice_in_wonderland.txt",
     pathlib.Path(__file__).parents[5] / "notebooks" / "data" / "alice_in_wonderland.txt",
     pathlib.Path(__file__).parents[5]
-    / "examples" / "demos" / "simple_document_qa" / "data" / "alice_in_wonderland.txt",
+    / "examples"
+    / "demos"
+    / "simple_document_qa"
+    / "data"
+    / "alice_in_wonderland.txt",
 ]
 
 
@@ -48,15 +51,15 @@ def _resolve_alice_path() -> str:
 async def run_alice_pipeline(provider: str = "turbopuffer"):
     """Full add -> cognify -> search pipeline against the given graph provider."""
     import cognee
-    from cognee_community_graph_adapter_turbopuffer import register
+    from cognee.base_config import get_base_config
+    from cognee.infrastructure.databases.graph.config import get_graph_config
     from cognee.infrastructure.files.storage import get_storage_config
     from cognee.modules.engine.models import NodeSet
     from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
-    from cognee.modules.search.types import SearchType
     from cognee.modules.search.operations import get_history
+    from cognee.modules.search.types import SearchType
     from cognee.modules.users.methods import get_default_user
-    from cognee.infrastructure.databases.graph.config import get_graph_config
-    from cognee.base_config import get_base_config
+    from cognee_community_graph_adapter_turbopuffer import register
 
     register()  # make "turbopuffer" graph provider resolvable
 
@@ -101,9 +104,7 @@ async def run_alice_pipeline(provider: str = "turbopuffer"):
         from cognee.infrastructure.databases.vector import get_vector_engine
 
         vector_engine = get_vector_engine()
-        random_node = (
-            await vector_engine.search("Entity_name", "Alice", include_payload=True)
-        )[0]
+        random_node = (await vector_engine.search("Entity_name", "Alice", include_payload=True))[0]
         random_node_name = random_node.payload["text"]
 
         # GRAPH_COMPLETION exercises the graph adapter's traversal/connection path.

--- a/packages/graph/turbopuffer/tests/test_kg.json
+++ b/packages/graph/turbopuffer/tests/test_kg.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Deterministic Wonderland demo graph for unit/integration tests. Mirrors the structure of cognee/tests/integration/infrastructure/graph/test_kg.json (id/name/type/description nodes; source_node_id/target_node_id/relationship_name edges). Two node types (Person, Animal) so get_filtered_graph_data can be exercised. Alice is a hub node (multiple in/out edges) for get_neighbors/get_connections.",
+  "nodes": [
+    { "id": "Alice", "name": "Alice", "type": "Person", "description": "The curious girl who falls down the rabbit hole." },
+    { "id": "WhiteRabbit", "name": "White Rabbit", "type": "Person", "description": "The anxious rabbit Alice follows." },
+    { "id": "QueenOfHearts", "name": "Queen of Hearts", "type": "Person", "description": "The tyrannical ruler of Wonderland." },
+    { "id": "MadHatter", "name": "Mad Hatter", "type": "Person", "description": "Host of the perpetual tea party." },
+    { "id": "CheshireCat", "name": "Cheshire Cat", "type": "Animal", "description": "The grinning cat who can vanish." }
+  ],
+  "edges": [
+    { "source_node_id": "Alice", "target_node_id": "WhiteRabbit", "relationship_name": "follows" },
+    { "source_node_id": "Alice", "target_node_id": "MadHatter", "relationship_name": "meets" },
+    { "source_node_id": "WhiteRabbit", "target_node_id": "QueenOfHearts", "relationship_name": "serves" },
+    { "source_node_id": "MadHatter", "target_node_id": "CheshireCat", "relationship_name": "knows" },
+    { "source_node_id": "QueenOfHearts", "target_node_id": "Alice", "relationship_name": "summons" }
+  ]
+}

--- a/packages/graph/turbopuffer/tests/test_registration.py
+++ b/packages/graph/turbopuffer/tests/test_registration.py
@@ -6,8 +6,6 @@ factory uses (``database_name=...``, no ``connection_string``). These are pure
 unit tests — no network, always run.
 """
 
-import pytest
-
 from cognee_community_graph_adapter_turbopuffer import TurbopufferGraphAdapter, register
 
 
@@ -16,6 +14,24 @@ def test_register_adds_turbopuffer_provider():
     from cognee.infrastructure.databases.graph.supported_databases import supported_databases
 
     assert supported_databases["turbopuffer"] is TurbopufferGraphAdapter
+
+
+def test_register_adds_graph_dataset_handler_under_graph_specific_key():
+    """The dataset handler must register under "turbopuffer_graph" (not the bare
+    "turbopuffer" key the vector adapter uses) so the two don't overwrite each
+    other in cognee's shared registry."""
+    from cognee_community_graph_adapter_turbopuffer.TurbopufferGraphDatasetDatabaseHandler import (
+        TurbopufferGraphDatasetDatabaseHandler,
+    )
+
+    register()
+    from cognee.infrastructure.databases.dataset_database_handler import (
+        supported_dataset_database_handlers,
+    )
+
+    entry = supported_dataset_database_handlers["turbopuffer_graph"]
+    assert entry["handler_instance"] is TurbopufferGraphDatasetDatabaseHandler
+    assert entry["handler_provider"] == "turbopuffer"
 
 
 def test_factory_shaped_construction_accepts_database_name():

--- a/packages/graph/turbopuffer/tests/test_registration.py
+++ b/packages/graph/turbopuffer/tests/test_registration.py
@@ -1,0 +1,54 @@
+"""Registration and factory-construction contract.
+
+Mirrors the pggraph community adapter tests: the adapter must register under a
+provider name and must accept the keyword shape cognee's ``_create_graph_engine``
+factory uses (``database_name=...``, no ``connection_string``). These are pure
+unit tests — no network, always run.
+"""
+
+import pytest
+
+from cognee_community_graph_adapter_turbopuffer import TurbopufferGraphAdapter, register
+
+
+def test_register_adds_turbopuffer_provider():
+    register()
+    from cognee.infrastructure.databases.graph.supported_databases import supported_databases
+
+    assert supported_databases["turbopuffer"] is TurbopufferGraphAdapter
+
+
+def test_factory_shaped_construction_accepts_database_name():
+    """cognee's factory passes the per-dataset name under ``database_name`` and
+    the API key under ``graph_database_key``. Construction must not require a
+    live client (lazy connect)."""
+    inst = TurbopufferGraphAdapter(
+        graph_database_url="gcp-us-east4",
+        graph_database_username="",
+        graph_database_password="",
+        graph_database_port="",
+        graph_database_key="tpuf-fake-key",
+        database_name="dataset_abc",
+    )
+    # The per-dataset prefix drives namespace naming.
+    assert inst.database_name == "dataset_abc"
+
+
+def test_explicit_graph_database_name_takes_priority_over_database_name():
+    inst = TurbopufferGraphAdapter(
+        graph_database_name="explicit",
+        database_name="from_factory",
+        graph_database_key="tpuf-fake-key",
+    )
+    assert inst.database_name == "explicit"
+
+
+def test_namespace_names_are_prefixed_per_dataset():
+    """Two logical collections (graph_node, graph_edge) per dataset, prefixed by
+    database_name so datasets are isolated at the namespace level."""
+    inst = TurbopufferGraphAdapter(database_name="ds1", graph_database_key="k")
+    node_ns = inst._namespace_name("graph_node")
+    edge_ns = inst._namespace_name("graph_edge")
+    assert node_ns == "ds1_graph_node"
+    assert edge_ns == "ds1_graph_edge"
+    assert node_ns != edge_ns


### PR DESCRIPTION
## What

Adds a community **graph** adapter for TurboPuffer at `packages/graph/turbopuffer/`. TurboPuffer is a vector/search store with no graph primitives, so the graph is **emulated on namespaces + attributes** — the same approach the core Postgres graph adapter takes on relational tables — and the packaging/registration/per-dataset-isolation patterns are reused from the existing TurboPuffer **vector** adapter.

This PR is the **test-first skeleton**: the full `GraphDBInterface` contract is pinned by a test suite that mirrors the existing adapter tests, and the adapter methods are stubbed to the v1 boundaries. A follow-up implements the methods until the suite goes green.

## Storage model (per dataset, namespace-prefixed by `database_name`)

- `{db}_graph_node` — `id`, `name`, `type`, `belongs_to_set[]`, `degree`, `properties` (json)
- `{db}_graph_edge` — `id = "{src}__{rel}__{tgt}"`, `source_id`/`target_id`, `relationship_name`, **denormalized endpoint identity** (`source_name/type`, `target_name/type`), `properties` (json)

The edge endpoint denormalization makes single-hop reads (`get_neighbors`/`get_connections`/`get_edges`) resolve in **one query with no hydration round-trip**.

## v1 scope

**Implemented:** CRUD, single-hop reads, `get_neighborhood(depth=1)`, `get_graph_data`, `get_filtered_graph_data`, `get_nodeset_subgraph` (OR + client-side AND), metrics counts + mean degree, `get_triplets_batch(offset=0)`, `delete_graph`.

**Deliberately not in v1** (assert `NotImplementedError`): multi-hop BFS (`get_neighborhood` depth≥2), Cypher (`query`), random-offset pagination (`get_triplets_batch` offset>0). Connectivity-dependent metrics (components/diameter/clustering) return the `-1` sentinel, matching the Postgres adapter.

## Tests (the spec)

| File | Mirrors |
|---|---|
| `test_adapter_methods.py` | `test_kuzu_adapter.py` — per-method contract |
| `test_registration.py` | pggraph tests — register + factory-shape construction (no network) |
| `test_e2e_alice.py` | `test_graphdb_shared.py` — full add→cognify→`GRAPH_COMPLETION`/`CHUNKS`/`SUMMARIES`→nodeset→prune, on **Alice in Wonderland** |
| `test_dataset_isolation.py` | namespace-level per-dataset isolation |

Tiers are env-gated (`COGNEE_TURBOPUFFER_GRAPH_TESTS` / `COGNEE_TURBOPUFFER_GRAPH_E2E`); registration/contract tests run with no network. See `tests/README.md`.

## State

Red, as intended: registration + boundary tests pass; behavioral tests fail with `NotImplementedError` until the adapter is implemented.

## Open questions for implementation

1. Exact TurboPuffer **row-level delete** signature (vector adapter only ever calls `delete_all()`).
2. Whether namespaces accept **vectorless** node/edge docs (pure-graph storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)