### PR TITLE
Fix: Allow Milvus to create vector embeddings in custom db

### DIFF
--- a/packages/vector/milvus/cognee_community_vector_adapter_milvus/milvus_adapter.py
+++ b/packages/vector/milvus/cognee_community_vector_adapter_milvus/milvus_adapter.py
@@ -51,7 +51,7 @@ class MilvusAdapter:
         url: str,
         api_key: str | None,
         embedding_engine: EmbeddingEngine,
-        database_name: str = "cognee",
+        database_name: str = "",
     ):
         self.url = url
         self.api_key = api_key
@@ -91,9 +91,9 @@ class MilvusAdapter:
 
         if not self.client:
             if self.api_key:
-                self.client = MilvusClient(uri=self.url, token=self.api_key)
+                self.client = MilvusClient(uri=self.url, token=self.api_key, db_name=self.database_name)
             else:
-                self.client = MilvusClient(uri=self.url)
+                self.client = MilvusClient(uri=self.url, db_name=self.database_name)
 
         return self.client
 


### PR DESCRIPTION
 Updated milvus adapter code to accept and pass the user-defined database parameter. Default value of db name is the empty string. Users can now successfully isolate and create vector embeddings within their custom databases.
