### PR TITLE
fix(falkordb): deserialize node metadata on read so round-trip doesn't lose dicts

### DIFF
--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -658,7 +658,13 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
             SET node += $properties, node.updated_at = timestamp()
             """).strip()
 
-        index_fields = (properties.get("metadata") or {}).get("index_fields", [])
+        node_metadata = properties.get("metadata")
+        if isinstance(node_metadata, str):
+            try:
+                node_metadata = json.loads(node_metadata)
+            except (ValueError, TypeError):
+                node_metadata = None
+        index_fields = (node_metadata or {}).get("index_fields", [])
         for field in index_fields:
             vector_key = f"{field}_vector"
             if vector_key in properties and properties[vector_key] is not None:
@@ -1172,6 +1178,32 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         )
         return results
 
+    @staticmethod
+    def _deserialize_node_properties(properties: Dict[str, Any]) -> Dict[str, Any]:
+        """Restore dict-valued node properties that the write path JSON-encoded.
+
+        FalkorDB stores only primitive property values, so ``add_node`` and
+        ``_coerce_stored_value`` ``json.dumps`` any dict-valued property (notably
+        ``metadata``) before persisting it. cognee core, however, treats
+        ``metadata`` as a dict — e.g. ``DataPoint.get_embeddable_property_names``
+        does ``metadata["index_fields"]``. Any code that reads a node back and
+        feeds it to core therefore needs ``metadata`` as a dict again; the cognee
+        1.2.0 ``namespace_entity_type_node_ids`` graph migration is the first such
+        path (it round-trips ``get_graph_data`` output through ``add_nodes``) and
+        otherwise raises ``TypeError: string indices must be integers``.
+
+        Scoped to ``metadata`` to avoid mangling legitimate string properties
+        (e.g. ``name``/``text``) that may happen to look like JSON. Non-string or
+        malformed values are left untouched, so this is safe and idempotent.
+        """
+        metadata = properties.get("metadata")
+        if isinstance(metadata, str):
+            try:
+                properties["metadata"] = json.loads(metadata)
+            except (ValueError, TypeError):
+                pass
+        return properties
+
     async def get_graph_data(
         self,
     ) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[Tuple[str, str, str, Dict[str, Any]]]]:
@@ -1190,7 +1222,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         nodes = [
             (
                 record[2]["id"],
-                record[2],
+                self._deserialize_node_properties(record[2]),
             )
             for record in result.result_set
         ]

--- a/packages/hybrid/falkordb/tests/test_metadata_roundtrip.py
+++ b/packages/hybrid/falkordb/tests/test_metadata_roundtrip.py
@@ -1,0 +1,63 @@
+"""Unit tests for node metadata deserialization on read.
+
+FalkorDB stores only primitive property values, so the adapter ``json.dumps``
+any dict-valued property (notably ``metadata``) on write (``add_node`` /
+``_coerce_stored_value``). cognee core, however, treats ``metadata`` as a dict
+— e.g. ``DataPoint.get_embeddable_property_names`` does
+``metadata["index_fields"]``. The read path therefore has to restore it.
+
+The cognee 1.2.0 ``namespace_entity_type_node_ids`` migration is the first code
+path to round-trip ``get_graph_data`` output back through ``add_nodes``; before
+this fix it crashed with ``TypeError: string indices must be integers, not str``
+because ``metadata`` came back as a JSON string.
+
+No FalkorDB connection is required.
+"""
+
+import json
+
+from cognee_community_hybrid_adapter_falkor.falkor_adapter import FalkorDBAdapter
+
+
+def test_metadata_json_string_is_deserialized():
+    stored = {
+        "id": "n1",
+        "name": "Entity A",
+        "metadata": json.dumps({"index_fields": ["name"], "type": "Entity"}),
+    }
+    result = FalkorDBAdapter._deserialize_node_properties(stored)
+    assert result["metadata"] == {"index_fields": ["name"], "type": "Entity"}
+    # The exact access that crashed the 1.2.0 migration now works:
+    assert result["metadata"]["index_fields"] == ["name"]
+
+
+def test_non_string_metadata_is_untouched():
+    # Idempotent / forward-compatible: a dict metadata (future adapter) is left as-is.
+    already = {"id": "n1", "metadata": {"index_fields": ["name"]}}
+    result = FalkorDBAdapter._deserialize_node_properties(already)
+    assert result["metadata"] == {"index_fields": ["name"]}
+
+
+def test_missing_metadata_is_untouched():
+    props = {"id": "n1", "name": "Entity A"}
+    result = FalkorDBAdapter._deserialize_node_properties(props)
+    assert result == {"id": "n1", "name": "Entity A"}
+
+
+def test_malformed_metadata_is_left_as_is():
+    # Not valid JSON -> tolerate rather than raise.
+    props = {"id": "n1", "metadata": "not json {"}
+    result = FalkorDBAdapter._deserialize_node_properties(props)
+    assert result["metadata"] == "not json {"
+
+
+def test_only_metadata_is_parsed():
+    # Scoped to metadata: a string property that happens to look like JSON is untouched.
+    props = {
+        "id": "n1",
+        "name": "{not metadata}",
+        "metadata": json.dumps({"index_fields": []}),
+    }
+    result = FalkorDBAdapter._deserialize_node_properties(props)
+    assert result["name"] == "{not metadata}"
+    assert result["metadata"] == {"index_fields": []}

--- a/packages/hybrid/falkordb/tests/test_metadata_roundtrip_integration.py
+++ b/packages/hybrid/falkordb/tests/test_metadata_roundtrip_integration.py
@@ -1,0 +1,60 @@
+"""Integration test: a node's dict `metadata` round-trips as a dict through a real FalkorDB.
+
+This exercises the path the cognee 1.2.0 `namespace_entity_type_node_ids` migration
+uses: write a node whose `metadata` is a dict, then read it back via `get_graph_data`.
+Before the fix, `metadata` came back as a JSON string and the migration's `add_nodes`
+raised `TypeError: string indices must be integers, not 'str'`.
+
+Requires a FalkorDB at localhost:6379 (skipped otherwise):
+    docker run --rm -d -p 6379:6379 falkordb/falkordb:latest
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from cognee_community_hybrid_adapter_falkor.falkor_adapter import FalkorDBAdapter
+
+
+def _falkordb_available() -> bool:
+    try:
+        from falkordb import FalkorDB
+
+        FalkorDB(host="localhost", port=6379).list_graphs()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _falkordb_available(),
+    reason="needs FalkorDB at localhost:6379 (docker run -p 6379:6379 falkordb/falkordb:latest)",
+)
+
+
+@pytest.mark.asyncio
+async def test_metadata_roundtrips_as_dict_through_falkordb():
+    adapter = FalkorDBAdapter(
+        graph_database_url="localhost",
+        graph_database_port=6379,
+        embedding_engine=MagicMock(),  # avoids get_embedding_engine(); no embedding happens here
+        database_name="metadata_roundtrip_itest",
+    )
+
+    await adapter.add_node(
+        "n1",
+        {
+            "id": "n1",
+            "type": "Entity",
+            "name": "Example",
+            "metadata": {"index_fields": ["name"], "type": "Entity"},
+        },
+    )
+
+    nodes, _ = await adapter.get_graph_data()
+
+    node = next(n for n in nodes if n[0] == "n1")
+    metadata = node[1]["metadata"]
+    assert isinstance(metadata, dict), (
+        f"metadata came back as {type(metadata).__name__}, expected dict"
+    )
+    assert metadata["index_fields"] == ["name"]


### PR DESCRIPTION
## Description
The adapter json.dumps dict-valued node properties (notably metadata) on  write, like via add_node or  _coerce_stored_value,  but never deserializes them on read, so `get_graph_data` returns `metadata` as a JSON string. That's breaking because cognee core expects `metadata` to be a dict: `DataPoint.get_embeddable_property_names` reads the key `metadata["index_fields"]`, and reading a key on a string raises `TypeError`. So any path that reads a node back and hands it to core breaks.

The fix is to deserialize metadata back to a dict in get_graph_data (inverse of the write), scoped to that key and tolerant of non-string/malformed values. Also harden add_node's index_fields read against a string metadata. Finally, it adds regression tests.

Fixes https://github.com/topoteretes/cognee/issues/3314

  ## Testing
  **Unit tests** (no FalkorDB needed):
<img width="1695" height="1076" alt="image" src="https://github.com/user-attachments/assets/74559baa-f518-4861-890a-b1c240410f33" />


**Integration test** (against a Docker FalkorDB):

<img width="1699" height="1090" alt="image" src="https://github.com/user-attachments/assets/6b0492db-2a41-43bf-b65a-1dff5f4d7c49" />

  ## Notes
ruff check passes and the changed lines are `ruff format` clean. The format-check job is red from a pre-existing issue on main (introduced by #119, commit f442408), unrelated to this change. A separate downstream add_edges blocker remains, filed as topoteretes/cognee#3324.

  ## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.