### PR TITLE
fix(memgraph): return real graph metrics instead of the all-zero fallback

### DIFF
--- a/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/memgraph_adapter.py
+++ b/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/memgraph_adapter.py
@@ -1161,6 +1161,67 @@ class MemgraphAdapter(GraphDBInterface):
         )
         return relationship_types_undirected_str
 
+    async def _connected_component_sizes(self) -> list[int]:
+        """
+        Return the sizes of the graph's weakly connected components.
+
+        Uses MAGE's weakly_connected_components when available, falling back to a
+        client-side union-find for deployments running Memgraph without MAGE.
+
+        Returns:
+        --------
+
+            - list[int]: One entry per component, holding that component's node count.
+        """
+        try:
+            rows = await self.query(
+                """
+                CALL weakly_connected_components.get()
+                YIELD node, component_id
+                RETURN component_id, count(node) AS size
+                """
+            )
+            return [int(row["size"]) for row in rows]
+        except Neo4jError:
+            logger.debug("MAGE unavailable; computing connected components client-side.")
+            return await self._connected_component_sizes_without_mage()
+
+    async def _connected_component_sizes_without_mage(self) -> list[int]:
+        """
+        Compute weakly connected component sizes client-side via union-find.
+
+        Transfers the node ids and edge endpoints, so cost grows with graph size; it
+        exists so metrics still work without the MAGE query modules installed.
+
+        Returns:
+        --------
+
+            - list[int]: One entry per component, holding that component's node count.
+        """
+        nodes = await self.query("MATCH (n) RETURN n.id AS id")
+        edges = await self.query("MATCH (a)-[]->(b) RETURN a.id AS source, b.id AS target")
+
+        parent = {row["id"]: row["id"] for row in nodes}
+
+        def find(node_id):
+            while parent[node_id] != node_id:
+                parent[node_id] = parent[parent[node_id]]
+                node_id = parent[node_id]
+            return node_id
+
+        for edge in edges:
+            source, target = edge["source"], edge["target"]
+            if source in parent and target in parent:
+                source_root, target_root = find(source), find(target)
+                if source_root != target_root:
+                    parent[target_root] = source_root
+
+        sizes: dict[Any, int] = {}
+        for node_id in parent:
+            root = find(node_id)
+            sizes[root] = sizes.get(root, 0) + 1
+        return list(sizes.values())
+
     async def get_graph_metrics(self, include_optional=False):
         """
         Calculate and return various metrics of the graph, including mandatory and optional
@@ -1179,11 +1240,12 @@ class MemgraphAdapter(GraphDBInterface):
         """
 
         try:
-            # Basic metrics
-            node_count = await self.query("MATCH (n) RETURN count(n)")
-            edge_count = await self.query("MATCH ()-[r]->() RETURN count(r)")
-            num_nodes = node_count[0][0] if node_count else 0
-            num_edges = edge_count[0][0] if edge_count else 0
+            # Basic metrics. query() returns a list of dicts keyed by the RETURN
+            # names, so every result is aliased and read by key.
+            node_count = await self.query("MATCH (n) RETURN count(n) AS cnt")
+            edge_count = await self.query("MATCH ()-[r]->() RETURN count(r) AS cnt")
+            num_nodes = node_count[0]["cnt"] if node_count else 0
+            num_edges = edge_count[0]["cnt"] if edge_count else 0
 
             # Calculate mandatory metrics
             mandatory_metrics = {
@@ -1193,18 +1255,7 @@ class MemgraphAdapter(GraphDBInterface):
                 "edge_density": (num_edges) / (num_nodes * (num_nodes - 1)) if num_nodes > 1 else 0,
             }
 
-            # Calculate connected components
-            components_query = """
-            MATCH (n:Node)
-            WITH n.id AS node_id
-            MATCH path = (n)-[:EDGE*0..]-()
-            WITH COLLECT(DISTINCT node_id) AS component
-            RETURN COLLECT(component) AS components
-            """
-            components_result = await self.query(components_query)
-            component_sizes = (
-                [len(comp) for comp in components_result[0][0]] if components_result else []
-            )
+            component_sizes = await self._connected_component_sizes()
 
             mandatory_metrics.update(
                 {
@@ -1214,58 +1265,17 @@ class MemgraphAdapter(GraphDBInterface):
             )
 
             if include_optional:
-                # Self-loops
-                self_loops_query = """
-                MATCH (n:Node)-[r:EDGE]->(n)
-                RETURN COUNT(r)
-                """
-                self_loops = await self.query(self_loops_query)
-                num_selfloops = self_loops[0][0] if self_loops else 0
+                self_loops = await self.query("MATCH (n)-[r]->(n) RETURN COUNT(r) AS cnt")
+                num_selfloops = self_loops[0]["cnt"] if self_loops else 0
 
-                # Shortest paths (simplified for Kuzu)
-                paths_query = """
-                MATCH (n:Node), (m:Node)
-                WHERE n.id < m.id
-                MATCH path = (n)-[:EDGE*]-(m)
-                RETURN MIN(LENGTH(path)) AS length
-                """
-                paths = await self.query(paths_query)
-                path_lengths = [p[0] for p in paths if p[0] is not None]
-
-                # Local clustering coefficient
-                clustering_query = """
-                /// Step 1: Get each node with its neighbors and degree
-                MATCH (n:Node)-[:EDGE]-(neighbor)
-                WITH n, COLLECT(DISTINCT neighbor) AS neighbors, COUNT(DISTINCT neighbor) AS degree
-
-                // Step 2: Pair up neighbors and check if they are connected
-                UNWIND neighbors AS n1
-                UNWIND neighbors AS n2
-                WITH n, degree, n1, n2
-                WHERE id(n1) < id(n2)  // avoid duplicate pairs
-
-                // Step 3: Use OPTIONAL MATCH to see if n1 and n2 are connected
-                OPTIONAL MATCH (n1)-[:EDGE]-(n2)
-                WITH n, degree, COUNT(n2) AS triangle_count
-
-                // Step 4: Compute local clustering coefficient
-                WITH n, degree,
-                    CASE WHEN degree <= 1 THEN 0.0
-                        ELSE (1.0 * triangle_count) / (degree * (degree - 1) / 2.0)
-                    END AS local_cc
-
-                // Step 5: Compute average
-                RETURN AVG(local_cc) AS avg_clustering_coefficient
-                """
-                clustering = await self.query(clustering_query)
-
+                # The all-pairs metrics below need every shortest path in the graph,
+                # which is prohibitive on a general graph. They are reported as
+                # unsupported (-1), consistent with the other community adapters.
                 optional_metrics = {
                     "num_selfloops": num_selfloops,
-                    "diameter": max(path_lengths) if path_lengths else -1,
-                    "avg_shortest_path_length": sum(path_lengths) / len(path_lengths)
-                    if path_lengths
-                    else -1,
-                    "avg_clustering": clustering[0][0] if clustering and clustering[0][0] else -1,
+                    "diameter": -1,
+                    "avg_shortest_path_length": -1,
+                    "avg_clustering": -1,
                 }
             else:
                 optional_metrics = {

--- a/packages/graph/memgraph/tests/test_memgraph.py
+++ b/packages/graph/memgraph/tests/test_memgraph.py
@@ -66,6 +66,43 @@ async def test_add_edges_persists_all_relationship_types(graph_engine):
     assert edge_count_rows[0]["edge_count"] == 3
 
 
+async def test_get_graph_metrics_reports_real_counts(graph_engine):
+    # Two disconnected components: Alice-Apollo-Acme (3) and Bob-Zeus (2).
+    alice_id = uuid4()
+    apollo_id = uuid4()
+    acme_id = uuid4()
+    bob_id = uuid4()
+    zeus_id = uuid4()
+
+    await graph_engine.add_nodes(
+        [
+            Person(id=alice_id, name="Alice"),
+            Project(id=apollo_id, name="Apollo"),
+            Company(id=acme_id, name="Acme"),
+            Person(id=bob_id, name="Bob"),
+            Project(id=zeus_id, name="Zeus"),
+        ]
+    )
+
+    await graph_engine.add_edges(
+        [
+            (str(alice_id), str(apollo_id), "WORKS_ON", {"role": "developer"}),
+            (str(alice_id), str(acme_id), "EMPLOYED_BY", {"since": "2025"}),
+            (str(bob_id), str(zeus_id), "WORKS_ON", {"role": "designer"}),
+        ]
+    )
+
+    metrics = await graph_engine.get_graph_metrics(include_optional=True)
+
+    assert metrics["num_nodes"] == 5
+    assert metrics["num_edges"] == 3
+    assert metrics["mean_degree"] == (2 * 3) / 5
+    assert metrics["edge_density"] == 3 / (5 * 4)
+    assert metrics["num_connected_components"] == 2
+    assert sorted(metrics["sizes_of_connected_components"], reverse=True) == [3, 2]
+    assert metrics["num_selfloops"] == 0
+
+
 async def main():
     cognee.config.set_relational_db_config({"db_provider": "sqlite"})
     cognee.config.set_graph_database_provider("memgraph")
@@ -99,6 +136,9 @@ async def main():
     await graph_engine.delete_graph()
 
     await test_add_edges_persists_all_relationship_types(graph_engine)
+
+    await graph_engine.delete_graph()
+    await test_get_graph_metrics_reports_real_counts(graph_engine)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`MemgraphAdapter.get_graph_metrics()` returns all zeros for any populated graph — and does it
silently, so callers get wrong numbers rather than an error.

Reproduced against `memgraph/memgraph-mage` on a graph with 5 nodes, 4 edges and 2 components:

    sanity check — actually in DB: nodes=5, edges=4
    get_graph_metrics(include_optional=True) -> num_nodes=0, num_edges=0,
                                               num_connected_components=0,
                                               sizes_of_connected_components=[]

The adapter logs `Failed to get graph metrics: 0` — that `0` is a swallowed `KeyError`.

Three defects, all in this one method:

**1. Results are read positionally.** `query()` returns `result.data()` — a list of dicts keyed
by the `RETURN` names. So `node_count[0]` is `{'count(n)': 5}`, and `node_count[0][0]` is a *key*
lookup → `KeyError: 0`. It's the first data access inside the `try`, so the broad `except`
catches it and returns the all-zero fallback. Every other method in the adapter already reads by
key — `has_node` uses `results[0]["node_exists"]`.

**2. The queries filter on labels this adapter never writes.** They match `(n:Node)` and
`[:EDGE]`, but nodes are merged unlabelled (`MERGE (node {id: $node_id})`) and edges carry their
real relationship name. Measured on the live graph: `MATCH (n:Node)` returns 0 where the truth is
5, and `MATCH ()-[r:EDGE]->()` returns 0 where the truth is 4. `:Node`/`:EDGE` appear nowhere
else in the file, and the leftover `# Shortest paths (simplified for Kuzu)` comment points at the
origin — the Kuzu adapter does define that fixed schema.

**3. The connected-components query collapses.** After `WITH n.id AS node_id`, `n` is out of
scope, so the following `MATCH (n)-[:EDGE*0..]-()` rebinds `n` to the whole graph and every node
lands in a single component.

### Fix

Alias each `RETURN ... AS cnt` and read it by key, drop the labels, and compute components with
MAGE's `weakly_connected_components`, falling back to a client-side union-find where MAGE isn't
installed. The all-pairs metrics (`diameter`, `avg_shortest_path_length`, `avg_clustering`) are
reported as unsupported (`-1`) — the old queries were both label-broken and O(V²)-ish on a
general graph. This follows the ArcadeDB adapter, which already aliases its returns, reads by
key, matches unlabelled, and reports the expensive metrics as `-1`.

Same graph, after:

    num_nodes=5, num_edges=4, mean_degree=1.6, edge_density=0.2,
    num_connected_components=2, sizes_of_connected_components=[3, 2], num_selfloops=1

### Testing

Added `test_get_graph_metrics_reports_real_counts` to
`packages/graph/memgraph/tests/test_memgraph.py`, following the existing
`test_add_edges_persists_all_relationship_types` — two disconnected components, 5 nodes, 3 edges,
sizes `[3, 2]`. It fails on `main` (`AssertionError` at `metrics["num_nodes"] == 5`) and passes
with the fix.

Both component paths were checked to agree: MAGE and the union-find fallback each return
`[3, 2, 1]` on a graph with an isolated node, and `[]` on an empty graph. `ruff check .` and
`ruff format --check .` pass under the memgraph package's own config.

### Questions

- **MAGE dependency**: `weakly_connected_components` needs the MAGE query modules — present in
  `memgraph-mage` (which CI uses) but not in stock `memgraph`, hence the fallback. If you'd
  rather not depend on MAGE at all, I'm happy to keep only the union-find.
- The broad `except Exception` is *why* this failed silently instead of loudly. I left it alone
  to keep the diff focused — worth narrowing in a separate PR?

Closes #122

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
