### PR TITLE
fix(falkordb): coerce non-primitive node property values before binding (fixes #118)

### DIFF
--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -107,31 +107,60 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         self.api_key = api_key
 
     @staticmethod
-    def _sanitize_cypher_params(params: dict) -> dict:
-        """Recursively convert Enum values to their underlying value.
+    def _coerce_param_value(value: Any) -> Any:
+        """Coerce a single query-param value to a FalkorDB-acceptable type.
 
-        FalkorDB serializes unknown types via ``str()``, which turns
-        ``MyEnum.member`` into ``"MyEnum.member"`` – an invalid Cypher
-        literal.  This helper ensures every Enum is replaced by its
-        ``.value`` before the params reach the driver.
+        FalkorDB query parameters accept only primitives (``str``/``int``/
+        ``float``/``bool``/``None``) and arrays of those primitives. Any other
+        value makes FalkorDB reject the *entire* query — and since node writes
+        bind every node property as the ``$properties`` map, one stray value
+        aborts the whole pipeline run. The two failure modes are:
+
+        - ``bytes`` -> ``ResponseError: Failed to parse query parameter
+          'properties' value``; and
+        - nested mappings / arrays containing non-primitives -> ``ResponseError:
+          Property values can only be of primitive types or arrays of primitive
+          types``.
+
+        Coerce such values to a JSON/text representation so they survive the
+        write instead of failing it. ``Enum`` is unwrapped to its ``.value``.
+        """
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, Enum):
+            return value.value
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        if isinstance(value, (list, tuple)):
+            coerced = [FalkorDBAdapter._coerce_param_value(item) for item in value]
+            # FalkorDB arrays must hold primitives (and reject null elements);
+            # if any element isn't one, store the whole array as a JSON string.
+            if all(
+                item is not None and isinstance(item, (bool, int, float, str))
+                for item in coerced
+            ):
+                return coerced
+            return json.dumps(value, default=str)
+        if isinstance(value, dict):
+            return json.dumps(value, default=str)
+        return str(value)
+
+    @staticmethod
+    def _sanitize_cypher_params(params: dict) -> dict:
+        """Make a params dict safe for FalkorDB.
+
+        Recurses into nested mappings (so the bound property map keeps its
+        structure and nested ``Enum``s are unwrapped) and routes every other
+        value through :meth:`_coerce_param_value`, which converts ``bytes`` and
+        other non-primitive types FalkorDB can't bind (they would otherwise
+        reject the whole query and abort the pipeline run).
         """
         sanitized = {}
         for key, value in params.items():
             if isinstance(value, dict):
                 sanitized[key] = FalkorDBAdapter._sanitize_cypher_params(value)
-            elif isinstance(value, Enum):
-                sanitized[key] = value.value
-            elif isinstance(value, list):
-                sanitized[key] = [
-                    item.value
-                    if isinstance(item, Enum)
-                    else FalkorDBAdapter._sanitize_cypher_params(item)
-                    if isinstance(item, dict)
-                    else item
-                    for item in value
-                ]
             else:
-                sanitized[key] = value
+                sanitized[key] = FalkorDBAdapter._coerce_param_value(value)
         return sanitized
 
     # TODO: This should return a list of results, not a single result

--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -107,23 +107,22 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         self.api_key = api_key
 
     @staticmethod
-    def _coerce_param_value(value: Any) -> Any:
-        """Coerce a single query-param value to a FalkorDB-acceptable type.
+    def _coerce_stored_value(value: Any) -> Any:
+        """Coerce a value that will be STORED as a node/edge property.
 
-        FalkorDB query parameters accept only primitives (``str``/``int``/
-        ``float``/``bool``/``None``) and arrays of those primitives. Any other
-        value makes FalkorDB reject the *entire* query — and since node writes
-        bind every node property as the ``$properties`` map, one stray value
-        aborts the whole pipeline run. The two failure modes are:
+        FalkorDB property values must be primitives or arrays of primitives. A
+        map, a non-primitive array, or a ``bytes`` value makes FalkorDB reject the
+        *entire* query — and since writes bind the property bag as ``$properties``
+        / each ``UNWIND``-ed ``$items`` element, one stray value aborts the whole
+        pipeline run. The failure modes are:
 
         - ``bytes`` -> ``ResponseError: Failed to parse query parameter
           'properties' value``; and
-        - nested mappings / arrays containing non-primitives -> ``ResponseError:
-          Property values can only be of primitive types or arrays of primitive
-          types``.
+        - maps / arrays containing non-primitives -> ``ResponseError: Property
+          values can only be of primitive types or arrays of primitive types``.
 
-        Coerce such values to a JSON/text representation so they survive the
-        write instead of failing it. ``Enum`` is unwrapped to its ``.value``.
+        JSON-encode maps and non-primitive arrays, decode ``bytes``, and unwrap
+        ``Enum`` to its ``.value`` so the value survives the write.
         """
         if value is None or isinstance(value, (bool, int, float, str)):
             return value
@@ -132,7 +131,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         if isinstance(value, bytes):
             return value.decode("utf-8", errors="replace")
         if isinstance(value, (list, tuple)):
-            coerced = [FalkorDBAdapter._coerce_param_value(item) for item in value]
+            coerced = [FalkorDBAdapter._coerce_stored_value(item) for item in value]
             # FalkorDB arrays must hold primitives (and reject null elements);
             # if any element isn't one, store the whole array as a JSON string.
             if all(
@@ -146,22 +145,46 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         return str(value)
 
     @staticmethod
-    def _sanitize_cypher_params(params: dict) -> dict:
-        """Make a params dict safe for FalkorDB.
+    def _coerce_param_value(value: Any) -> Any:
+        """Coerce a bound query-param value, PRESERVING the structure FalkorDB
+        needs.
 
-        Recurses into nested mappings (so the bound property map keeps its
-        structure and nested ``Enum``s are unwrapped) and routes every other
-        value through :meth:`_coerce_param_value`, which converts ``bytes`` and
-        other non-primitive types FalkorDB can't bind (they would otherwise
-        reject the whole query and abort the pipeline run).
+        Maps and arrays-of-maps are valid *bound params* — e.g. an
+        ``UNWIND $items AS item ... SET edge += item`` edge batch binds a list of
+        maps — so this keeps that shape. A record map keeps its keys, but its
+        values are primitivized via :meth:`_coerce_stored_value` (they get stored
+        as properties). Flattening a list of maps to JSON strings (as a blanket
+        coercion would) makes the ``UNWIND`` fail with ``Type mismatch: expected
+        Map ... but was String``. ``bytes`` / ``Enum`` outside a record map are
+        still coerced.
         """
-        sanitized = {}
-        for key, value in params.items():
-            if isinstance(value, dict):
-                sanitized[key] = FalkorDBAdapter._sanitize_cypher_params(value)
-            else:
-                sanitized[key] = FalkorDBAdapter._coerce_param_value(value)
-        return sanitized
+        if isinstance(value, dict):
+            return {
+                key: FalkorDBAdapter._coerce_stored_value(val)
+                for key, val in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [FalkorDBAdapter._coerce_param_value(item) for item in value]
+        if isinstance(value, Enum):
+            return value.value
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        return value
+
+    @staticmethod
+    def _sanitize_cypher_params(params: dict) -> dict:
+        """Make a bound-params dict safe for FalkorDB.
+
+        Routes every value through :meth:`_coerce_param_value` (structure-
+        preserving), which primitivizes the values that get stored as properties
+        via :meth:`_coerce_stored_value`. Without this a ``bytes`` value or a
+        nested map/array in a model-extracted entity rejects the whole query and
+        aborts the pipeline run.
+        """
+        return {
+            key: FalkorDBAdapter._coerce_param_value(value)
+            for key, value in params.items()
+        }
 
     # TODO: This should return a list of results, not a single result
     async def query(self, query: str, params: dict = None) -> list:

--- a/packages/hybrid/falkordb/tests/test_sanitize_params.py
+++ b/packages/hybrid/falkordb/tests/test_sanitize_params.py
@@ -66,3 +66,47 @@ def test_mixed_complex():
         "tags": ["green", "manual"],
         "nested": {"priority": 1, "value": 42},
     }
+
+
+def test_bytes_value_decoded():
+    # bytes would otherwise make FalkorDB reject the whole query with
+    # "Failed to parse query parameter 'properties' value".
+    result = FalkorDBAdapter._sanitize_cypher_params({"blob": b"abc"})
+    assert result == {"blob": "abc"}
+
+
+def test_bytes_value_in_property_map_decoded():
+    result = FalkorDBAdapter._sanitize_cypher_params(
+        {"properties": {"name": "ok", "raw": b"\xe2\x9c\x93 done"}}
+    )
+    assert result == {"properties": {"name": "ok", "raw": "✓ done"}}
+
+
+def test_primitive_array_preserved():
+    params = {"nums": [1, 2, 3], "words": ["a", "b"]}
+    result = FalkorDBAdapter._sanitize_cypher_params(params)
+    assert result == params
+
+
+def test_dict_array_elements_stringified():
+    # dict elements aren't valid FalkorDB array members -> each becomes a JSON
+    # string, keeping a (now-primitive) array FalkorDB accepts.
+    result = FalkorDBAdapter._sanitize_cypher_params({"items": [{"k": 1}, {"k": 2}]})
+    assert result == {"items": ['{"k": 1}', '{"k": 2}']}
+
+
+def test_array_with_null_json_encoded():
+    # FalkorDB rejects null elements inside arrays; the array can't be made
+    # all-primitive, so the whole array is stored as a JSON string instead.
+    result = FalkorDBAdapter._sanitize_cypher_params({"tags": ["a", None]})
+    assert result == {"tags": '["a", null]'}
+
+
+def test_coerce_param_value_helper():
+    coerce = FalkorDBAdapter._coerce_param_value
+    assert coerce(b"hi") == "hi"
+    assert coerce("x") == "x"
+    assert coerce(7) == 7
+    assert coerce(None) is None
+    assert coerce([1, 2]) == [1, 2]
+    assert coerce(Color.RED) == "red"

--- a/packages/hybrid/falkordb/tests/test_sanitize_params.py
+++ b/packages/hybrid/falkordb/tests/test_sanitize_params.py
@@ -88,18 +88,42 @@ def test_primitive_array_preserved():
     assert result == params
 
 
-def test_dict_array_elements_stringified():
-    # dict elements aren't valid FalkorDB array members -> each becomes a JSON
-    # string, keeping a (now-primitive) array FalkorDB accepts.
-    result = FalkorDBAdapter._sanitize_cypher_params({"items": [{"k": 1}, {"k": 2}]})
-    assert result == {"items": ['{"k": 1}', '{"k": 2}']}
+def test_bound_list_of_maps_preserved_for_unwind():
+    # A list of maps bound as a param (e.g. the `UNWIND $items AS item ... SET
+    # edge += item` edge batch) MUST stay a list of maps — JSON-stringifying the
+    # elements makes FalkorDB fail with "Type mismatch: expected Map ... but was
+    # String". The element maps' values are still primitivized (they get stored).
+    result = FalkorDBAdapter._sanitize_cypher_params(
+        {"items": [{"edge_index": 0, "props": {"w": 1}}, {"edge_index": 1}]}
+    )
+    assert result == {
+        "items": [{"edge_index": 0, "props": '{"w": 1}'}, {"edge_index": 1}]
+    }
 
 
-def test_array_with_null_json_encoded():
-    # FalkorDB rejects null elements inside arrays; the array can't be made
-    # all-primitive, so the whole array is stored as a JSON string instead.
-    result = FalkorDBAdapter._sanitize_cypher_params({"tags": ["a", None]})
-    assert result == {"tags": '["a", null]'}
+def test_stored_map_value_json_encoded():
+    # A map *value* inside the stored $properties bag can't be a property value,
+    # so it is JSON-encoded.
+    result = FalkorDBAdapter._sanitize_cypher_params(
+        {"properties": {"meta": {"a": 1}, "name": "ok"}}
+    )
+    assert result == {"properties": {"meta": '{"a": 1}', "name": "ok"}}
+
+
+def test_stored_array_of_maps_json_encoded():
+    # An array of maps as a stored property value becomes an array of JSON strings
+    # (a valid array-of-primitives).
+    result = FalkorDBAdapter._sanitize_cypher_params(
+        {"properties": {"objs": [{"k": 1}, {"k": 2}]}}
+    )
+    assert result == {"properties": {"objs": ['{"k": 1}', '{"k": 2}']}}
+
+
+def test_stored_array_with_null_json_encoded():
+    # FalkorDB rejects null elements inside a stored array; it can't be made
+    # all-primitive, so the whole array becomes a JSON string.
+    result = FalkorDBAdapter._sanitize_cypher_params({"properties": {"tags": ["a", None]}})
+    assert result == {"properties": {"tags": '["a", null]'}}
 
 
 def test_coerce_param_value_helper():
@@ -110,3 +134,14 @@ def test_coerce_param_value_helper():
     assert coerce(None) is None
     assert coerce([1, 2]) == [1, 2]
     assert coerce(Color.RED) == "red"
+    # a bound map keeps its structure; its values are primitivized for storage
+    assert coerce({"a": 1, "b": {"c": 2}}) == {"a": 1, "b": '{"c": 2}'}
+
+
+def test_coerce_stored_value_helper():
+    stored = FalkorDBAdapter._coerce_stored_value
+    assert stored(b"hi") == "hi"
+    assert stored({"a": 1}) == '{"a": 1}'
+    assert stored([1, 2]) == [1, 2]
+    assert stored([{"k": 1}]) == ['{"k": 1}']
+    assert stored(Color.RED) == "red"


### PR DESCRIPTION
## What

Fixes #118 — a single non-primitive node property value aborts the entire `cognify` pipeline run on the FalkorDB adapter.

`FalkorDBAdapter.create_data_point_query` binds every node property as the `$properties` map, but `_sanitize_cypher_params` only unwrapped `Enum`s. Values FalkorDB can't accept as parameters slipped through to the driver:

- **`bytes`** → `ResponseError: Failed to parse query parameter 'properties' value`
- **nested mappings / arrays containing non-primitives (or `null`)** → `ResponseError: Property values can only be of primitive types or arrays of primitive types`

Because this raises during `add_data_points`, the whole pipeline run errors and a re-run hits the same record and fails again.

## Change

- New `_coerce_param_value` helper: leaves primitives (`str`/`int`/`float`/`bool`/`None`) untouched, unwraps `Enum` → `.value`, decodes `bytes` → `str`, coerces array elements (falling back to a JSON string when an array can't be made all-primitive, e.g. it contains `null`), and JSON-encodes any other mapping/object.
- `_sanitize_cypher_params` still recurses into nested mappings (so the bound property map keeps its structure and nested `Enum`s are still unwrapped) and routes every other value through the helper.

The adapter already had a robust string serializer (`stringify_properties`/`parse_value`), but it's only used on the inlined **edge** path; this brings equivalent safety to the **node** param path centrally, so both `create_data_point_query` variants are covered.

## Repro (before)

```python
from falkordb import FalkorDB
g = FalkorDB(host="localhost", port=6379).select_graph("repro")
g.query("MERGE (n:T {id:$id}) SET n += $properties",
        {"id": "1", "properties": {"p": b"abc"}})
# ResponseError: Failed to parse query parameter 'properties' value
```

After the fix, `b"abc"` is bound as `"abc"` and the write succeeds.

## Tests

Extended `tests/test_sanitize_params.py` (pure unit tests, no FalkorDB connection) with cases for `bytes`, bytes inside a property map, primitive arrays (unchanged), dict-array elements, null-in-array, and the `_coerce_param_value` helper. All existing Enum tests still pass.
