### PR TITLE
Add LodeDB vector database adapter

### DIFF
--- a/packages/vector/lodedb/.env.example
+++ b/packages/vector/lodedb/.env.example
@@ -1,0 +1,7 @@
+LLM_API_KEY=YOUR_OPENAI_API_KEY
+
+# LodeDB is local, on-disk, and in-process: no server, account, or API key.
+# vector_db_url is the base directory for LodeDB indexes (created if absent);
+# one LodeDB index is kept per cognee collection under it.
+VECTOR_DB_PROVIDER=lodedb
+VECTOR_DB_URL=./.lodedb

--- a/packages/vector/lodedb/README.md
+++ b/packages/vector/lodedb/README.md
@@ -25,8 +25,7 @@ poetry install   # run in the directory containing pyproject.toml
 
 The adapter itself ships in the `lodedb` package
 (`lodedb.local.integrations.cognee.CogneeLodeDBAdapter`); this package registers it with
-cognee. It needs the LodeDB release that includes the cognee adapter (`pip install
-"lodedb[cognee]"`).
+cognee. It needs LodeDB >= 1.3.1 (the release that added the cognee adapter).
 
 ## Usage
 

--- a/packages/vector/lodedb/README.md
+++ b/packages/vector/lodedb/README.md
@@ -1,0 +1,72 @@
+# Cognee LodeDB Adapter
+
+[LodeDB](https://github.com/Egoist-Machines/LodeDB) is a local-first, on-disk, in-process
+vector database: no server, no account, no API key, and your data never leaves the machine.
+It has an exact brute-force scan by default (results don't drift with index size), optional
+IVF-style ANN for large corpora, hybrid (vector + BM25) retrieval, and O(changed) delta
+persistence for fast incremental writes.
+
+This package registers LodeDB as a cognee `vector_db_provider`.
+
+## Installation
+
+If published, install via pip:
+
+```bash
+pip install cognee-community-vector-adapter-lodedb
+```
+
+Otherwise build it locally from this directory:
+
+```bash
+pip install poetry
+poetry install   # run in the directory containing pyproject.toml
+```
+
+The adapter itself ships in the `lodedb` package
+(`lodedb.local.integrations.cognee.CogneeLodeDBAdapter`); this package registers it with
+cognee. It needs the LodeDB release that includes the cognee adapter (`pip install
+"lodedb[cognee]"`).
+
+## Usage
+
+Import and register the adapter, then point cognee at a local directory:
+
+```python
+import cognee
+from cognee_community_vector_adapter_lodedb import register  # noqa: F401
+
+cognee.config.set_vector_db_config(
+    {
+        "vector_db_provider": "lodedb",
+        "vector_db_url": "./.lodedb",  # base directory for LodeDB indexes
+    }
+)
+```
+
+Or configure it entirely from the environment (see `.env.example`):
+
+```dotenv
+VECTOR_DB_PROVIDER=lodedb
+VECTOR_DB_URL=./.lodedb
+```
+
+`vector_db_url` is a directory (created if absent). LodeDB keeps one index per cognee
+collection under it. `vector_db_key` is unused (LodeDB is local and needs no credential).
+
+## How it works
+
+cognee owns embedding via its configured `EmbeddingEngine`, so the adapter uses LodeDB's
+vector-in path. For each cognee `DataPoint` it embeds the indexed field and stores the vector
+in LodeDB; the serialized DataPoint payload is kept in LodeDB's raw-text sidecar (so
+`retrieve` and `include_payload` searches return it), and `belongs_to_set` membership is stored
+as scalar metadata presence keys so cognee's `node_name` (NodeSet) filtering pushes into
+LodeDB's metadata planner. cognee ranks by cosine distance (lower is better), so search results
+report `1 - cosine_similarity`.
+
+The embedding dimension must be a positive multiple of 8 (a LodeDB vector-index requirement).
+Common embedding dimensions (384, 768, 1024, 1536, 3072) all satisfy this.
+
+## Example
+
+See `example.py`.

--- a/packages/vector/lodedb/cognee_community_vector_adapter_lodedb/__init__.py
+++ b/packages/vector/lodedb/cognee_community_vector_adapter_lodedb/__init__.py
@@ -1,0 +1,3 @@
+from .lodedb_adapter import CogneeLodeDBAdapter, LodeDBAdapter
+
+__all__ = ["CogneeLodeDBAdapter", "LodeDBAdapter"]

--- a/packages/vector/lodedb/cognee_community_vector_adapter_lodedb/lodedb_adapter.py
+++ b/packages/vector/lodedb/cognee_community_vector_adapter_lodedb/lodedb_adapter.py
@@ -1,0 +1,25 @@
+"""LodeDB vector adapter for cognee.
+
+The adapter implementation lives in the ``lodedb`` package
+(``lodedb.local.integrations.cognee.CogneeLodeDBAdapter``), where it is maintained and
+tested against LodeDB's API and versioned with LodeDB releases. This module re-exports
+it under the cognee-community naming so :mod:`register` can register the provider.
+
+LodeDB is a local-first, on-disk, in-process vector store (no server, no account, no
+API key), so the adapter treats ``vector_db_url`` as a base directory and keeps one
+LodeDB index per cognee collection under it.
+"""
+
+try:
+    from lodedb.local.integrations.cognee import CogneeLodeDBAdapter, IndexSchema
+except ImportError as exc:  # pragma: no cover - clear install hint
+    raise ImportError(
+        "cognee-community-vector-adapter-lodedb needs a LodeDB build that ships the "
+        "cognee adapter (lodedb.local.integrations.cognee). Install/upgrade with "
+        "'pip install \"lodedb[cognee]\"'."
+    ) from exc
+
+# Alias to the cognee-community adapter naming convention (e.g. QDrantAdapter).
+LodeDBAdapter = CogneeLodeDBAdapter
+
+__all__ = ["CogneeLodeDBAdapter", "LodeDBAdapter", "IndexSchema"]

--- a/packages/vector/lodedb/cognee_community_vector_adapter_lodedb/register.py
+++ b/packages/vector/lodedb/cognee_community_vector_adapter_lodedb/register.py
@@ -1,0 +1,5 @@
+from cognee.infrastructure.databases.vector import use_vector_adapter
+
+from .lodedb_adapter import LodeDBAdapter
+
+use_vector_adapter("lodedb", LodeDBAdapter)

--- a/packages/vector/lodedb/example.py
+++ b/packages/vector/lodedb/example.py
@@ -1,0 +1,48 @@
+import asyncio
+import os
+import pathlib
+from os import path
+
+import cognee
+from cognee import config
+
+# NOTE: Importing the register module lets cognee know it can use the LodeDB vector adapter.
+# NOTE: The "noqa: F401" mark keeps the linter from flagging this as an unused import.
+from cognee_community_vector_adapter_lodedb import register  # noqa: F401
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MY_PREFERENCE = """
+- I like to visit places near the beach where I can find the best spots.
+- I need locations that are rare to find on blogs but are goldmine places for your eyes
+- I prefer Vegetarian meals. Use this when I ask for restaurants recommendation
+- My hobbies that might also help in planning Itineraries: I love Anime, F1 and Cricket.
+"""
+
+
+async def main():
+    system_path = pathlib.Path(__file__).parent
+    config.system_root_directory(path.join(system_path, ".cognee_system"))
+    config.data_root_directory(path.join(system_path, ".data_storage"))
+
+    config.set_relational_db_config({"db_provider": "sqlite"})
+    # LodeDB is local and on-disk: vector_db_url is a directory (created if absent).
+    config.set_vector_db_config(
+        {
+            "vector_db_provider": "lodedb",
+            "vector_db_url": os.getenv("VECTOR_DB_URL", path.join(system_path, ".lodedb")),
+            "vector_db_key": "",
+        }
+    )
+    await cognee.remember(MY_PREFERENCE)
+
+    query_text = "plan a 3 days Itinerary for Berlin along with restaurants to try food."
+    search_results = await cognee.recall(query_text=query_text)
+
+    for result_text in search_results:
+        print(result_text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/vector/lodedb/pyproject.toml
+++ b/packages/vector/lodedb/pyproject.toml
@@ -6,9 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     # The adapter implementation ships in the lodedb package
-    # (lodedb.local.integrations.cognee). Requires the LodeDB release that first
-    # includes it; bump this floor to that version when it is published.
-    "lodedb>=1.4.0",
+    # (lodedb.local.integrations.cognee), added in lodedb 1.3.1.
+    "lodedb>=1.3.1",
     "cognee>=1.1.0,<2.0.0",
 ]
 

--- a/packages/vector/lodedb/pyproject.toml
+++ b/packages/vector/lodedb/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "cognee-community-vector-adapter-lodedb"
+version = "0.1.0"
+description = "LodeDB vector database adapter for cognee"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    # The adapter implementation ships in the lodedb package
+    # (lodedb.local.integrations.cognee). Requires the LodeDB release that first
+    # includes it; bump this floor to that version when it is published.
+    "lodedb>=1.4.0",
+    "cognee>=1.1.0,<2.0.0",
+]
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["cognee_community_vector_adapter_lodedb*"]

--- a/packages/vector/lodedb/tests/test_lodedb.py
+++ b/packages/vector/lodedb/tests/test_lodedb.py
@@ -1,0 +1,76 @@
+"""Offline tests for the cognee-community LodeDB vector adapter.
+
+These drive the adapter directly with a deterministic one-hot embedding engine, so they
+run with no LLM or API key. Importing ``register`` also verifies the provider registers
+with cognee's vector-adapter registry.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("lodedb")
+pytest.importorskip("cognee")
+
+from cognee.infrastructure.databases.vector.supported_databases import supported_databases
+from cognee.infrastructure.engine import DataPoint
+from cognee_community_vector_adapter_lodedb import register  # noqa: F401
+from cognee_community_vector_adapter_lodedb.lodedb_adapter import LodeDBAdapter
+
+DIM = 8
+
+
+class OneHotEmbeddingEngine:
+    def __init__(self) -> None:
+        self._index: dict[str, int] = {}
+
+    async def embed_text(self, text: list[str]) -> list[list[float]]:
+        vectors = []
+        for value in text:
+            self._index.setdefault(value, len(self._index))
+            vector = [0.0] * DIM
+            vector[self._index[value]] = 1.0
+            vectors.append(vector)
+        return vectors
+
+    def get_vector_size(self) -> int:
+        return DIM
+
+    def get_batch_size(self) -> int:
+        return 32
+
+
+class Note(DataPoint):
+    text: str
+    metadata: dict = {"index_fields": ["text"]}
+
+
+def test_register_registers_lodedb_provider():
+    assert "lodedb" in supported_databases
+    assert supported_databases["lodedb"] is LodeDBAdapter
+
+
+def test_create_search_retrieve_and_node_name(tmp_path):
+    async def body():
+        adapter = LodeDBAdapter(url=str(tmp_path), embedding_engine=OneHotEmbeddingEngine())
+        a = Note(text="alice likes espresso", belongs_to_set=["people"])
+        b = Note(text="the project uses lodedb", belongs_to_set=["project"])
+        await adapter.create_data_points("Note_text", [a, b])
+
+        hits = await adapter.search(
+            "Note_text", query_text="alice likes espresso", limit=2, include_payload=True
+        )
+        assert hits[0].id == a.id
+        assert hits[0].payload["text"] == "alice likes espresso"
+        assert hits[0].score <= hits[1].score
+
+        scoped = await adapter.search(
+            "Note_text", query_text="alice likes espresso", limit=5, node_name=["project"]
+        )
+        assert {hit.id for hit in scoped} == {b.id}
+
+        got = await adapter.retrieve("Note_text", [str(a.id)])
+        assert got[0].payload["text"] == "alice likes espresso"
+        adapter.close()
+
+    asyncio.run(body())


### PR DESCRIPTION
## Summary
Adds `cognee-community-vector-adapter-lodedb`, registering [LodeDB](https://github.com/Egoist-Machines/LodeDB) as a cognee `vector_db_provider`. LodeDB is a local-first, on-disk, in-process vector store (no server, no account, no API key): an exact brute-force scan by default, optional IVF-style ANN for large corpora, hybrid (vector + BM25) retrieval, and O(changed) delta persistence for fast incremental writes.

## How it works
cognee owns embedding (its `EmbeddingEngine`), so the adapter uses LodeDB's vector-in path:
- One LodeDB index per cognee collection under `vector_db_url` (a local directory, created if absent).
- The serialized DataPoint payload is kept in LodeDB's raw-text sidecar, so `retrieve` and `include_payload` searches return it.
- `belongs_to_set` membership is stored as scalar metadata presence keys, so `node_name` (NodeSet) filtering pushes into LodeDB's metadata planner rather than post-filtering in Python.
- cognee ranks by cosine distance (lower is better), so results report `1 - cosine_similarity`.

Implements the full `VectorDBInterface` (`has_collection`, `create_collection`, `create_data_points`, `search`, `batch_search`, `retrieve`, `delete_data_points`, `create_vector_index`, `index_data_points`, `prune`, `embed_data`) plus `remove_belongs_to_set_tags` and `upsert_raw_vectors`.

The adapter implementation ships in the `lodedb` package (`lodedb.local.integrations.cognee`, added in lodedb 1.3.1) where it is maintained and tested against LodeDB's API; this package registers it via `use_vector_adapter("lodedb", ...)`.

## Usage
```python
import cognee
from cognee_community_vector_adapter_lodedb import register  # noqa: F401

cognee.config.set_vector_db_config(
    {"vector_db_provider": "lodedb", "vector_db_url": "./.lodedb"}
)
```
Or via env (`.env.example`): `VECTOR_DB_PROVIDER=lodedb`, `VECTOR_DB_URL=./.lodedb`.

## Contents
- `cognee_community_vector_adapter_lodedb/` — `register` module + adapter re-export
- `pyproject.toml` (`lodedb>=1.3.1`, `cognee>=1.1.0,<2`), `README.md`, `example.py`, `.env.example`
- `tests/test_lodedb.py` — offline tests (deterministic stub embedding, no LLM or network): provider registration, create/search/retrieve roundtrip, and `node_name` (`belongs_to_set`) filtering.

## Notes
I held off on adding a `test_lodedb.yml` workflow and a committed lockfile, since CI wiring depends on the org's LLM/embedding secrets and your preferred lock tooling. Happy to add a per-package workflow following the milvus/qdrant pattern (the included tests are offline and need no secrets) and a `poetry.lock` if you'd like.