### PR TITLE
fix(memgraph): compute get_graph_metrics from graph data

### DIFF
--- a/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/memgraph_adapter.py
+++ b/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/memgraph_adapter.py
@@ -20,6 +20,58 @@ from neo4j.exceptions import Neo4jError
 logger = get_logger("MemgraphAdapter", level=ERROR)
 
 
+def weakly_connected_component_sizes(
+    node_ids: list[Any], edges: list[tuple[Any, Any]]
+) -> list[int]:
+    """Return the sizes of the graph's weakly connected components, largest first.
+
+    The graph is treated as undirected (edge direction is ignored), so this matches
+    the "weakly connected component" definition. Nodes without any edge form their
+    own singleton component. Edge endpoints that are not present in ``node_ids`` are
+    ignored defensively.
+
+    Implemented as a self-contained union-find so component statistics are computed
+    in-process and do not depend on a graph-algorithm extension being installed.
+
+    Parameters:
+    -----------
+
+        - node_ids (list[Any]): Identifiers of every node in the graph.
+        - edges (list[tuple[Any, Any]]): ``(source, target)`` endpoint pairs.
+
+    Returns:
+    --------
+
+        - list[int]: Component sizes ordered from largest to smallest.
+    """
+    parent = {node_id: node_id for node_id in node_ids}
+
+    def find(node):
+        root = node
+        while parent[root] != root:
+            root = parent[root]
+        # Path compression keeps repeated lookups cheap on large graphs.
+        while parent[node] != root:
+            parent[node], node = root, parent[node]
+        return root
+
+    def union(left, right):
+        left_root, right_root = find(left), find(right)
+        if left_root != right_root:
+            parent[left_root] = right_root
+
+    for source, target in edges:
+        if source in parent and target in parent:
+            union(source, target)
+
+    sizes: dict[Any, int] = {}
+    for node_id in node_ids:
+        root = find(node_id)
+        sizes[root] = sizes.get(root, 0) + 1
+
+    return sorted(sizes.values(), reverse=True)
+
+
 class MemgraphAdapter(GraphDBInterface):
     """
     Handles interaction with a Memgraph database through various graph operations.
@@ -1179,93 +1231,41 @@ class MemgraphAdapter(GraphDBInterface):
         """
 
         try:
-            # Basic metrics
-            node_count = await self.query("MATCH (n) RETURN count(n)")
-            edge_count = await self.query("MATCH ()-[r]->() RETURN count(r)")
-            num_nodes = node_count[0][0] if node_count else 0
-            num_edges = edge_count[0][0] if edge_count else 0
+            # Pull the full node/edge set once via the model-independent accessor.
+            # Metrics are then computed in-process: the previous Cypher relied on
+            # ``:Node``/``:EDGE`` labels (copied from the Kuzu adapter) that this
+            # adapter never writes, and indexed dict-shaped results positionally,
+            # so every metric silently collapsed to the all-zeros fallback below.
+            nodes, edges = await self.get_graph_data()
 
-            # Calculate mandatory metrics
+            node_ids = [node_id for node_id, _ in nodes]
+            edge_endpoints = [(source, target) for source, target, *_ in edges]
+
+            num_nodes = len(node_ids)
+            num_edges = len(edge_endpoints)
+
+            component_sizes = weakly_connected_component_sizes(node_ids, edge_endpoints)
+
             mandatory_metrics = {
                 "num_nodes": num_nodes,
                 "num_edges": num_edges,
                 "mean_degree": (2 * num_edges) / num_nodes if num_nodes > 0 else 0,
-                "edge_density": (num_edges) / (num_nodes * (num_nodes - 1)) if num_nodes > 1 else 0,
+                "edge_density": num_edges / (num_nodes * (num_nodes - 1)) if num_nodes > 1 else 0,
+                "num_connected_components": len(component_sizes),
+                "sizes_of_connected_components": component_sizes,
             }
 
-            # Calculate connected components
-            components_query = """
-            MATCH (n:Node)
-            WITH n.id AS node_id
-            MATCH path = (n)-[:EDGE*0..]-()
-            WITH COLLECT(DISTINCT node_id) AS component
-            RETURN COLLECT(component) AS components
-            """
-            components_result = await self.query(components_query)
-            component_sizes = (
-                [len(comp) for comp in components_result[0][0]] if components_result else []
-            )
-
-            mandatory_metrics.update(
-                {
-                    "num_connected_components": len(component_sizes),
-                    "sizes_of_connected_components": component_sizes,
-                }
-            )
-
             if include_optional:
-                # Self-loops
-                self_loops_query = """
-                MATCH (n:Node)-[r:EDGE]->(n)
-                RETURN COUNT(r)
-                """
-                self_loops = await self.query(self_loops_query)
-                num_selfloops = self_loops[0][0] if self_loops else 0
-
-                # Shortest paths (simplified for Kuzu)
-                paths_query = """
-                MATCH (n:Node), (m:Node)
-                WHERE n.id < m.id
-                MATCH path = (n)-[:EDGE*]-(m)
-                RETURN MIN(LENGTH(path)) AS length
-                """
-                paths = await self.query(paths_query)
-                path_lengths = [p[0] for p in paths if p[0] is not None]
-
-                # Local clustering coefficient
-                clustering_query = """
-                /// Step 1: Get each node with its neighbors and degree
-                MATCH (n:Node)-[:EDGE]-(neighbor)
-                WITH n, COLLECT(DISTINCT neighbor) AS neighbors, COUNT(DISTINCT neighbor) AS degree
-
-                // Step 2: Pair up neighbors and check if they are connected
-                UNWIND neighbors AS n1
-                UNWIND neighbors AS n2
-                WITH n, degree, n1, n2
-                WHERE id(n1) < id(n2)  // avoid duplicate pairs
-
-                // Step 3: Use OPTIONAL MATCH to see if n1 and n2 are connected
-                OPTIONAL MATCH (n1)-[:EDGE]-(n2)
-                WITH n, degree, COUNT(n2) AS triangle_count
-
-                // Step 4: Compute local clustering coefficient
-                WITH n, degree,
-                    CASE WHEN degree <= 1 THEN 0.0
-                        ELSE (1.0 * triangle_count) / (degree * (degree - 1) / 2.0)
-                    END AS local_cc
-
-                // Step 5: Compute average
-                RETURN AVG(local_cc) AS avg_clustering_coefficient
-                """
-                clustering = await self.query(clustering_query)
-
+                num_selfloops = sum(1 for source, target in edge_endpoints if source == target)
                 optional_metrics = {
                     "num_selfloops": num_selfloops,
-                    "diameter": max(path_lengths) if path_lengths else -1,
-                    "avg_shortest_path_length": sum(path_lengths) / len(path_lengths)
-                    if path_lengths
-                    else -1,
-                    "avg_clustering": clustering[0][0] if clustering and clustering[0][0] else -1,
+                    # diameter, avg_shortest_path_length and avg_clustering require
+                    # all-pairs traversals that are prohibitively expensive on large
+                    # graphs, so they are reported as unsupported (-1) — matching the
+                    # Neptune community/core adapter.
+                    "diameter": -1,
+                    "avg_shortest_path_length": -1,
+                    "avg_clustering": -1,
                 }
             else:
                 optional_metrics = {

--- a/packages/graph/memgraph/examples/example.py
+++ b/packages/graph/memgraph/examples/example.py
@@ -77,6 +77,13 @@ async def main():
     print("\nDirect graph data:")
     pprint.pprint(graph_data)
 
+    # Descriptive graph metrics computed from the live graph. These previously
+    # collapsed to an all-zeros fallback for Memgraph; they now report real counts,
+    # connected-component sizes and self-loops.
+    print("\nGraph metrics:")
+    graph_metrics = await graph_engine.get_graph_metrics(include_optional=True)
+    pprint.pprint(graph_metrics)
+
     # Or visualize it in HTML
     print("\nVisualizing the graph...")
     await cognee.visualize_graph(system_path / "graph.html")

--- a/packages/graph/memgraph/tests/test_graph_metrics.py
+++ b/packages/graph/memgraph/tests/test_graph_metrics.py
@@ -1,0 +1,108 @@
+"""Unit tests for Memgraph graph-metrics computation.
+
+These tests exercise the pure component helper and ``get_graph_metrics()`` with a
+stubbed ``get_graph_data()``, so they run without a live Memgraph instance.
+
+Regression coverage for the bug where ``get_graph_metrics()`` filtered on
+``:Node``/``:EDGE`` labels the adapter never writes and indexed dict-shaped query
+results positionally, making every metric collapse to the all-zeros fallback.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee_community_graph_adapter_memgraph.memgraph_adapter import (
+    MemgraphAdapter,
+    weakly_connected_component_sizes,
+)
+
+
+def _make_adapter(nodes, edges):
+    """Build a MemgraphAdapter without touching the DB, stubbing get_graph_data()."""
+    adapter = MemgraphAdapter.__new__(MemgraphAdapter)
+    adapter.get_graph_data = AsyncMock(return_value=(nodes, edges))
+    return adapter
+
+
+# --------------------------------------------------------------------------- #
+# weakly_connected_component_sizes
+# --------------------------------------------------------------------------- #
+
+
+def test_component_sizes_two_components():
+    sizes = weakly_connected_component_sizes([1, 2, 3, 4, 5], [(1, 2), (2, 3), (4, 5)])
+    assert sizes == [3, 2]
+
+
+def test_component_sizes_singletons():
+    assert weakly_connected_component_sizes([1, 2, 3], []) == [1, 1, 1]
+
+
+def test_component_sizes_treats_edges_as_undirected():
+    assert weakly_connected_component_sizes([1, 2], [(2, 1)]) == [2]
+
+
+def test_component_sizes_empty():
+    assert weakly_connected_component_sizes([], []) == []
+
+
+def test_component_sizes_ignores_unknown_endpoints():
+    # An edge referencing a node id that is not in the node list must not crash.
+    assert weakly_connected_component_sizes([1, 2], [(1, 99)]) == [1, 1]
+
+
+def test_component_sizes_self_loop_stays_singleton():
+    assert weakly_connected_component_sizes([1, 2], [(1, 1)]) == [1, 1]
+
+
+# --------------------------------------------------------------------------- #
+# get_graph_metrics
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_get_graph_metrics_connected_graph():
+    nodes = [(1, {}), (2, {}), (3, {})]
+    edges = [(1, 2, "REL", {}), (2, 3, "REL", {})]
+    metrics = await _make_adapter(nodes, edges).get_graph_metrics()
+
+    assert metrics["num_nodes"] == 3
+    assert metrics["num_edges"] == 2
+    assert metrics["num_connected_components"] == 1
+    assert metrics["sizes_of_connected_components"] == [3]
+    assert metrics["mean_degree"] == pytest.approx(4 / 3)
+    assert metrics["edge_density"] == pytest.approx(2 / (3 * 2))
+    # Optional metrics are off by default.
+    assert metrics["num_selfloops"] == -1
+    assert metrics["diameter"] == -1
+
+
+@pytest.mark.asyncio
+async def test_get_graph_metrics_disconnected_with_selfloop():
+    # Components: {1, 2}, {3} (self-loop), {4} (isolated).
+    nodes = [(1, {}), (2, {}), (3, {}), (4, {})]
+    edges = [(1, 2, "REL", {}), (3, 3, "REL", {})]
+    metrics = await _make_adapter(nodes, edges).get_graph_metrics(include_optional=True)
+
+    assert metrics["num_nodes"] == 4
+    assert metrics["num_edges"] == 2
+    assert metrics["num_connected_components"] == 3
+    assert metrics["sizes_of_connected_components"] == [2, 1, 1]
+    assert metrics["num_selfloops"] == 1
+    # Expensive all-pairs metrics remain unsupported.
+    assert metrics["diameter"] == -1
+    assert metrics["avg_shortest_path_length"] == -1
+    assert metrics["avg_clustering"] == -1
+
+
+@pytest.mark.asyncio
+async def test_get_graph_metrics_empty_graph():
+    metrics = await _make_adapter([], []).get_graph_metrics()
+
+    assert metrics["num_nodes"] == 0
+    assert metrics["num_edges"] == 0
+    assert metrics["mean_degree"] == 0
+    assert metrics["edge_density"] == 0
+    assert metrics["num_connected_components"] == 0
+    assert metrics["sizes_of_connected_components"] == []


### PR DESCRIPTION
## Description

`MemgraphAdapter.get_graph_metrics()` returned all-zero / fallback metrics for any non-empty graph. This PR computes the metrics correctly from the live graph and adds both unit tests and end-to-end CI coverage.

Closes #122.

**Root causes (all three fixed):**

1. **Positional indexing of dict-shaped results** — `node_count[0][0]` raised `KeyError` (`query()` returns dicts keyed by the `RETURN` name), which the broad `except` swallowed,returning the all-zeros fallback.
3. **Label/relationship filters the adapter never writes** — the metric queries filtered on `MATCH (n:Node)` / `[:EDGE]` (copied from the Kuzu adapter), but this adapter writes unlabeled nodes and real relationship-typed edges, so every labelled query matched nothing.
4. **Broken connected-components aggregation** — after `WITH n.id AS node_id`, `n` went out of scope and was rebound to the whole graph, collapsing every node into a single component.

**What changed:**

- **`memgraph_adapter.py`** — compute metrics in-process from `get_graph_data()`:
  - `num_nodes`, `num_edges`, `mean_degree`, `edge_density`
  - connected components via a self-contained **union-find** helper (`weakly_connected_component_sizes`)
  - `num_selfloops` from edge endpoints
  - `diameter`, `avg_shortest_path_length`, `avg_clustering` reported as unsupported (`-1`), matching the Neptune adapter (cognee#3171), since they need prohibitively expensive all-pairs traversals.
- **`tests/test_graph_metrics.py`** — unit tests for the component helper and `get_graph_metrics()` with a stubbed `get_graph_data()` (no live Memgraph required).
- **`examples/example.py`** — call `get_graph_metrics(include_optional=True)` so the Memgraph CI workflow (which runs `examples/example.py`) exercises the corrected path  end-to-end against a live instance.

**Testing:**

- `pytest tests/test_graph_metrics.py` → **9 passed** (against cognee 1.2.x).
- `ruff check` → passed on all changed files.
- `examples/example.py` now prints real, non-zero metrics on a live Memgraph run.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
