### PR TITLE
feat: add ClickHouse vector adapter

### DIFF
--- a/.github/workflows/test_clickhouse.yml
+++ b/.github/workflows/test_clickhouse.yml
@@ -1,0 +1,156 @@
+name: Test ClickHouse Community Adapter
+
+on:
+  workflow_call:
+    inputs:
+      event-type:
+        required: false
+        type: string
+        default: "regular-testing-event"
+    secrets:
+      LLM_MODEL:
+        required: true
+      LLM_ENDPOINT:
+        required: true
+      LLM_API_KEY:
+        required: true
+      LLM_API_VERSION:
+        required: true
+      EMBEDDING_MODEL:
+        required: true
+      EMBEDDING_ENDPOINT:
+        required: true
+      EMBEDDING_API_KEY:
+        required: true
+      EMBEDDING_API_VERSION:
+        required: true
+  workflow_dispatch:
+  pull_request:
+    branches: [ main, dev ]
+    paths:
+      - 'packages/vector/clickhouse/**'
+      - '.github/workflows/test_clickhouse.yml'
+      - '.github/workflows/vector_db_community_tests.yml'
+
+concurrency:
+  group: clickhouse-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+env:
+  VECTOR_DB_PROVIDER: clickhouse
+  VECTOR_DATASET_DATABASE_HANDLER: clickhouse
+  VECTOR_DB_URL: http://127.0.0.1:8123/cognee
+  VECTOR_DB_NAME: cognee
+  CLICKHOUSE_HOST: 127.0.0.1
+  CLICKHOUSE_PORT: 8123
+  CLICKHOUSE_DATABASE: cognee
+  CLICKHOUSE_USERNAME: default
+  CLICKHOUSE_PASSWORD: ''
+  CLICKHOUSE_SECURE: 'false'
+
+jobs:
+  run-clickhouse-example:
+    name: "ClickHouse Community Adapter Example"
+    runs-on: ubuntu-22.04
+    services:
+      clickhouse:
+        image: clickhouse/clickhouse-server:25.8
+        env:
+          CLICKHOUSE_DB: cognee
+          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+        ports:
+          - 8123:8123
+          - 9000:9000
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Community Setup
+        uses: ./.github/actions/community_setup
+        with:
+          python-version: '3.11.x'
+          package-path: packages/vector/clickhouse
+          event-type: ${{ inputs.event-type }}
+
+      - name: Wait for ClickHouse
+        run: |
+          for i in {1..60}; do
+            if curl -fsS "http://127.0.0.1:8123/ping"; then
+              curl -fsS "http://127.0.0.1:8123/" \
+                --data-binary "CREATE DATABASE IF NOT EXISTS cognee"
+              exit 0
+            fi
+            echo "ClickHouse not ready yet... (attempt $i/60)"
+            sleep 2
+          done
+          exit 1
+
+      - name: Run ClickHouse Example
+        env:
+          ENV: 'dev'
+          ENABLE_BACKEND_ACCESS_CONTROL: False
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_ENDPOINT: ${{ secrets.EMBEDDING_ENDPOINT }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+          EMBEDDING_API_VERSION: ${{ secrets.EMBEDDING_API_VERSION }}
+          CLICKHOUSE_URL: http://127.0.0.1:8123/cognee
+          CLICKHOUSE_KEY: ''
+        working-directory: ./packages/vector/clickhouse
+        run: poetry run python example.py
+
+  test-clickhouse:
+    name: "ClickHouse Community Adapter Test"
+    runs-on: ubuntu-22.04
+    services:
+      clickhouse:
+        image: clickhouse/clickhouse-server:25.8
+        env:
+          CLICKHOUSE_DB: cognee
+          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+        ports:
+          - 8123:8123
+          - 9000:9000
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Community Setup
+        uses: ./.github/actions/community_setup
+        with:
+          python-version: '3.11.x'
+          package-path: packages/vector/clickhouse
+          event-type: ${{ inputs.event-type }}
+
+      - name: Wait for ClickHouse
+        run: |
+          for i in {1..60}; do
+            if curl -fsS "http://127.0.0.1:8123/ping"; then
+              curl -fsS "http://127.0.0.1:8123/" \
+                --data-binary "CREATE DATABASE IF NOT EXISTS cognee"
+              exit 0
+            fi
+            echo "ClickHouse not ready yet... (attempt $i/60)"
+            sleep 2
+          done
+          exit 1
+
+      - name: Run ClickHouse Tests
+        env:
+          ENV: 'dev'
+          ENABLE_BACKEND_ACCESS_CONTROL: False
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_ENDPOINT: ${{ secrets.EMBEDDING_ENDPOINT }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+          EMBEDDING_API_VERSION: ${{ secrets.EMBEDDING_API_VERSION }}
+          CLICKHOUSE_URL: http://127.0.0.1:8123/cognee
+          CLICKHOUSE_KEY: ''
+        working-directory: ./packages/vector/clickhouse
+        run: poetry run pytest tests/test_clickhouse.py

--- a/.github/workflows/vector_db_community_tests.yml
+++ b/.github/workflows/vector_db_community_tests.yml
@@ -83,6 +83,14 @@ jobs:
     uses: ./.github/workflows/test_singlestore.yml
     secrets: inherit
 
+  test-clickhouse:
+    name: "ClickHouse Community Adapter Test"
+    if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'clickhouse') }}
+    with:
+      event-type: ${{ inputs.event-type }}
+    uses: ./.github/workflows/test_clickhouse.yml
+    secrets: inherit
+
   test-valkey:
     name: "Valkey Community Adapter Test"
     if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'valkey') }}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ poetry run python ./examples/example.py
 | Package Name                                 | Type     | Description                                        |
 |----------------------------------------------|----------|----------------------------------------------------|
 | `cognee-community-vector-adapter-azure`      | Vector   | Azure AI search vector database adapter for cognee |
+| `cognee-community-vector-adapter-clickhouse` | Vector   | ClickHouse vector database adapter for cognee      |
 | `cognee-community-vector-adapter-milvus`     | Vector   | Milvus vector database adapter for cognee          |
 | `cognee-community-vector-adapter-opensearch` | Vector   | Opensearch vector database adapter for cognee      |
 | `cognee-community-vector-adapter-pinecone`   | Vector   | Pinecone vector database adapter for cognee        |

--- a/packages/vector/clickhouse/.env.example
+++ b/packages/vector/clickhouse/.env.example
@@ -1,0 +1,48 @@
+# ClickHouse connection
+VECTOR_DB_PROVIDER=clickhouse
+VECTOR_DATASET_DATABASE_HANDLER=clickhouse
+VECTOR_DB_URL=http://127.0.0.1:8123/cognee
+CLICKHOUSE_URL=http://127.0.0.1:8123/cognee
+CLICKHOUSE_KEY=
+
+# Individual connection fields (used when CLICKHOUSE_URL is not set)
+# CLICKHOUSE_HOST=127.0.0.1
+# CLICKHOUSE_PORT=8123
+# CLICKHOUSE_DATABASE=cognee
+# CLICKHOUSE_USERNAME=default
+# CLICKHOUSE_PASSWORD=
+# CLICKHOUSE_SECURE=false
+
+# ClickHouse Cloud (HTTPS on port 8443)
+# CLICKHOUSE_HOST=<service-host>.clickhouse.cloud
+# CLICKHOUSE_PORT=8443
+# CLICKHOUSE_DATABASE=cognee
+# CLICKHOUSE_USERNAME=default
+# CLICKHOUSE_PASSWORD=<password>
+# CLICKHOUSE_SECURE=true
+
+# LLM — required by example.py and test_cognee_recall_flow
+LLM_PROVIDER=openai
+LLM_MODEL=openai/gpt-4o-mini
+LLM_API_KEY=
+LLM_ENDPOINT=
+LLM_API_VERSION=
+
+# Embeddings — fastembed runs locally with no API key
+EMBEDDING_PROVIDER=fastembed
+EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+EMBEDDING_DIMENSIONS=384
+EMBEDDING_API_KEY=not-needed-for-fastembed
+EMBEDDING_ENDPOINT=
+EMBEDDING_API_VERSION=
+
+# Cognee local testing helpers
+COGNEE_SKIP_CONNECTION_TEST=true
+ENABLE_BACKEND_ACCESS_CONTROL=false
+
+# Optional adapter tuning (defaults shown)
+# COGNEE_CLICKHOUSE_TABLE_PREFIX=cognee_vec_
+# COGNEE_CLICKHOUSE_NORMALIZE_VECTORS=true
+# COGNEE_CLICKHOUSE_ENABLE_VECTOR_INDEX=false
+# COGNEE_CLICKHOUSE_VECTOR_INDEX_GRANULARITY=100000000
+# COGNEE_CLICKHOUSE_VECTOR_INDEX_NAME=idx_vector

--- a/packages/vector/clickhouse/README.md
+++ b/packages/vector/clickhouse/README.md
@@ -1,0 +1,312 @@
+# Cognee ClickHouse Adapter
+
+ClickHouse vector database adapter for Cognee. Cognee remains the memory and orchestration layer; ClickHouse stores embeddings, payload metadata, and dataset-scoped vector rows.
+
+The adapter uses the official `clickhouse-connect` Python client, ClickHouse `Array(Float32)` vectors, exact `dotProduct` search, and optional ClickHouse `vector_similarity` indexes for approximate cosine search on ClickHouse 25.8+.
+
+## Installation
+
+If published, install the package with pip:
+
+```bash
+pip install cognee-community-vector-adapter-clickhouse
+```
+
+For local development, install from this package directory:
+
+```bash
+pip install poetry
+poetry install
+```
+
+## Register The Adapter
+
+Import the `register` module before using Cognee so the provider is available:
+
+```python
+from cognee_community_vector_adapter_clickhouse import register  # noqa: F401
+```
+
+Configure Cognee:
+
+```python
+import os
+
+from cognee import config
+
+os.environ.setdefault("VECTOR_DATASET_DATABASE_HANDLER", "clickhouse")
+
+config.set_vector_db_config(
+    {
+        "vector_db_provider": "clickhouse",
+        "vector_db_url": os.getenv("CLICKHOUSE_URL", "http://127.0.0.1:8123/cognee"),
+        "vector_db_key": os.getenv("CLICKHOUSE_KEY", ""),
+    }
+)
+```
+
+## Local Docker
+
+Start ClickHouse and create the physical database used by the adapter:
+
+```bash
+docker run -d --name clickhouse-cognee \
+  -e CLICKHOUSE_DB=cognee \
+  -p 8123:8123 -p 9000:9000 \
+  clickhouse/clickhouse-server:25.8
+```
+
+Set connection variables:
+
+```bash
+export VECTOR_DB_PROVIDER=clickhouse
+export VECTOR_DATASET_DATABASE_HANDLER=clickhouse
+
+export VECTOR_DB_URL=http://127.0.0.1:8123/cognee
+export VECTOR_DB_NAME=cognee
+export CLICKHOUSE_HOST=127.0.0.1
+export CLICKHOUSE_PORT=8123
+export CLICKHOUSE_DATABASE=cognee
+export CLICKHOUSE_USERNAME=default
+export CLICKHOUSE_PASSWORD=
+export CLICKHOUSE_SECURE=false
+```
+
+The adapter does not create the physical ClickHouse database outside Docker's `CLICKHOUSE_DB` bootstrap path. For existing servers, create it first:
+
+```bash
+curl -sS "http://127.0.0.1:8123/" --data-binary "CREATE DATABASE IF NOT EXISTS cognee"
+```
+
+## ClickHouse Cloud
+
+ClickHouse Cloud uses HTTPS on port 8443:
+
+```bash
+export VECTOR_DB_PROVIDER=clickhouse
+export VECTOR_DATASET_DATABASE_HANDLER=clickhouse
+
+export CLICKHOUSE_HOST="<service-host>.clickhouse.cloud"
+export CLICKHOUSE_PORT=8443
+export CLICKHOUSE_DATABASE=cognee
+export CLICKHOUSE_USERNAME=default
+export CLICKHOUSE_PASSWORD="<password>"
+export CLICKHOUSE_SECURE=true
+```
+
+Do not commit credentials or customer data in `.env` files.
+
+## Environment Variables
+
+```dotenv
+VECTOR_DB_PROVIDER=clickhouse
+VECTOR_DATASET_DATABASE_HANDLER=clickhouse
+
+# Either use a URL:
+VECTOR_DB_URL=http://127.0.0.1:8123/cognee
+
+# Or individual fields (fallbacks if CLICKHOUSE_URL is not set):
+CLICKHOUSE_HOST=127.0.0.1
+CLICKHOUSE_PORT=8123
+CLICKHOUSE_DATABASE=cognee
+CLICKHOUSE_USERNAME=default
+CLICKHOUSE_PASSWORD=
+CLICKHOUSE_SECURE=false
+
+# Advanced TLS / connection options
+# CLICKHOUSE_COMPRESS=false
+# CLICKHOUSE_VERIFY=true
+# CLICKHOUSE_CA_CERT=
+# CLICKHOUSE_CLIENT_CERT=
+# CLICKHOUSE_CLIENT_CERT_KEY=
+# CLICKHOUSE_CONNECT_TIMEOUT=10
+# CLICKHOUSE_SEND_RECEIVE_TIMEOUT=300
+
+# Optional Cognee-owned table prefix.
+COGNEE_CLICKHOUSE_TABLE_PREFIX=cognee_vec_
+
+# Optional. Enabled by default so dotProduct behaves like cosine similarity.
+COGNEE_CLICKHOUSE_NORMALIZE_VECTORS=true
+
+# Optional approximate vector index. Requires ClickHouse 25.8+.
+COGNEE_CLICKHOUSE_ENABLE_VECTOR_INDEX=false
+COGNEE_CLICKHOUSE_VECTOR_INDEX_GRANULARITY=100000000
+COGNEE_CLICKHOUSE_VECTOR_INDEX_NAME=idx_vector
+
+# Set explicitly if your embedding model produces a non-standard size.
+# EMBEDDING_DIMENSIONS=384
+```
+
+`VECTOR_DB_NAME` or `CLICKHOUSE_DATABASE` is the physical ClickHouse database. Cognee's dataset database handler stores each Cognee dataset using a separate vector engine `database_name`; the adapter writes that value to a `database_name` column for row-level dataset isolation.
+
+`VECTOR_DB_KEY` / `CLICKHOUSE_KEY` may be a raw password or JSON:
+
+```json
+{"username":"default","password":"secret","database":"cognee","secure":true}
+```
+
+## LLM And Embedding Providers
+
+Cognee needs an LLM for graph extraction and an embedding provider for vector storage. Cursor subscription credentials are not used by Cognee; configure provider API credentials in your shell or `.env`.
+
+### OpenAI
+
+```bash
+export LLM_PROVIDER=openai
+export LLM_MODEL=openai/gpt-4o-mini
+export LLM_API_KEY="<openai-api-key>"
+unset LLM_ENDPOINT LLM_API_VERSION
+
+export EMBEDDING_PROVIDER=openai
+export EMBEDDING_MODEL=openai/text-embedding-3-small
+export EMBEDDING_API_KEY="$LLM_API_KEY"
+export EMBEDDING_DIMENSIONS=1536
+unset EMBEDDING_ENDPOINT EMBEDDING_API_VERSION
+```
+
+### Local Embeddings With fastembed (no API key needed)
+
+The `fastembed` provider runs entirely locally using ONNX models downloaded from Hugging Face. No API key is required for embeddings:
+
+```bash
+poetry run pip install fastembed
+
+export EMBEDDING_PROVIDER=fastembed
+export EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+export EMBEDDING_DIMENSIONS=384
+```
+
+Pair with any LLM provider for the graph extraction step.
+
+### OpenAI-Compatible APIs
+
+For any OpenAI-compatible endpoint (e.g. Featherless, local vLLM):
+
+```bash
+export LLM_PROVIDER=openai
+export LLM_MODEL="openai/<model-id>"
+export LLM_API_KEY="<api-key>"
+export LLM_ENDPOINT="https://<host>/v1"
+export LLM_API_VERSION=""
+export LLM_INSTRUCTOR_MODE=json_mode
+export LLM_MAX_COMPLETION_TOKENS=2048
+
+export OPENAI_API_KEY="$LLM_API_KEY"
+export OPENAI_BASE_URL="$LLM_ENDPOINT"
+```
+
+Verify model availability:
+
+```bash
+curl -sS "$LLM_ENDPOINT/models" \
+  -H "Authorization: Bearer $LLM_API_KEY" | jq -r '.data[].id'
+```
+
+Plain chat support is not enough for Cognee; the endpoint/model must also work with Cognee's `instructor` structured-output path. If graph extraction hangs or schema validation fails, use a model with stronger structured JSON behaviour or switch to OpenAI native.
+
+### AWS Bedrock Native API
+
+Install the Bedrock dependency in the Poetry environment:
+
+```bash
+poetry run pip install "boto3>=1.34,<2" "botocore[crt]"
+```
+
+```bash
+export AWS_REGION=us-east-1
+# export AWS_PROFILE=<profile-name>
+
+export LLM_PROVIDER=bedrock
+export LLM_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0
+export LLM_INSTRUCTOR_MODE=json_schema_mode
+export LLM_MAX_COMPLETION_TOKENS=2048
+unset LLM_API_KEY LLM_ENDPOINT LLM_API_VERSION
+
+export EMBEDDING_PROVIDER=bedrock
+export EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+export EMBEDDING_DIMENSIONS=1024
+unset EMBEDDING_API_KEY EMBEDDING_ENDPOINT EMBEDDING_API_VERSION
+```
+
+## Schema
+
+The adapter creates one ClickHouse `ReplacingMergeTree` table per Cognee collection:
+
+```sql
+CREATE TABLE cognee_vec_<collection>
+(
+    database_name  String,
+    id             String,
+    payload        String,
+    text           String,
+    belongs_to_set Array(String),
+    vector         Array(Float32),
+    version        UInt64,
+    is_deleted     UInt8
+)
+ENGINE = ReplacingMergeTree(version, is_deleted)
+ORDER BY (database_name, id);
+```
+
+Logical deletes write a tombstone row (`is_deleted = 1`) with a higher `version`. All queries use `FINAL` to deduplicate and filter `is_deleted = 0` for correctness. `prune()` issues an `ALTER TABLE … DELETE` for the current dataset's rows and only drops the physical table when no live rows remain across all datasets.
+
+## Search And Indexing
+
+Exact search is always available and is the correctness baseline. The adapter normalises vectors by default and scores exact search with `dotProduct`, so higher scores are better, matching the other Cognee vector adapters.
+
+When `COGNEE_CLICKHOUSE_ENABLE_VECTOR_INDEX=true`, the adapter tries to add and materialise a ClickHouse `vector_similarity('hnsw', cosineDistance, <dimension>)` index. If the server is older than ClickHouse 25.8 or index creation fails, the adapter logs a warning and continues with exact search. ANN search converts cosine distance back to a higher-is-better score with `1 - cosineDistance(...)`.
+
+## Filtering And Pruning
+
+- `belongs_to_set` filters are evaluated with ClickHouse `hasAny` / `hasAll` on the `belongs_to_set` array column.
+- Searches, retrievals, deletes, collection listing, and prune operations are scoped by `database_name`.
+- `prune()` deletes only rows for the current Cognee dataset and drops only prefixed tables that become fully empty across all datasets.
+- No credentials or raw customer/export data are ingested by default.
+
+## Run The Example
+
+After ClickHouse and LLM/embedding credentials are configured:
+
+```bash
+export COGNEE_SKIP_CONNECTION_TEST=true
+export ENABLE_BACKEND_ACCESS_CONTROL=false
+
+poetry run python example.py
+```
+
+Inspect ClickHouse tables during or after a run:
+
+```bash
+curl -sS "http://127.0.0.1:8123/" \
+  --data-binary "SELECT name FROM system.tables WHERE database = 'cognee' AND name LIKE 'cognee_vec_%'"
+```
+
+## Tests
+
+Unit and integration tests (no LLM calls needed) cover connection config, serialisation, vector validation, filter logic, mocked search, adapter lifecycle (create/search/delete/prune), dataset handler, and vector index smoke test. Run them with a live ClickHouse but without setting any LLM credentials:
+
+```bash
+poetry run pytest tests/test_clickhouse.py -k "not recall"
+```
+
+The full suite including the end-to-end recall flow test:
+
+```bash
+poetry run pytest tests/test_clickhouse.py
+```
+
+`test_cognee_recall_flow` is automatically skipped when `LLM_API_KEY` or `EMBEDDING_API_KEY` are not set. The full test expects:
+
+- A reachable ClickHouse database.
+- Working LLM and embedding provider configuration.
+- `VECTOR_DATASET_DATABASE_HANDLER=clickhouse`.
+
+## Troubleshooting
+
+- `LLM connection test timed out`: verify API reachability, or set `COGNEE_SKIP_CONNECTION_TEST=true` for local testing.
+- OpenAI quota or rate-limit errors: switch to a lower-concurrency model or a different provider. Models with high per-request concurrency costs (e.g. Kimi-K2 on Featherless) can exhaust plan limits when `cognify()` fires parallel LLM calls; use a smaller model such as `Qwen/Qwen2.5-14B-Instruct`.
+- `KeyError: 'Could not automatically map <model> to a tokeniser'`: `EMBEDDING_PROVIDER=openai` uses TikToken which only knows OpenAI model names. Use `EMBEDDING_PROVIDER=openai_compatible` with `EMBEDDING_DIMENSIONS` set explicitly, or `EMBEDDING_PROVIDER=fastembed` for local embeddings.
+- Vector dimension mismatch on first write: set `EMBEDDING_DIMENSIONS` explicitly to match your embedding model's output size. The adapter reads this at table-creation time and cannot change it afterwards without dropping the table.
+- Bedrock `MissingDependencyException`: install `poetry run pip install "botocore[crt]"`.
+- Bedrock `on-demand throughput isn't supported`: use an inference profile ID such as `us.anthropic.claude-3-5-haiku-20241022-v1:0`.
+- OpenAI-compatible endpoint works with `curl` but Cognee hangs: the model may not support `instructor` structured output reliably. Use a model with stronger structured JSON behaviour.

--- a/packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/ClickHouseDatasetDatabaseHandler.py
+++ b/packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/ClickHouseDatasetDatabaseHandler.py
@@ -1,0 +1,37 @@
+from typing import Optional
+from uuid import UUID
+
+from cognee.infrastructure.databases.dataset_database_handler import DatasetDatabaseHandlerInterface
+from cognee.infrastructure.databases.vector import get_vectordb_config
+from cognee.infrastructure.databases.vector.create_vector_engine import create_vector_engine
+from cognee.modules.users.models import DatasetDatabase, User
+
+
+class ClickHouseDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
+    @classmethod
+    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        vector_config = get_vectordb_config()
+
+        if vector_config.vector_db_provider != "clickhouse":
+            raise ValueError(
+                "ClickHouseDatasetDatabaseHandler can only be used with the "
+                "ClickHouse vector database provider."
+            )
+
+        return {
+            "vector_database_provider": vector_config.vector_db_provider,
+            "vector_database_url": vector_config.vector_db_url,
+            "vector_database_key": vector_config.vector_db_key,
+            "vector_database_name": f"{dataset_id}",
+            "vector_dataset_database_handler": "clickhouse",
+        }
+
+    @classmethod
+    async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
+        vector_engine = create_vector_engine(
+            vector_db_provider=dataset_database.vector_database_provider,
+            vector_db_url=dataset_database.vector_database_url,
+            vector_db_key=dataset_database.vector_database_key,
+            vector_db_name=dataset_database.vector_database_name,
+        )
+        await vector_engine.prune()

--- a/packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/__init__.py
+++ b/packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/__init__.py
@@ -1,0 +1,3 @@
+from .clickhouse_adapter import ClickHouseAdapter
+
+__all__ = ["ClickHouseAdapter"]

--- a/packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/clickhouse_adapter.py
+++ b/packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/clickhouse_adapter.py
@@ -1,0 +1,878 @@
+import asyncio
+import base64
+import hashlib
+import json
+import math
+import os
+import re
+import time
+from typing import Any, Iterable, List, Optional
+from urllib.parse import parse_qs, unquote, urlparse
+from uuid import UUID
+
+import clickhouse_connect
+from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
+from cognee.infrastructure.databases.vector import VectorDBInterface
+from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import (
+    EmbeddingEngine,
+)
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.engine.utils import parse_id
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("ClickHouseAdapter")
+
+
+class ClickHouseDataPoint(DataPoint):
+    text: str
+    metadata: dict = {"index_fields": ["text"]}
+    belongs_to_set: List[str] = []
+
+
+class VectorEngineInitializationError(Exception):
+    pass
+
+
+def serialize_for_json(obj: Any) -> Any:
+    if isinstance(obj, UUID):
+        return str(obj)
+    if isinstance(obj, dict):
+        return {key: serialize_for_json(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [serialize_for_json(item) for item in obj]
+    return obj
+
+
+def safe_parse_id(value: str) -> Any:
+    try:
+        return parse_id(value)
+    except Exception:
+        return value
+
+
+class ClickHouseAdapter(VectorDBInterface):
+    name = "ClickHouse"
+
+    def __init__(
+        self,
+        url: str | None = None,
+        api_key: str | None = None,
+        database_name: str = "cognee",
+        embedding_engine: EmbeddingEngine | None = None,
+        endpoint: str | None = None,
+        **kwargs: dict | None,
+    ):
+        if embedding_engine is None:
+            raise VectorEngineInitializationError("Embedding engine is required!")
+
+        self.embedding_engine = embedding_engine
+        self.database_name = database_name or "cognee"
+        self.table_prefix = self._sanitize_prefix(
+            os.getenv("COGNEE_CLICKHOUSE_TABLE_PREFIX", "cognee_vec_")
+        )
+        self.normalize_vectors = self._env_flag("COGNEE_CLICKHOUSE_NORMALIZE_VECTORS", True)
+        self.enable_vector_index = self._env_flag("COGNEE_CLICKHOUSE_ENABLE_VECTOR_INDEX", False)
+        self.vector_index_granularity = self._env_int(
+            "COGNEE_CLICKHOUSE_VECTOR_INDEX_GRANULARITY", 100000000
+        )
+        self.vector_index_name = self._sanitize_identifier(
+            os.getenv("COGNEE_CLICKHOUSE_VECTOR_INDEX_NAME", "idx_vector")
+        )
+        self.VECTOR_DB_LOCK = asyncio.Lock()
+        self._warned_vector_index_unsupported = False
+
+        raw_url = (
+            endpoint
+            or url
+            or kwargs.get("url")
+            or os.getenv("CLICKHOUSE_URL")
+            or os.getenv("VECTOR_DB_URL")
+        )
+        raw_key = api_key or os.getenv("CLICKHOUSE_KEY") or os.getenv("VECTOR_DB_KEY")
+        self.connection_config = self._build_connection_config(raw_url, raw_key)
+
+    async def embed_data(self, data: list[str]) -> list[list[float]]:
+        return await self.embedding_engine.embed_text(data)
+
+    async def has_collection(self, collection_name: str) -> bool:
+        table_name = self._table_name(collection_name)
+        result = await self._fetch_one(
+            """
+            SELECT count() AS table_count
+            FROM system.tables
+            WHERE database = currentDatabase()
+              AND name = {table_name:String}
+            """,
+            {"table_name": table_name},
+        )
+        return bool(result and int(result["table_count"]) > 0)
+
+    async def create_collection(self, collection_name: str, payload_schema: Any | None = None):
+        async with self.VECTOR_DB_LOCK:
+            table_name = self._table_name(collection_name)
+            vector_size = self._vector_size()
+
+            await self._execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {self._quote_identifier(table_name)} (
+                    database_name String,
+                    id String,
+                    payload String,
+                    text String,
+                    belongs_to_set Array(String),
+                    vector Array(Float32),
+                    version UInt64,
+                    is_deleted UInt8 DEFAULT 0,
+                    created_at DateTime64(6) DEFAULT now64(6),
+                    updated_at DateTime64(6) DEFAULT now64(6),
+                    CONSTRAINT vector_length CHECK length(vector) = {int(vector_size)}
+                )
+                ENGINE = ReplacingMergeTree(version, is_deleted)
+                ORDER BY (database_name, id)
+                """
+            )
+            await self._ensure_vector_index(table_name, vector_size)
+
+    async def create_data_points(self, collection_name: str, data_points: list[DataPoint]) -> None:
+        if not data_points:
+            return
+
+        if not await self.has_collection(collection_name):
+            await self.create_collection(collection_name, type(data_points[0]))
+
+        embeddable_data = [DataPoint.get_embeddable_data(data_point) for data_point in data_points]
+        vectors = await self.embed_data(embeddable_data)
+        if len(vectors) != len(data_points):
+            raise ValueError(
+                "Embedding engine returned a different number of vectors than input data points."
+            )
+
+        expected_size = self._vector_size()
+        table_name = self._table_name(collection_name)
+        base_version = time.time_ns()
+        rows = []
+
+        for row_offset, (data_point, vector) in enumerate(zip(data_points, vectors, strict=False)):
+            normalized_vector = self._normalize_vector(
+                self._validate_vector(vector, expected_size=expected_size)
+            )
+            payload = serialize_for_json(data_point.model_dump())
+            payload["database_name"] = self.database_name
+            belongs_to_set = self._belongs_to_set(data_point)
+            rows.append(
+                (
+                    self.database_name,
+                    str(data_point.id),
+                    json.dumps(payload, separators=(",", ":")),
+                    self._get_text_content(data_point),
+                    belongs_to_set,
+                    normalized_vector,
+                    base_version + row_offset,
+                    0,
+                )
+            )
+
+        await self._insert(
+            table_name,
+            rows,
+            [
+                "database_name",
+                "id",
+                "payload",
+                "text",
+                "belongs_to_set",
+                "vector",
+                "version",
+                "is_deleted",
+            ],
+        )
+
+    async def create_vector_index(self, index_name: str, index_property_name: str):
+        collection_name = f"{index_name}_{index_property_name}"
+        await self.create_collection(collection_name)
+        if self.enable_vector_index:
+            await self._ensure_vector_index(self._table_name(collection_name), self._vector_size())
+
+    async def index_data_points(
+        self, index_name: str, index_property_name: str, data_points: list[DataPoint]
+    ):
+        await self.create_data_points(
+            f"{index_name}_{index_property_name}",
+            [
+                ClickHouseDataPoint(
+                    id=data_point.id,
+                    text=getattr(
+                        data_point,
+                        data_point.metadata.get("index_fields", ["text"])[0],
+                    ),
+                    belongs_to_set=(data_point.belongs_to_set or []),
+                )
+                for data_point in data_points
+            ],
+        )
+
+    async def retrieve(
+        self, collection_name: str, data_point_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        if not data_point_ids or not await self.has_collection(collection_name):
+            return []
+
+        table_name = self._table_name(collection_name)
+        rows = await self._fetch_all(
+            f"""
+            SELECT id, payload
+            FROM {self._quote_identifier(table_name)} FINAL
+            WHERE database_name = {{database_name:String}}
+              AND is_deleted = 0
+              AND has({{ids:Array(String)}}, id)
+            """,
+            {
+                "database_name": self.database_name,
+                "ids": [str(data_id) for data_id in data_point_ids],
+            },
+        )
+        payload_by_id = {
+            str(row["id"]): self._payload_with_id(row.get("payload"), str(row["id"]))
+            for row in rows
+        }
+        return [
+            payload_by_id[str(data_id)]
+            for data_id in data_point_ids
+            if str(data_id) in payload_by_id
+        ]
+
+    async def search(
+        self,
+        collection_name: str,
+        query_text: str | None = None,
+        query_vector: list[float] | None = None,
+        limit: int | None = 15,
+        with_vector: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: str = "OR",
+    ) -> list[ScoredResult]:
+        if query_text is None and query_vector is None:
+            raise MissingQueryParameterError()
+
+        if not await self.has_collection(collection_name):
+            return []
+
+        if query_vector is None:
+            query_vector = (await self.embed_data([query_text]))[0]
+
+        if limit is None:
+            limit = await self._collection_size(collection_name)
+        if limit <= 0:
+            return []
+
+        expected_size = self._vector_size()
+        query_vector = self._normalize_vector(
+            self._validate_vector(query_vector, expected_size=expected_size)
+        )
+        table_name = self._table_name(collection_name)
+        filter_sql, filter_params = self._build_filter(node_name, node_name_filter_operator)
+        parameters: dict[str, Any] = {
+            "database_name": self.database_name,
+            "limit": int(limit),
+            "query_vector": query_vector,
+            **filter_params,
+        }
+        select_payload = ", payload" if include_payload else ""
+        select_vector = ", vector" if with_vector else ""
+        use_vector_index = self.enable_vector_index and await self.has_vector_index(collection_name)
+        score_expression = (
+            "1 - cosineDistance(vector, {query_vector:Array(Float32)})"
+            if use_vector_index
+            else "dotProduct(vector, {query_vector:Array(Float32)})"
+        )
+        order_expression = (
+            "cosineDistance(vector, {query_vector:Array(Float32)}) ASC"
+            if use_vector_index
+            else "score DESC"
+        )
+
+        rows = await self._fetch_all(
+            f"""
+            SELECT id{select_payload}{select_vector},
+                   {score_expression} AS score
+            FROM {self._quote_identifier(table_name)} FINAL
+            WHERE database_name = {{database_name:String}}
+              AND is_deleted = 0{filter_sql}
+            ORDER BY {order_expression}
+            LIMIT {{limit:UInt64}}
+            """,
+            parameters,
+        )
+
+        return [
+            ScoredResult(
+                id=safe_parse_id(str(row["id"])),
+                payload=self._payload_with_id(row.get("payload"), str(row["id"]))
+                if include_payload
+                else None,
+                score=float(row.get("score") or 0.0),
+            )
+            for row in rows
+        ]
+
+    async def batch_search(
+        self,
+        collection_name: str,
+        query_texts: list[str],
+        limit: int | None = 15,
+        with_vectors: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: str = "OR",
+    ) -> list[list[ScoredResult]]:
+        if not query_texts:
+            return []
+
+        vectors = await self.embed_data(query_texts)
+        if len(vectors) != len(query_texts):
+            raise ValueError(
+                "Embedding engine returned a different number of vectors than input queries."
+            )
+
+        return await asyncio.gather(
+            *[
+                self.search(
+                    collection_name=collection_name,
+                    query_vector=vector,
+                    limit=limit,
+                    with_vector=with_vectors,
+                    include_payload=include_payload,
+                    node_name=node_name,
+                    node_name_filter_operator=node_name_filter_operator,
+                )
+                for vector in vectors
+            ]
+        )
+
+    async def delete_data_points(
+        self, collection_name: str, data_point_ids: list[str]
+    ) -> dict[str, int]:
+        if not data_point_ids or not await self.has_collection(collection_name):
+            return {"deleted": 0}
+
+        table_name = self._table_name(collection_name)
+        ids = [str(data_id) for data_id in data_point_ids]
+        existing = await self._fetch_one(
+            f"""
+            SELECT count() AS row_count
+            FROM {self._quote_identifier(table_name)} FINAL
+            WHERE database_name = {{database_name:String}}
+              AND is_deleted = 0
+              AND has({{ids:Array(String)}}, id)
+            """,
+            {"database_name": self.database_name, "ids": ids},
+        )
+        deleted_count = int(existing["row_count"]) if existing else 0
+        vector_size = self._vector_size()
+        base_version = time.time_ns()
+        rows = [
+            (
+                self.database_name,
+                data_id,
+                "{}",
+                "",
+                [],
+                [0.0] * vector_size,
+                base_version + row_offset,
+                1,
+            )
+            for row_offset, data_id in enumerate(ids)
+        ]
+        await self._insert(
+            table_name,
+            rows,
+            [
+                "database_name",
+                "id",
+                "payload",
+                "text",
+                "belongs_to_set",
+                "vector",
+                "version",
+                "is_deleted",
+            ],
+        )
+        return {"deleted": deleted_count}
+
+    async def prune(self) -> None:
+        for table_name in await self._list_prefixed_tables():
+            quoted_table_name = self._quote_identifier(table_name)
+            await self._execute(
+                (
+                    f"ALTER TABLE {quoted_table_name} "
+                    "DELETE WHERE database_name = {database_name:String}"
+                ),
+                {"database_name": self.database_name},
+                settings={"mutations_sync": 2},
+            )
+            total_remaining = await self._fetch_one(
+                f"SELECT count() AS row_count FROM {quoted_table_name} FINAL "
+                f"WHERE is_deleted = 0",
+                {},
+            )
+            if total_remaining and int(total_remaining["row_count"]) == 0:
+                await self._execute(f"DROP TABLE IF EXISTS {quoted_table_name}")
+
+    async def get_collection_names(self) -> list[str]:
+        collection_names = []
+        for table_name in await self._list_prefixed_tables():
+            result = await self._fetch_one(
+                f"""
+                SELECT count() AS row_count
+                FROM {self._quote_identifier(table_name)} FINAL
+                WHERE database_name = {{database_name:String}}
+                  AND is_deleted = 0
+                """,
+                {"database_name": self.database_name},
+            )
+            if result and int(result["row_count"]) > 0:
+                collection_names.append(table_name)
+        return collection_names
+
+    async def has_vector_index(self, collection_name: str) -> bool:
+        table_name = self._table_name(collection_name)
+        result = await self._fetch_one(
+            """
+            SELECT count() AS index_count
+            FROM system.data_skipping_indices
+            WHERE database = currentDatabase()
+              AND table = {table_name:String}
+              AND name = {index_name:String}
+              AND type = 'vector_similarity'
+            """,
+            {"table_name": table_name, "index_name": self.vector_index_name},
+        )
+        return bool(result and int(result["index_count"]) > 0)
+
+    async def _collection_size(self, collection_name: str) -> int:
+        table_name = self._table_name(collection_name)
+        result = await self._fetch_one(
+            f"""
+            SELECT count() AS row_count
+            FROM {self._quote_identifier(table_name)} FINAL
+            WHERE database_name = {{database_name:String}}
+              AND is_deleted = 0
+            """,
+            {"database_name": self.database_name},
+        )
+        return int(result["row_count"]) if result else 0
+
+    def _build_filter(
+        self, node_name: Optional[List[str]], node_name_filter_operator: str
+    ) -> tuple[str, dict[str, Any]]:
+        if not node_name:
+            return "", {}
+
+        operator = node_name_filter_operator.upper()
+        function_name = "hasAll" if operator == "AND" else "hasAny"
+        return (
+            f" AND {function_name}(belongs_to_set, {{node_names:Array(String)}})",
+            {"node_names": [str(name) for name in node_name]},
+        )
+
+    async def _list_prefixed_tables(self) -> list[str]:
+        rows = await self._fetch_all(
+            """
+            SELECT name AS table_name
+            FROM system.tables
+            WHERE database = currentDatabase()
+              AND startsWith(name, {table_prefix:String})
+            """,
+            {"table_prefix": self.table_prefix},
+        )
+        return [
+            str(row["table_name"])
+            for row in rows
+            if str(row["table_name"]).startswith(self.table_prefix)
+        ]
+
+    async def _ensure_vector_index(self, table_name: str, vector_size: int) -> None:
+        if not self.enable_vector_index:
+            return
+
+        if not await self._supports_vector_index():
+            if not self._warned_vector_index_unsupported:
+                logger.warning(
+                    "ClickHouse vector indexes require ClickHouse 25.8 or newer; "
+                    "falling back to exact vector search."
+                )
+                self._warned_vector_index_unsupported = True
+            return
+
+        quoted_table_name = self._quote_identifier(table_name)
+        quoted_index_name = self._quote_identifier(self.vector_index_name)
+        try:
+            await self._execute(
+                f"""
+                ALTER TABLE {quoted_table_name}
+                ADD INDEX IF NOT EXISTS {quoted_index_name}
+                vector TYPE vector_similarity('hnsw', cosineDistance, {int(vector_size)})
+                GRANULARITY {int(self.vector_index_granularity)}
+                """
+            )
+            await self._execute(
+                f"ALTER TABLE {quoted_table_name} MATERIALIZE INDEX {quoted_index_name}",
+                settings={"mutations_sync": 2},
+            )
+        except Exception as error:
+            logger.warning(
+                "Could not create ClickHouse vector index on %s: %s. "
+                "Falling back to exact vector search.",
+                table_name,
+                error,
+            )
+
+    async def _supports_vector_index(self) -> bool:
+        try:
+            result = await self._fetch_one("SELECT version() AS version")
+        except Exception as error:
+            logger.warning("Could not detect ClickHouse version: %s", error)
+            return False
+
+        if not result:
+            return False
+        return self._version_at_least(str(result["version"]), (25, 8))
+
+    @staticmethod
+    def _version_at_least(version: str, minimum: tuple[int, int]) -> bool:
+        parts = []
+        for part in version.split("."):
+            match = re.match(r"(\d+)", part)
+            if match is None:
+                break
+            parts.append(int(match.group(1)))
+        while len(parts) < len(minimum):
+            parts.append(0)
+        return tuple(parts[: len(minimum)]) >= minimum
+
+    async def _execute(
+        self,
+        sql: str,
+        params: dict[str, Any] | None = None,
+        settings: dict[str, Any] | None = None,
+    ) -> Any:
+        return await asyncio.to_thread(self._execute_sync, sql, params, settings)
+
+    async def _insert(
+        self, table_name: str, rows: list[tuple[Any, ...]], columns: list[str]
+    ) -> None:
+        await asyncio.to_thread(self._insert_sync, table_name, rows, columns)
+
+    async def _fetch_one(
+        self, sql: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        rows = await self._fetch_all(sql, params)
+        return rows[0] if rows else None
+
+    async def _fetch_all(
+        self, sql: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._fetch_all_sync, sql, params)
+
+    def _execute_sync(
+        self,
+        sql: str,
+        params: dict[str, Any] | None = None,
+        settings: dict[str, Any] | None = None,
+    ) -> Any:
+        client = self._connect()
+        try:
+            return client.command(sql, parameters=params or {}, settings=settings or {})
+        finally:
+            self._close_client(client)
+
+    def _insert_sync(
+        self, table_name: str, rows: list[tuple[Any, ...]], columns: list[str]
+    ) -> None:
+        client = self._connect()
+        try:
+            client.insert(table_name, rows, column_names=columns)
+        finally:
+            self._close_client(client)
+
+    def _fetch_all_sync(
+        self, sql: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        client = self._connect()
+        try:
+            result = client.query(sql, parameters=params or {})
+            return list(result.named_results())
+        finally:
+            self._close_client(client)
+
+    def _fetch_one_sync(
+        self, sql: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        rows = self._fetch_all_sync(sql, params)
+        return rows[0] if rows else None
+
+    def _connect(self):
+        return clickhouse_connect.get_client(**self.connection_config)
+
+    @staticmethod
+    def _close_client(client: Any) -> None:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+
+    def _build_connection_config(self, url: str | None, api_key: str | None) -> dict[str, Any]:
+        api_key_config = self._decode_api_key(api_key)
+        url_config = self._parse_url(url)
+        password = self._first_present(
+            os.getenv("CLICKHOUSE_PASSWORD"),
+            os.getenv("VECTOR_DB_PASSWORD"),
+            api_key_config.get("password"),
+            api_key_config.get("api_key"),
+            url_config.get("password"),
+        )
+
+        config: dict[str, Any] = {
+            "host": self._first_present(
+                os.getenv("CLICKHOUSE_HOST"),
+                os.getenv("VECTOR_DB_HOST"),
+                url_config.get("host"),
+                api_key_config.get("host"),
+                "localhost",
+            ),
+            "port": int(
+                self._first_present(
+                    os.getenv("CLICKHOUSE_PORT"),
+                    os.getenv("VECTOR_DB_PORT"),
+                    url_config.get("port"),
+                    api_key_config.get("port"),
+                    8123,
+                )
+            ),
+            "username": self._first_present(
+                os.getenv("CLICKHOUSE_USERNAME"),
+                os.getenv("VECTOR_DB_USERNAME"),
+                url_config.get("username"),
+                api_key_config.get("username"),
+                "default",
+            ),
+            "password": password if password is not None else "",
+            "database": self._first_present(
+                os.getenv("CLICKHOUSE_DATABASE"),
+                os.getenv("VECTOR_DB_NAME"),
+                api_key_config.get("database"),
+                url_config.get("database"),
+                "default",
+            ),
+            "secure": self._to_bool(
+                self._first_present(
+                    os.getenv("CLICKHOUSE_SECURE"),
+                    os.getenv("VECTOR_DB_SECURE"),
+                    url_config.get("secure"),
+                    api_key_config.get("secure"),
+                    False,
+                )
+            ),
+            "compress": self._to_bool(
+                self._first_present(
+                    os.getenv("CLICKHOUSE_COMPRESS"),
+                    api_key_config.get("compress"),
+                    True,
+                )
+            ),
+            "client_name": "cognee-community-clickhouse-vector-adapter",
+        }
+
+        optional_mapping = {
+            "verify": "CLICKHOUSE_VERIFY",
+            "ca_cert": "CLICKHOUSE_CA_CERT",
+            "client_cert": "CLICKHOUSE_CLIENT_CERT",
+            "client_cert_key": "CLICKHOUSE_CLIENT_CERT_KEY",
+            "connect_timeout": "CLICKHOUSE_CONNECT_TIMEOUT",
+            "send_receive_timeout": "CLICKHOUSE_SEND_RECEIVE_TIMEOUT",
+        }
+        for key, env_name in optional_mapping.items():
+            value = self._first_present(os.getenv(env_name), api_key_config.get(key))
+            if value is None:
+                continue
+            if key in {"verify"}:
+                config[key] = self._to_bool(value)
+            elif key in {"connect_timeout", "send_receive_timeout"}:
+                config[key] = int(value)
+            else:
+                config[key] = value
+
+        return config
+
+    def _parse_url(self, raw_url: str | None) -> dict[str, Any]:
+        if not raw_url:
+            return {}
+
+        if "://" not in raw_url:
+            if "@" in raw_url or "/" in raw_url:
+                raw_url = f"http://{raw_url}"
+            else:
+                host, _, port = raw_url.partition(":")
+                return {"host": host, "port": int(port) if port else None}
+
+        parsed = urlparse(raw_url)
+        query_params = parse_qs(parsed.query)
+        database = parsed.path.lstrip("/").split("/", 1)[0] if parsed.path else None
+        return {
+            "host": parsed.hostname,
+            "port": parsed.port,
+            "username": unquote(parsed.username) if parsed.username else None,
+            "password": unquote(parsed.password) if parsed.password else None,
+            "database": database or None,
+            "secure": parsed.scheme in {"https", "clickhouses"}
+            or query_params.get("secure", [None])[0],
+        }
+
+    def _decode_api_key(self, api_key: str | None) -> dict[str, Any]:
+        if not api_key:
+            return {}
+
+        for candidate in (api_key, self._try_base64_decode(api_key)):
+            if not candidate:
+                continue
+            try:
+                decoded = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(decoded, dict):
+                return decoded
+
+        return {"api_key": api_key}
+
+    @staticmethod
+    def _try_base64_decode(value: str) -> str | None:
+        try:
+            return base64.b64decode(value).decode("utf-8")
+        except Exception:
+            return None
+
+    def _table_name(self, collection_name: str) -> str:
+        normalized = collection_name.lower()
+        sanitized = re.sub(r"[^a-z0-9_]+", "_", normalized).strip("_") or "collection"
+        needs_hash = sanitized != normalized or len(self.table_prefix + sanitized) > 64
+        suffix = ""
+        if needs_hash:
+            suffix = "_" + hashlib.sha1(collection_name.encode("utf-8")).hexdigest()[:8]
+
+        max_collection_length = 64 - len(self.table_prefix) - len(suffix)
+        return f"{self.table_prefix}{sanitized[:max_collection_length]}{suffix}"
+
+    def _sanitize_prefix(self, prefix: str) -> str:
+        sanitized = re.sub(r"[^a-zA-Z0-9_]+", "_", prefix)
+        return (sanitized or "cognee_vec_")[:48]
+
+    def _sanitize_identifier(self, identifier: str) -> str:
+        sanitized = re.sub(r"[^a-zA-Z0-9_]+", "_", identifier).strip("_")
+        return sanitized or "idx_vector"
+
+    def _quote_identifier(self, identifier: str) -> str:
+        return f"`{identifier.replace('`', '``')}`"
+
+    def _vector_size(self) -> int:
+        try:
+            vector_size = int(self.embedding_engine.get_vector_size())
+        except Exception:
+            vector_size = int(os.getenv("EMBEDDING_DIMENSIONS", "0"))
+
+        if vector_size <= 0:
+            raise ValueError(
+                "ClickHouse adapter requires a positive embedding dimension. "
+                "Configure an embedding engine with get_vector_size() or set EMBEDDING_DIMENSIONS."
+            )
+        return vector_size
+
+    def _validate_vector(
+        self, vector: Iterable[Any], expected_size: int | None = None
+    ) -> list[float]:
+        if hasattr(vector, "tolist") and not isinstance(vector, (str, bytes, bytearray)):
+            vector = vector.tolist()
+
+        values = list(vector)
+        if not values:
+            raise ValueError("ClickHouse vectors must not be empty.")
+        if expected_size is not None and len(values) != expected_size:
+            raise ValueError(
+                "ClickHouse vector dimension mismatch: "
+                f"expected {expected_size}, got {len(values)}."
+            )
+
+        result = []
+        for value in values:
+            float_value = float(value)
+            if not math.isfinite(float_value):
+                raise ValueError("ClickHouse vectors must contain only finite numeric values.")
+            result.append(float_value)
+        return result
+
+    def _normalize_vector(self, vector: list[float]) -> list[float]:
+        if not self.normalize_vectors:
+            return [float(value) for value in vector]
+
+        norm = math.sqrt(sum(value * value for value in vector))
+        if norm == 0:
+            return [float(value) for value in vector]
+        return [float(value) / norm for value in vector]
+
+    def _payload_with_id(self, payload: Any, data_point_id: str) -> dict[str, Any]:
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except json.JSONDecodeError:
+                payload = {}
+        elif payload is None:
+            payload = {}
+
+        if not isinstance(payload, dict):
+            payload = {"payload": payload}
+        payload["id"] = safe_parse_id(data_point_id)
+        return payload
+
+    @staticmethod
+    def _get_text_content(data_point: DataPoint) -> str:
+        metadata = getattr(data_point, "metadata", None)
+        if isinstance(metadata, dict):
+            index_fields = metadata.get("index_fields", ["text"])
+            field_name = index_fields[0] if index_fields else "text"
+        else:
+            field_name = "text"
+        return str(getattr(data_point, field_name, ""))
+
+    @staticmethod
+    def _belongs_to_set(data_point: DataPoint) -> list[str]:
+        belongs_to_set = getattr(data_point, "belongs_to_set", None) or []
+        return [str(value) for value in belongs_to_set]
+
+    @staticmethod
+    def _first_present(*values: Any) -> Any:
+        for value in values:
+            if value is not None and value != "":
+                return value
+        return None
+
+    @staticmethod
+    def _to_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return False
+        return str(value).lower() in {"1", "true", "yes", "on", "https"}
+
+    @staticmethod
+    def _env_flag(name: str, default: bool) -> bool:
+        value = os.getenv(name)
+        if value is None:
+            return default
+        return value.lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _env_int(name: str, default: int) -> int:
+        value = os.getenv(name)
+        if value is None:
+            return default
+        return int(value)

--- a/packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/register.py
+++ b/packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/register.py
@@ -1,0 +1,8 @@
+from cognee.infrastructure.databases.dataset_database_handler import use_dataset_database_handler
+from cognee.infrastructure.databases.vector import use_vector_adapter
+
+from .ClickHouseDatasetDatabaseHandler import ClickHouseDatasetDatabaseHandler
+from .clickhouse_adapter import ClickHouseAdapter
+
+use_vector_adapter("clickhouse", ClickHouseAdapter)
+use_dataset_database_handler("clickhouse", ClickHouseDatasetDatabaseHandler, "clickhouse")

--- a/packages/vector/clickhouse/example.py
+++ b/packages/vector/clickhouse/example.py
@@ -1,0 +1,51 @@
+import asyncio
+import os
+import pathlib
+from os import path
+
+# NOTE: Importing the register module lets cognee use the ClickHouse vector adapter.
+# NOTE: The "noqa: F401" mark keeps linters from flagging the side-effect import.
+from cognee_community_vector_adapter_clickhouse import register  # noqa: F401
+
+
+async def main():
+    from cognee import SearchType, add, cognify, config, prune, search
+
+    os.environ.setdefault("VECTOR_DATASET_DATABASE_HANDLER", "clickhouse")
+
+    system_path = pathlib.Path(__file__).parent
+    config.system_root_directory(path.join(system_path, ".cognee_system"))
+    config.data_root_directory(path.join(system_path, ".data_storage"))
+
+    config.set_relational_db_config({"db_provider": "sqlite"})
+    config.set_vector_db_config(
+        {
+            "vector_db_provider": "clickhouse",
+            "vector_db_url": os.getenv("CLICKHOUSE_URL", "http://127.0.0.1:8123/cognee"),
+            "vector_db_key": os.getenv("CLICKHOUSE_KEY", ""),
+        }
+    )
+    config.set_graph_db_config({"graph_database_provider": "ladybug"})
+
+    await prune.prune_data()
+    await prune.prune_system(metadata=True)
+
+    text = """
+    Natural language processing (NLP) is an interdisciplinary
+    subfield of computer science and information retrieval.
+    """
+
+    await add(text)
+    await cognify()
+
+    search_results = await search(
+        query_type=SearchType.GRAPH_COMPLETION,
+        query_text="Tell me about NLP",
+    )
+
+    for result_text in search_results:
+        print(result_text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/vector/clickhouse/pyproject.toml
+++ b/packages/vector/clickhouse/pyproject.toml
@@ -1,0 +1,69 @@
+[project]
+name = "cognee-community-vector-adapter-clickhouse"
+version = "0.1.0"
+description = "ClickHouse vector database adapter for cognee"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    "clickhouse-connect>=0.8.0",
+    "cognee>=1.1.0,<2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=1.4.0",
+    "mypy>=1.10,<2",
+]
+
+[tool.poetry]
+name = "cognee-community-vector-adapter-clickhouse"
+version = "0.1.0"
+description = "ClickHouse vector database adapter for cognee"
+authors = ["Cognee Community <support@cognee.ai>"]
+readme = "README.md"
+packages = [{ include = "cognee_community_vector_adapter_clickhouse" }]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<=3.13"
+clickhouse-connect = ">=0.8.0"
+cognee = ">=1.1.0,<2.0.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=7.0"
+pytest-asyncio = ">=1.4.0"
+mypy = ">=1.10,<2"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+exclude = [
+  "/dist",
+  "/.venv",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_vector_adapter_clickhouse"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[tool.mypy]
+python_version = "3.12"
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+no_implicit_optional = true
+check_untyped_defs = true
+disallow_any_generics = true
+strict_equality = true
+exclude = ["^\\.venv/"]
+
+[[tool.mypy.overrides]]
+module = [
+  "clickhouse_connect.*",
+  "cognee.*",
+]
+ignore_missing_imports = true

--- a/packages/vector/clickhouse/tests/test_clickhouse.py
+++ b/packages/vector/clickhouse/tests/test_clickhouse.py
@@ -1,0 +1,528 @@
+import os
+import pathlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import cognee
+import pytest
+from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
+from cognee.modules.search.types import SearchType
+from cognee_community_vector_adapter_clickhouse import register  # noqa: F401
+from cognee_community_vector_adapter_clickhouse.ClickHouseDatasetDatabaseHandler import (
+    ClickHouseDatasetDatabaseHandler,
+)
+from cognee_community_vector_adapter_clickhouse.clickhouse_adapter import (
+    ClickHouseAdapter,
+    ClickHouseDataPoint,
+    serialize_for_json,
+)
+
+
+class DeterministicEmbeddingEngine:
+    def get_vector_size(self) -> int:
+        return 3
+
+    async def embed_text(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed(text) for text in texts]
+
+    def _embed(self, text: str) -> list[float]:
+        text = text.lower()
+        if "hybrid" in text:
+            return [0.8, 0.2, 0.0]
+        if "quantum" in text:
+            return [0.0, 1.0, 0.0]
+        if "nlp" in text:
+            return [1.0, 0.0, 0.0]
+        return [0.0, 0.0, 1.0]
+
+
+CLICKHOUSE_ENV_NAMES = [
+    "CLICKHOUSE_HOST",
+    "CLICKHOUSE_PORT",
+    "CLICKHOUSE_USERNAME",
+    "CLICKHOUSE_PASSWORD",
+    "CLICKHOUSE_DATABASE",
+    "CLICKHOUSE_SECURE",
+    "CLICKHOUSE_COMPRESS",
+    "CLICKHOUSE_VERIFY",
+    "CLICKHOUSE_CA_CERT",
+    "CLICKHOUSE_CLIENT_CERT",
+    "CLICKHOUSE_CLIENT_CERT_KEY",
+    "CLICKHOUSE_CONNECT_TIMEOUT",
+    "CLICKHOUSE_SEND_RECEIVE_TIMEOUT",
+    "CLICKHOUSE_URL",
+    "CLICKHOUSE_KEY",
+    "VECTOR_DB_URL",
+    "VECTOR_DB_KEY",
+    "VECTOR_DB_HOST",
+    "VECTOR_DB_PORT",
+    "VECTOR_DB_NAME",
+    "VECTOR_DB_USERNAME",
+    "VECTOR_DB_PASSWORD",
+    "VECTOR_DB_SECURE",
+    "COGNEE_CLICKHOUSE_TABLE_PREFIX",
+    "COGNEE_CLICKHOUSE_NORMALIZE_VECTORS",
+    "COGNEE_CLICKHOUSE_ENABLE_VECTOR_INDEX",
+]
+
+
+def clear_clickhouse_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in CLICKHOUSE_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def clickhouse_url() -> str:
+    return (
+        os.getenv("CLICKHOUSE_URL")
+        or os.getenv("VECTOR_DB_URL")
+        or "http://127.0.0.1:8123/cognee"
+    )
+
+
+def clickhouse_key() -> str:
+    return (
+        os.getenv("CLICKHOUSE_KEY")
+        or os.getenv("VECTOR_DB_KEY")
+        or os.getenv("CLICKHOUSE_PASSWORD")
+        or ""
+    )
+
+
+def clickhouse_available() -> bool:
+    try:
+        adapter = ClickHouseAdapter(
+            url=clickhouse_url(),
+            api_key=clickhouse_key(),
+            database_name="availability_check",
+            embedding_engine=DeterministicEmbeddingEngine(),
+        )
+        result = adapter._fetch_one_sync("SELECT 1 AS ok")
+        return bool(result and int(result["ok"]) == 1)
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="session")
+def require_clickhouse():
+    if not clickhouse_available():
+        pytest.skip("ClickHouse is not reachable; skipping live ClickHouse tests.")
+
+
+def test_connection_config_from_url_and_env(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_HOST", "env-host")
+    monkeypatch.setenv("CLICKHOUSE_PORT", "8443")
+    monkeypatch.setenv("CLICKHOUSE_USERNAME", "env-user")
+    monkeypatch.setenv("CLICKHOUSE_PASSWORD", "env-password")
+    monkeypatch.setenv("CLICKHOUSE_DATABASE", "env-db")
+    monkeypatch.setenv("CLICKHOUSE_SECURE", "true")
+
+    adapter = ClickHouseAdapter(
+        url="http://url-user:url-password@url-host:8123/url-db",
+        api_key="raw-password",
+        embedding_engine=DeterministicEmbeddingEngine(),
+    )
+
+    assert adapter.connection_config["host"] == "env-host"
+    assert adapter.connection_config["port"] == 8443
+    assert adapter.connection_config["username"] == "env-user"
+    assert adapter.connection_config["password"] == "env-password"
+    assert adapter.connection_config["database"] == "env-db"
+    assert adapter.connection_config["secure"] is True
+
+
+def test_connection_config_from_json_key(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    adapter = ClickHouseAdapter(
+        url="https://url-user:url-password@clickhouse.example.com:8443/url-db",
+        api_key='{"username":"key-user","password":"key-password","database":"key-db"}',
+        embedding_engine=DeterministicEmbeddingEngine(),
+    )
+
+    assert adapter.connection_config["host"] == "clickhouse.example.com"
+    assert adapter.connection_config["port"] == 8443
+    assert adapter.connection_config["username"] == "url-user"
+    assert adapter.connection_config["password"] == "key-password"
+    assert adapter.connection_config["database"] == "key-db"
+    assert adapter.connection_config["secure"] is True
+
+
+def test_table_name_sanitization_and_identifier_quoting(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    adapter = ClickHouseAdapter(
+        embedding_engine=DeterministicEmbeddingEngine(),
+    )
+
+    table_name = adapter._table_name("Entity Name / With Symbols And A Very Long Suffix" * 3)
+
+    assert table_name.startswith("cognee_vec_")
+    assert len(table_name) <= 64
+    assert table_name == table_name.lower()
+    assert "`" not in table_name
+    assert adapter._quote_identifier("a`b") == "`a``b`"
+
+
+def test_json_serialization_and_payload_id(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    data_id = uuid4()
+    serialized = serialize_for_json({"id": data_id, "values": [data_id]})
+    adapter = ClickHouseAdapter(embedding_engine=DeterministicEmbeddingEngine())
+
+    assert serialized == {"id": str(data_id), "values": [str(data_id)]}
+    payload = adapter._payload_with_id('{"text":"hello"}', str(data_id))
+    assert payload["text"] == "hello"
+    assert payload["id"] == data_id
+
+
+def test_vector_validation_and_normalization(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    adapter = ClickHouseAdapter(embedding_engine=DeterministicEmbeddingEngine())
+
+    assert adapter._validate_vector([1, 2, 3], expected_size=3) == [1.0, 2.0, 3.0]
+    assert adapter._normalize_vector([3.0, 4.0, 0.0]) == [0.6, 0.8, 0.0]
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        adapter._validate_vector([], expected_size=3)
+    with pytest.raises(ValueError, match="dimension mismatch"):
+        adapter._validate_vector([1.0, 2.0], expected_size=3)
+    with pytest.raises(ValueError, match="finite"):
+        adapter._validate_vector([1.0, float("nan"), 3.0], expected_size=3)
+
+
+def test_filter_builder(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    adapter = ClickHouseAdapter(embedding_engine=DeterministicEmbeddingEngine())
+
+    sql, params = adapter._build_filter(["NLP", "Quantum"], "AND")
+    assert "hasAll" in sql
+    assert params == {"node_names": ["NLP", "Quantum"]}
+
+    sql, params = adapter._build_filter(["NLP"], "OR")
+    assert "hasAny" in sql
+    assert params == {"node_names": ["NLP"]}
+
+    sql, params = adapter._build_filter(None, "OR")
+    assert sql == ""
+    assert params == {}
+
+
+@pytest.mark.asyncio
+async def test_search_query_uses_typed_vector_parameter_and_filters(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clear_clickhouse_env(monkeypatch)
+    data_id = uuid4()
+    adapter = ClickHouseAdapter(embedding_engine=DeterministicEmbeddingEngine())
+    adapter.has_collection = AsyncMock(return_value=True)
+    adapter._fetch_all = AsyncMock(
+        return_value=[{"id": str(data_id), "payload": '{"text":"NLP"}', "score": 0.9}]
+    )
+
+    results = await adapter.search(
+        "Entity_name",
+        query_vector=[1.0, 0.0, 0.0],
+        include_payload=True,
+        node_name=["NLP", "Quantum"],
+        node_name_filter_operator="AND",
+        limit=5,
+    )
+
+    sql = adapter._fetch_all.call_args.args[0]
+    params = adapter._fetch_all.call_args.args[1]
+    assert "FINAL" in sql
+    assert "dotProduct" in sql
+    assert "{query_vector:Array(Float32)}" in sql
+    assert "hasAll" in sql
+    assert params["query_vector"] == [1.0, 0.0, 0.0]
+    assert params["node_names"] == ["NLP", "Quantum"]
+    assert results[0].id == data_id
+    assert results[0].payload["text"] == "NLP"
+
+
+@pytest.mark.asyncio
+async def test_search_missing_query_parameters(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    adapter = ClickHouseAdapter(embedding_engine=DeterministicEmbeddingEngine())
+
+    with pytest.raises(MissingQueryParameterError):
+        await adapter.search("Entity_name")
+
+
+@pytest.mark.asyncio
+async def test_unsupported_ann_falls_back_to_exact(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    monkeypatch.setenv("COGNEE_CLICKHOUSE_ENABLE_VECTOR_INDEX", "true")
+    adapter = ClickHouseAdapter(embedding_engine=DeterministicEmbeddingEngine())
+    adapter._fetch_one = AsyncMock(return_value={"version": "25.7.9"})
+    adapter._execute = AsyncMock()
+
+    await adapter._ensure_vector_index("cognee_vec_entities", 3)
+
+    adapter._execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_adapter_lifecycle_and_filters(require_clickhouse):
+    collection_name = f"adapter_collection_{uuid4().hex}"
+    dataset_a = f"dataset_a_{uuid4().hex}"
+    dataset_b = f"dataset_b_{uuid4().hex}"
+    embedding_engine = DeterministicEmbeddingEngine()
+
+    adapter_a = ClickHouseAdapter(
+        url=clickhouse_url(),
+        api_key=clickhouse_key(),
+        database_name=dataset_a,
+        embedding_engine=embedding_engine,
+    )
+    adapter_b = ClickHouseAdapter(
+        url=clickhouse_url(),
+        api_key=clickhouse_key(),
+        database_name=dataset_b,
+        embedding_engine=embedding_engine,
+    )
+
+    await adapter_a.prune()
+    await adapter_b.prune()
+
+    nlp_id = uuid4()
+    hybrid_id = uuid4()
+    quantum_id = uuid4()
+    other_dataset_id = uuid4()
+
+    await adapter_a.create_data_points(
+        collection_name,
+        [
+            ClickHouseDataPoint(id=nlp_id, text="NLP document", belongs_to_set=["NLP"]),
+            ClickHouseDataPoint(
+                id=hybrid_id,
+                text="Hybrid NLP quantum note",
+                belongs_to_set=["NLP", "Quantum"],
+            ),
+            ClickHouseDataPoint(
+                id=quantum_id,
+                text="Quantum computers",
+                belongs_to_set=["Quantum", "Computers"],
+            ),
+        ],
+    )
+    await adapter_b.create_data_points(
+        collection_name,
+        [
+            ClickHouseDataPoint(
+                id=other_dataset_id,
+                text="NLP document from another dataset",
+                belongs_to_set=["NLP"],
+            )
+        ],
+    )
+
+    assert await adapter_a.has_collection(collection_name)
+
+    retrieved = await adapter_a.retrieve(collection_name, [str(nlp_id), str(hybrid_id)])
+    assert {payload["id"] for payload in retrieved} == {nlp_id, hybrid_id}
+
+    search_results = await adapter_a.search(
+        collection_name,
+        query_text="NLP",
+        include_payload=True,
+        limit=2,
+    )
+    assert search_results[0].payload["id"] == nlp_id
+
+    or_results = await adapter_a.search(
+        collection_name,
+        query_text="NLP",
+        include_payload=True,
+        limit=None,
+        node_name=["NLP", "Quantum"],
+        node_name_filter_operator="OR",
+    )
+    assert {result.payload["id"] for result in or_results} == {nlp_id, hybrid_id, quantum_id}
+
+    and_results = await adapter_a.search(
+        collection_name,
+        query_text="NLP",
+        include_payload=True,
+        limit=None,
+        node_name=["NLP", "Quantum"],
+        node_name_filter_operator="AND",
+    )
+    assert {result.payload["id"] for result in and_results} == {hybrid_id}
+
+    batch_results = await adapter_a.batch_search(
+        collection_name,
+        query_texts=["NLP", "Quantum"],
+        include_payload=True,
+        limit=1,
+    )
+    assert len(batch_results) == 2
+    assert all(len(result_group) == 1 for result_group in batch_results)
+
+    tenant_b_results = await adapter_b.search(
+        collection_name,
+        query_text="NLP",
+        include_payload=True,
+        limit=None,
+    )
+    assert {result.payload["id"] for result in tenant_b_results} == {other_dataset_id}
+
+    replacement_id = uuid4()
+    await adapter_a.create_data_points(
+        collection_name,
+        [ClickHouseDataPoint(id=replacement_id, text="NLP old", belongs_to_set=["Old"])],
+    )
+    await adapter_a.create_data_points(
+        collection_name,
+        [ClickHouseDataPoint(id=replacement_id, text="NLP new", belongs_to_set=["New"])],
+    )
+    replacement = await adapter_a.retrieve(collection_name, [str(replacement_id)])
+    assert replacement[0]["text"] == "NLP new"
+
+    deleted = await adapter_a.delete_data_points(collection_name, [str(nlp_id)])
+    assert deleted["deleted"] == 1
+    assert await adapter_a.retrieve(collection_name, [str(nlp_id)]) == []
+
+    await adapter_a.prune()
+    assert await adapter_a.get_collection_names() == []
+    assert len(await adapter_b.get_collection_names()) == 1
+
+    await adapter_b.prune()
+    assert await adapter_b.get_collection_names() == []
+
+
+@pytest.mark.asyncio
+async def test_dataset_handler_metadata_and_delete(require_clickhouse):
+    from cognee import config
+
+    dataset_id = uuid4()
+    config.set_vector_db_config(
+        {
+            "vector_db_provider": "clickhouse",
+            "vector_db_url": clickhouse_url(),
+            "vector_db_key": clickhouse_key(),
+        }
+    )
+
+    dataset_config = await ClickHouseDatasetDatabaseHandler.create_dataset(dataset_id, None)
+    assert dataset_config["vector_database_provider"] == "clickhouse"
+    assert dataset_config["vector_database_name"] == str(dataset_id)
+    assert dataset_config["vector_dataset_database_handler"] == "clickhouse"
+
+    adapter = ClickHouseAdapter(
+        url=clickhouse_url(),
+        api_key=clickhouse_key(),
+        database_name=str(dataset_id),
+        embedding_engine=DeterministicEmbeddingEngine(),
+    )
+    collection_name = f"dataset_delete_{uuid4().hex}"
+    await adapter.create_data_points(
+        collection_name,
+        [ClickHouseDataPoint(id=uuid4(), text="NLP document", belongs_to_set=["NLP"])],
+    )
+    assert len(await adapter.get_collection_names()) == 1
+
+    dataset_database = SimpleNamespace(
+        vector_database_provider="clickhouse",
+        vector_database_url=clickhouse_url(),
+        vector_database_key=clickhouse_key(),
+        vector_database_name=str(dataset_id),
+    )
+
+    with patch(
+        "cognee_community_vector_adapter_clickhouse."
+        "ClickHouseDatasetDatabaseHandler.create_vector_engine",
+        return_value=adapter,
+    ):
+        await ClickHouseDatasetDatabaseHandler.delete_dataset(dataset_database)
+
+    assert await adapter.get_collection_names() == []
+
+
+@pytest.mark.asyncio
+async def test_vector_index_smoke(require_clickhouse, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("COGNEE_CLICKHOUSE_ENABLE_VECTOR_INDEX", "true")
+    adapter = ClickHouseAdapter(
+        url=clickhouse_url(),
+        api_key=clickhouse_key(),
+        database_name=f"ann_{uuid4().hex}",
+        embedding_engine=DeterministicEmbeddingEngine(),
+    )
+    collection_name = f"ann_collection_{uuid4().hex}"
+    await adapter.create_collection(collection_name)
+
+    version_result = await adapter._fetch_one("SELECT version() AS version")
+    version = str(version_result["version"]) if version_result else "0"
+    if adapter._version_at_least(version, (25, 8)):
+        assert await adapter.has_vector_index(collection_name)
+
+    await adapter.prune()
+
+
+@pytest.mark.asyncio
+async def test_cognee_recall_flow(require_clickhouse):
+    if not os.getenv("LLM_API_KEY") or not os.getenv("EMBEDDING_API_KEY"):
+        pytest.skip("Cognee recall flow requires LLM_API_KEY and EMBEDDING_API_KEY.")
+
+    os.environ.setdefault("VECTOR_DATASET_DATABASE_HANDLER", "clickhouse")
+
+    cognee.config.set_relational_db_config({"db_provider": "sqlite"})
+    cognee.config.set_vector_db_config(
+        {
+            "vector_db_provider": "clickhouse",
+            "vector_db_url": clickhouse_url(),
+            "vector_db_key": clickhouse_key(),
+        }
+    )
+    cognee.config.set_graph_db_config({"graph_database_provider": "ladybug"})
+
+    data_directory_path = str(
+        pathlib.Path(
+            os.path.join(pathlib.Path(__file__).parent, ".data_storage/test_clickhouse")
+        ).resolve()
+    )
+    cognee.config.data_root_directory(data_directory_path)
+    cognee_directory_path = str(
+        pathlib.Path(
+            os.path.join(pathlib.Path(__file__).parent, ".cognee_system/test_clickhouse")
+        ).resolve()
+    )
+    cognee.config.system_root_directory(cognee_directory_path)
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    explanation_file_path_nlp = os.path.join(
+        pathlib.Path(__file__).parent.parent.parent.parent,
+        "test_data/Natural_language_processing.txt",
+    )
+    explanation_file_path_quantum = os.path.join(
+        pathlib.Path(__file__).parent.parent.parent.parent,
+        "test_data/Quantum_computers.txt",
+    )
+
+    await cognee.add([explanation_file_path_nlp], "natural_language")
+    await cognee.add([explanation_file_path_quantum], "quantum")
+    await cognee.cognify(["quantum", "natural_language"])
+
+    search_results = await cognee.search(
+        query_type=SearchType.GRAPH_COMPLETION,
+        query_text="Tell me about Quantum computers",
+        datasets=["quantum"],
+    )
+    assert len(search_results) != 0, "The search results list is empty."
+
+    from cognee.infrastructure.databases.vector import get_vector_engine
+
+    vector_engine = get_vector_engine()
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    assert await vector_engine.get_collection_names() == []
+
+
+def test_uuid_payload_ids_remain_uuid_objects(monkeypatch: pytest.MonkeyPatch):
+    clear_clickhouse_env(monkeypatch)
+    adapter = ClickHouseAdapter(embedding_engine=DeterministicEmbeddingEngine())
+    data_id = uuid4()
+    payload = adapter._payload_with_id("{}", str(data_id))
+    assert isinstance(payload["id"], UUID)


### PR DESCRIPTION
## Description
Adds a Cognee community vector adapter for ClickHouse at `packages/vector/clickhouse`.

Cognee remains the memory, graph, and orchestration layer. ClickHouse stores vector embeddings and payload metadata in Cognee-owned `ReplacingMergeTree` tables, one table per Cognee vector collection.

The adapter includes:

- `ClickHouseAdapter` registered as `clickhouse`.
- `ClickHouseDatasetDatabaseHandler` registered as `clickhouse`.
- ClickHouse `Array(Float32)` vector storage with `ReplacingMergeTree` for upsert and soft-delete semantics.
- Exact `dotProduct` search over normalized vectors.
- JSON payload storage and `belongs_to_set` filtering via `hasAny` / `hasAll`.
- Dataset-scoped row isolation with `database_name`.
- Optional approximate vector index (`vector_similarity('hnsw', cosineDistance)`) on ClickHouse 25.8+.
- Prefix-gated, multi-dataset-safe prune behaviour.
- README, `.env.example`, example, tests, and CI workflow wiring.

## Files Added

- `packages/vector/clickhouse/pyproject.toml`
- `packages/vector/clickhouse/README.md`
- `packages/vector/clickhouse/.env.example`
- `packages/vector/clickhouse/example.py`
- `packages/vector/clickhouse/tests/test_clickhouse.py`
- `packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/__init__.py`
- `packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/register.py`
- `packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/clickhouse_adapter.py`
- `packages/vector/clickhouse/cognee_community_vector_adapter_clickhouse/ClickHouseDatasetDatabaseHandler.py`
- `.github/workflows/test_clickhouse.yml`

## Files Updated

- `.github/workflows/vector_db_community_tests.yml`
- `README.md`

## ClickHouse Setup

Local Docker:

```bash
docker run -d --name clickhouse-cognee \
  -e CLICKHOUSE_DB=cognee \
  -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
  -p 8123:8123 -p 9000:9000 \
  clickhouse/clickhouse-server:25.8

curl -sS "http://127.0.0.1:8123/" \
  --data-binary "CREATE DATABASE IF NOT EXISTS cognee"
```

ClickHouse environment:

```bash
export VECTOR_DB_PROVIDER=clickhouse
export VECTOR_DATASET_DATABASE_HANDLER=clickhouse
export VECTOR_DB_URL=http://127.0.0.1:8123/cognee
export CLICKHOUSE_URL=http://127.0.0.1:8123/cognee
export CLICKHOUSE_KEY=
```

For ClickHouse Cloud, use HTTPS on port 8443 with `CLICKHOUSE_SECURE=true`.

## LLM And Embedding Setup Used For Validation

The full Cognee integration test was validated with Featherless AI (OpenAI-compatible endpoint):

```bash
export LLM_PROVIDER=openai
export LLM_MODEL=openai/Qwen/Qwen2.5-14B-Instruct
export LLM_API_KEY="<featherless-api-key>"
export LLM_ENDPOINT="https://api.featherless.ai/v1"
export LLM_INSTRUCTOR_MODE=json_mode

export EMBEDDING_PROVIDER=fastembed
export EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
export EMBEDDING_DIMENSIONS=384

export COGNEE_SKIP_CONNECTION_TEST=true
export ENABLE_BACKEND_ACCESS_CONTROL=false
```

`fastembed` runs entirely locally with no API key required for embeddings. `Qwen2.5-14B-Instruct` was selected because it works reliably with Cognee's `instructor` structured-output flow. High-concurrency-cost models (e.g. Kimi-K2 at 4 units/request) can exhaust plan limits when `cognify()` fires parallel LLM calls.

## Storage Design

Each Cognee collection maps to one ClickHouse table:

```sql
CREATE TABLE cognee_vec_<collection>
(
    database_name  String,
    id             String,
    payload        String,
    text           String,
    belongs_to_set Array(String),
    vector         Array(Float32),
    version        UInt64,
    is_deleted     UInt8
)
ENGINE = ReplacingMergeTree(version, is_deleted)
ORDER BY (database_name, id);
```

Search:

```sql
SELECT id, payload
FROM cognee_vec_<collection> FINAL
WHERE database_name = {database_name:String}
  AND is_deleted = 0
ORDER BY dotProduct(vector, {query_vector:Array(Float32)}) DESC
LIMIT {limit:UInt64};
```

Vectors are normalized before insert and query by default so `dotProduct` behaves like cosine similarity.

## Dataset Isolation

The dataset database handler stores each Cognee dataset with a dataset-specific vector engine `database_name`.

The adapter writes `database_name` as a first-class table column for efficient filtering. All searches, retrievals, deletes, collection listing, and prune operations are scoped by `database_name`.

## Prune Safety

`prune()` only touches tables whose names start with `COGNEE_CLICKHOUSE_TABLE_PREFIX`, defaulting to `cognee_vec_`.

For each prefixed table it issues `ALTER TABLE … DELETE WHERE database_name = ?` (synchronous mutation), then drops the table only when no live rows remain across **all** logical databases sharing that physical table.

No unprefixed user tables are touched.

## Validation Results Observed Locally

- ClickHouse table creation and schema verification.
- Upsert (create and overwrite via `ReplacingMergeTree` version bump).
- Retrieve by ID.
- Exact vector search with `dotProduct`.
- Payload JSON round-trip.
- `belongs_to_set` OR and AND filtering.
- Dataset isolation between two `database_name` values in the same physical table.
- Dataset handler create and delete behaviour.
- Vector index smoke test (ANN index creation on ClickHouse 25.8).
- Full Cognee `add`, `cognify`, and `search` (GRAPH_COMPLETION).
- Final prune cleanup with empty-collection assertion.
- `example.py` end-to-end run.

All 14 tests passed on ClickHouse 24.8, 25.7, and 25.8.

## Known Notes

- Exact search is always the fallback and correctness baseline across all supported ClickHouse versions.
- ANN index creation (`vector_similarity`) is best-effort: the adapter logs a warning and falls back to exact search when the server version is below 25.8 or index creation fails.
- `EMBEDDING_PROVIDER=openai` uses TikToken and only maps OpenAI model names. Use `EMBEDDING_PROVIDER=openai_compatible` with explicit `EMBEDDING_DIMENSIONS`, or `EMBEDDING_PROVIDER=fastembed` for local embeddings.
- All queries use `FINAL` to deduplicate `ReplacingMergeTree` tombstones at query time.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
