### PR TITLE
feat(falkordb): add get_id_filtered_graph_data

### DIFF
--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -135,8 +135,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
             # FalkorDB arrays must hold primitives (and reject null elements);
             # if any element isn't one, store the whole array as a JSON string.
             if all(
-                item is not None and isinstance(item, (bool, int, float, str))
-                for item in coerced
+                item is not None and isinstance(item, (bool, int, float, str)) for item in coerced
             ):
                 return coerced
             return json.dumps(value, default=str)
@@ -159,10 +158,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         still coerced.
         """
         if isinstance(value, dict):
-            return {
-                key: FalkorDBAdapter._coerce_stored_value(val)
-                for key, val in value.items()
-            }
+            return {key: FalkorDBAdapter._coerce_stored_value(val) for key, val in value.items()}
         if isinstance(value, (list, tuple)):
             return [FalkorDBAdapter._coerce_param_value(item) for item in value]
         if isinstance(value, Enum):
@@ -181,10 +177,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         nested map/array in a model-extracted entity rejects the whole query and
         aborts the pipeline run.
         """
-        return {
-            key: FalkorDBAdapter._coerce_param_value(value)
-            for key, value in params.items()
-        }
+        return {key: FalkorDBAdapter._coerce_param_value(value) for key, value in params.items()}
 
     # TODO: This should return a list of results, not a single result
     async def query(self, query: str, params: dict = None) -> list:

--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -1552,6 +1552,71 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         # FalkorDB returns node objects as first element in each record
         return [record[0] for record in result.result_set] if result.result_set else []
 
+    async def get_id_filtered_graph_data(
+        self, target_ids: list[str]
+    ) -> tuple[list[tuple[str, dict]], list[tuple[str, str, str, dict]]]:
+        """
+        Fetch a subgraph scoped to ``target_ids`` and their incident edges.
+
+        cognee's ``GraphCompletionRetriever`` vector-searches the top
+        ``wide_search_top_k`` relevant node ids, then projects a graph scoped to
+        them via ``CogneeGraph._get_full_or_id_filtered_graph`` — but only if the
+        adapter implements this method. Without it the retriever silently falls
+        back to ``get_graph_data()`` and loads the whole graph, so the vector
+        search results are ignored and every query projects the same (full)
+        subgraph regardless of query content (the Neo4j, Postgres and Ladybug
+        adapters all implement it; this brings FalkorDB in line).
+
+        The traversal is anchored on the bound id set (``WHERE a.id IN $ids`` — a
+        NodeByIdSeek via the :Node(id) index) and expands undirected, mirroring
+        ``get_nodeset_subgraph``, NOT an untyped full-graph ``MATCH ()-[r]-()``:
+        cognee mints ~one relationship TYPE per relationship name (easily tens of
+        thousands on a real graph) and FalkorDB keeps one adjacency matrix per
+        type, so an unanchored untyped match probes every per-type matrix for
+        every node. Edge direction is taken from ``properties(r).source_node_id``
+        / ``target_node_id`` so it survives the undirected match; a seed<->seed
+        edge returned twice (once per anchor) is de-duped.
+
+        Returns the same tuple shape as ``get_graph_data``::
+
+            (
+                [(node_id, properties), ...],
+                [(source_id, target_id, relationship_type, properties), ...],
+            )
+        """
+        if not target_ids:
+            return [], []
+
+        query = """
+        MATCH (a)-[r]-(b)
+        WHERE a.id IN $ids
+        RETURN properties(a) AS a_props, properties(b) AS b_props,
+               type(r) AS rel_type, properties(r) AS rel_props
+        """
+        result = await self.query(query, {"ids": list(target_ids)})
+
+        nodes: dict = {}
+        edges: dict = {}
+        if result.result_set:
+            for record in result.result_set:
+                # FalkorDB returns values by index: a_props, b_props, type, rel_props
+                a_props = self._deserialize_node_properties(record[0])
+                b_props = self._deserialize_node_properties(record[1])
+                rel_type = record[2]
+                rel_props = record[3] or {}
+                nodes[a_props["id"]] = (a_props["id"], a_props)
+                nodes[b_props["id"]] = (b_props["id"], b_props)
+                source_id = rel_props.get("source_node_id", a_props["id"])
+                target_id = rel_props.get("target_node_id", b_props["id"])
+                edges[(source_id, target_id, rel_type)] = (
+                    source_id,
+                    target_id,
+                    rel_type,
+                    rel_props,
+                )
+
+        return list(nodes.values()), list(edges.values())
+
     async def get_nodeset_subgraph(
         self, node_type: type[Any], node_name: list[str], node_name_filter_operator: str = "OR"
     ) -> tuple[list[tuple[int, dict]], list[tuple[int, int, str, dict]]]:

--- a/packages/hybrid/falkordb/tests/test_id_filtered_graph_data.py
+++ b/packages/hybrid/falkordb/tests/test_id_filtered_graph_data.py
@@ -53,9 +53,7 @@ def test_projects_nodes_and_directed_edges():
         "s1": {"id": "s1", "name": "seed"},
         "n1": {"id": "n1", "name": "neighbor"},
     }
-    assert edges == [
-        ("s1", "n1", "RELATES_TO", {"source_node_id": "s1", "target_node_id": "n1"})
-    ]
+    assert edges == [("s1", "n1", "RELATES_TO", {"source_node_id": "s1", "target_node_id": "n1"})]
 
 
 def test_direction_from_rel_props_not_match_order():
@@ -71,9 +69,7 @@ def test_direction_from_rel_props_not_match_order():
     ]
     adapter, _ = _make_adapter_with_mock_query(rows)
     _, edges = asyncio.run(adapter.get_id_filtered_graph_data(["s1"]))
-    assert edges == [
-        ("s1", "n1", "RELATES_TO", {"source_node_id": "s1", "target_node_id": "n1"})
-    ]
+    assert edges == [("s1", "n1", "RELATES_TO", {"source_node_id": "s1", "target_node_id": "n1"})]
 
 
 def test_seed_to_seed_edge_deduped():

--- a/packages/hybrid/falkordb/tests/test_id_filtered_graph_data.py
+++ b/packages/hybrid/falkordb/tests/test_id_filtered_graph_data.py
@@ -1,0 +1,97 @@
+"""Unit tests for get_id_filtered_graph_data().
+
+Verifies the id-scoped subgraph projection used by cognee's
+GraphCompletionRetriever: node/edge tuple shapes, edge direction taken from
+properties(r), and seed<->seed de-dup. No FalkorDB connection is required —
+uses a mock driver, same style as test_query_return_type.py.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+from cognee_community_hybrid_adapter_falkor.falkor_adapter import FalkorDBAdapter
+
+
+def _make_adapter_with_mock_query(result_set):
+    """Create a FalkorDBAdapter whose query() returns a fixed result_set."""
+    adapter = object.__new__(FalkorDBAdapter)
+    adapter.graph_name = "test_graph"
+
+    mock_result = MagicMock()
+    mock_result.result_set = result_set
+    mock_result.header = []
+
+    mock_graph = MagicMock()
+    mock_graph.query.return_value = mock_result
+
+    mock_driver = MagicMock()
+    mock_driver.select_graph.return_value = mock_graph
+
+    adapter.driver = mock_driver
+    return adapter, mock_graph
+
+
+def test_empty_target_ids_short_circuits():
+    adapter, mock_graph = _make_adapter_with_mock_query([])
+    nodes, edges = asyncio.run(adapter.get_id_filtered_graph_data([]))
+    assert nodes == [] and edges == []
+    mock_graph.query.assert_not_called()  # never touches the DB
+
+
+def test_projects_nodes_and_directed_edges():
+    rows = [
+        [
+            {"id": "s1", "name": "seed"},
+            {"id": "n1", "name": "neighbor"},
+            "RELATES_TO",
+            {"source_node_id": "s1", "target_node_id": "n1"},
+        ],
+    ]
+    adapter, _ = _make_adapter_with_mock_query(rows)
+    nodes, edges = asyncio.run(adapter.get_id_filtered_graph_data(["s1"]))
+    assert dict(nodes) == {
+        "s1": {"id": "s1", "name": "seed"},
+        "n1": {"id": "n1", "name": "neighbor"},
+    }
+    assert edges == [
+        ("s1", "n1", "RELATES_TO", {"source_node_id": "s1", "target_node_id": "n1"})
+    ]
+
+
+def test_direction_from_rel_props_not_match_order():
+    # Undirected match can bind `a` to the target end; direction must come from
+    # properties(r), so the edge stays s1 -> n1 even though a == n1 here.
+    rows = [
+        [
+            {"id": "n1"},
+            {"id": "s1"},
+            "RELATES_TO",
+            {"source_node_id": "s1", "target_node_id": "n1"},
+        ],
+    ]
+    adapter, _ = _make_adapter_with_mock_query(rows)
+    _, edges = asyncio.run(adapter.get_id_filtered_graph_data(["s1"]))
+    assert edges == [
+        ("s1", "n1", "RELATES_TO", {"source_node_id": "s1", "target_node_id": "n1"})
+    ]
+
+
+def test_seed_to_seed_edge_deduped():
+    # Undirected match returns a seed<->seed edge twice (once per anchor).
+    e = {"source_node_id": "s1", "target_node_id": "s2"}
+    rows = [
+        [{"id": "s1"}, {"id": "s2"}, "REL", e],
+        [{"id": "s2"}, {"id": "s1"}, "REL", e],
+    ]
+    adapter, _ = _make_adapter_with_mock_query(rows)
+    nodes, edges = asyncio.run(adapter.get_id_filtered_graph_data(["s1", "s2"]))
+    assert {n[0] for n in nodes} == {"s1", "s2"}
+    assert len(edges) == 1
+    assert edges[0][:3] == ("s1", "s2", "REL")
+
+
+def test_falls_back_to_endpoints_when_rel_props_lack_ids():
+    rows = [[{"id": "s1"}, {"id": "n1"}, "REL", {}]]
+    adapter, _ = _make_adapter_with_mock_query(rows)
+    _, edges = asyncio.run(adapter.get_id_filtered_graph_data(["s1"]))
+    assert edges == [("s1", "n1", "REL", {})]

--- a/packages/hybrid/falkordb/tests/test_sanitize_params.py
+++ b/packages/hybrid/falkordb/tests/test_sanitize_params.py
@@ -96,9 +96,7 @@ def test_bound_list_of_maps_preserved_for_unwind():
     result = FalkorDBAdapter._sanitize_cypher_params(
         {"items": [{"edge_index": 0, "props": {"w": 1}}, {"edge_index": 1}]}
     )
-    assert result == {
-        "items": [{"edge_index": 0, "props": '{"w": 1}'}, {"edge_index": 1}]
-    }
+    assert result == {"items": [{"edge_index": 0, "props": '{"w": 1}'}, {"edge_index": 1}]}
 
 
 def test_stored_map_value_json_encoded():
@@ -113,9 +111,7 @@ def test_stored_map_value_json_encoded():
 def test_stored_array_of_maps_json_encoded():
     # An array of maps as a stored property value becomes an array of JSON strings
     # (a valid array-of-primitives).
-    result = FalkorDBAdapter._sanitize_cypher_params(
-        {"properties": {"objs": [{"k": 1}, {"k": 2}]}}
-    )
+    result = FalkorDBAdapter._sanitize_cypher_params({"properties": {"objs": [{"k": 1}, {"k": 2}]}})
     assert result == {"properties": {"objs": ['{"k": 1}', '{"k": 2}']}}
 
 


### PR DESCRIPTION
## Problem

`CogneeGraph._get_full_or_id_filtered_graph` scopes graph projection to the vector-search hits by calling `adapter.get_id_filtered_graph_data(target_ids)` **when the adapter implements it**, else it falls back to `get_graph_data()` (full graph). The Neo4j, Postgres and Ladybug adapters implement it; **`FalkorDBAdapter` does not**, so on FalkorDB the fallback always fires:

- the `wide_search_top_k` vector-search node ids are silently ignored
- every `GRAPH_COMPLETION` query projects the same full subgraph regardless of query content
- no error, no warning — just a full-graph load that is unusable on a large graph (times out)

This mirrors the Postgres gap fixed in topoteretes/cognee#2998.

## Fix

Implement `get_id_filtered_graph_data(target_ids)` with a single anchored Cypher that seeks the seed ids (`WHERE a.id IN $ids` — a NodeByIdSeek via the `:Node(id)` index) and expands their incident edges undirected, **mirroring the existing `get_nodeset_subgraph` idiom** rather than an untyped full-graph `MATCH ()-[r]-()`.

Why not the untyped form the Neo4j adapter uses: cognee mints ~one relationship **type** per relationship name (tens of thousands on a real graph), and FalkorDB keeps one adjacency matrix per type, so an unanchored untyped match probes every per-type matrix for every node. Anchoring the traversal to the bound seed set keeps it a NodeByIdSeek + real-degree expansion.

Details:
- Edge direction is taken from `properties(r).source_node_id` / `target_node_id` (the same fields `get_graph_data` reads), so it survives the undirected match; `startNode`/`endNode` are avoided (unused elsewhere in this adapter).
- A seed↔seed edge returned twice (once per anchor) is de-duped by `(source, target, type)`.
- Node properties are run through `_deserialize_node_properties`, matching `get_graph_data`.
- Returns the same `(nodes, edges)` tuple shape as `get_graph_data`.

## Tests

Adds `tests/test_id_filtered_graph_data.py` (mock driver, no FalkorDB connection required): empty-input short-circuit, node/edge projection, direction-from-`properties(r)`, seed↔seed de-dup, endpoint fallback when edge props lack ids.

## Notes

Deployed and verified against a live ~124k-node / 1.6M-edge FalkorDB cognee graph: an explicit `GRAPH_COMPLETION` recall went from timing out (>180s, no answer) to returning a real graph-grounded answer; the id-filtered projection of a 100-seed subgraph returns 549 nodes / 1430 edges in ~24s vs the full-graph load timing out.