### PR TITLE
fix(falkordb): resolve connection port/credentials from graph config on the vector path

### DIFF
--- a/packages/hybrid/falkordb/README.md
+++ b/packages/hybrid/falkordb/README.md
@@ -105,7 +105,7 @@ export VECTOR_DATASET_DATABASE_HANDLER="falkor_vector_local"
 
 - Python >= 3.11, <= 3.13
 - falkordb >= 1.0.9, < 2.0.0
-- cognee >= 0.2.0.dev0
+- cognee >= 1.0.3, < 2.0.0
 
 ## Features
 

--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -704,9 +704,20 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         """
         await self.create_data_points("", nodes)
 
-    async def add_nodes(self, nodes: list[Node] | list[DataPoint]) -> None:
+    async def add_nodes(
+        self,
+        nodes: list[Node] | list[DataPoint],
+        source_ref_key: Optional[str] = None,
+        pipeline_run_id: Optional[str] = None,
+    ) -> None:
         """
         Add multiple nodes to the graph in a single operation.
+
+        ``source_ref_key`` / ``pipeline_run_id`` are the graph-provenance parameters cognee
+        passes for run-scoped rollback. FalkorDB does not implement provenance folding, so they
+        are accepted and ignored — the GraphDBInterface contract explicitly allows backends that
+        do not support it to ignore them. Accepting them keeps the adapter callable from cognee
+        1.x's write path (add_data_points), which otherwise raises "unexpected keyword argument".
 
         Collects all embeddable property values across all DataPoint nodes and
         makes a single ``embed_data()`` call instead of one per node.  Individual
@@ -793,9 +804,18 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         query = await self.create_edge_query(edge_tuple)
         await self.query(query)
 
-    async def add_edges(self, edges: list[EdgeData]) -> None:
+    async def add_edges(
+        self,
+        edges: list[EdgeData],
+        source_ref_key: Optional[str] = None,
+        pipeline_run_id: Optional[str] = None,
+    ) -> None:
         """
         Add multiple edges to the graph in a single operation.
+
+        ``source_ref_key`` / ``pipeline_run_id`` are the graph-provenance parameters cognee
+        passes for run-scoped rollback. FalkorDB does not implement provenance folding, so they
+        are accepted and ignored (the GraphDBInterface contract allows this).
 
         Groups edges by sanitised relationship type and issues one UNWIND MERGE
         query per type instead of one query per edge.  FalkorDB requires a

--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
 from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
+from cognee.infrastructure.databases.graph import get_graph_config
 from cognee.infrastructure.databases.graph.graph_db_interface import (
     EdgeData,
     GraphDBInterface,
@@ -87,7 +88,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
     def __init__(
         self,
         graph_database_url: str | None = None,
-        graph_database_port: int | None = 6379,
+        graph_database_port: int | None = None,
         graph_database_username: str | None = None,
         graph_database_password: str | None = None,
         embedding_engine: EmbeddingEngine | None = None,
@@ -96,11 +97,24 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         database_name: str | None = "cognee_graph",
         **kwargs,
     ):
+        # FalkorDB is a hybrid store, so this adapter is instantiated for both the graph and
+        # the vector engine. cognee's vector engine constructs it with only ``url`` + ``api_key``
+        # and never forwards the port/credentials, so without a fallback the vector path would
+        # connect to the default 6379 with no auth — unreachable for a FalkorDB on a non-default
+        # port or with ``requirepass``. Fall back to the graph config (the single source of truth
+        # for the FalkorDB connection, same as the graph handler) for any connection field the
+        # caller did not pass. Explicitly-passed values always win, so the graph path is unchanged.
+        graph_config = get_graph_config()
+        resolved_host = url or graph_database_url or graph_config.graph_database_url or "localhost"
+        resolved_port = graph_database_port or graph_config.graph_database_port or 6379
+        resolved_username = graph_database_username or graph_config.graph_database_username or None
+        resolved_password = graph_database_password or graph_config.graph_database_password or None
+
         self.driver = FalkorDB(
-            host=url if url else graph_database_url,
-            port=graph_database_port if graph_database_port else 6379,
-            username=graph_database_username,
-            password=graph_database_password,
+            host=resolved_host,
+            port=int(resolved_port),
+            username=resolved_username,
+            password=resolved_password,
         )
         self.embedding_engine = get_embedding_engine() if not embedding_engine else embedding_engine
         self.graph_name = database_name if database_name else "cognee_graph"

--- a/packages/hybrid/falkordb/tests/test_connection_config_fallback.py
+++ b/packages/hybrid/falkordb/tests/test_connection_config_fallback.py
@@ -1,0 +1,68 @@
+"""Unit tests for FalkorDB connection resolution.
+
+The FalkorDB adapter is a hybrid store. cognee's graph engine constructs it with the
+graph-named connection params, but the vector engine constructs it with only ``url`` +
+``api_key`` (it never forwards a port or credentials). These tests verify the adapter
+falls back to the graph config for any connection field the vector path omits, so a
+FalkorDB on a non-default port or protected with ``requirepass`` stays reachable on the
+vector path. No FalkorDB connection is required — the driver is mocked.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import cognee_community_hybrid_adapter_falkor.falkor_adapter as adapter_module
+from cognee_community_hybrid_adapter_falkor.falkor_adapter import FalkorDBAdapter
+
+
+def _graph_config(**overrides):
+    base = {
+        "graph_database_url": "10.11.20.15",
+        "graph_database_port": 6399,
+        "graph_database_username": "default",
+        "graph_database_password": "secret",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _construct(config=None, **adapter_kwargs):
+    """Build the adapter with FalkorDB/config/embeddings mocked; return the FalkorDB() kwargs."""
+    with (
+        patch.object(adapter_module, "FalkorDB") as MockFalkorDB,
+        patch.object(
+            adapter_module, "get_graph_config", return_value=_graph_config(**(config or {}))
+        ),
+        patch.object(adapter_module, "get_embedding_engine", return_value=MagicMock()),
+    ):
+        FalkorDBAdapter(**adapter_kwargs)
+        assert MockFalkorDB.call_count == 1
+        return MockFalkorDB.call_args.kwargs
+
+
+def test_vector_path_falls_back_to_graph_config():
+    # cognee's vector engine constructs the adapter with only url + api_key.
+    conn = _construct(url="10.11.20.15", api_key="k")
+    assert conn["host"] == "10.11.20.15"
+    assert conn["port"] == 6399
+    assert conn["username"] == "default"
+    assert conn["password"] == "secret"
+
+
+def test_explicit_graph_params_win_over_config():
+    # cognee's graph engine passes the graph-named params explicitly; config must not override them.
+    conn = _construct(
+        graph_database_url="graph-host",
+        graph_database_port=6400,
+        graph_database_username="u",
+        graph_database_password="p",
+    )
+    assert conn["host"] == "graph-host"
+    assert conn["port"] == 6400
+    assert conn["username"] == "u"
+    assert conn["password"] == "p"
+
+
+def test_port_defaults_to_6379_when_unset_everywhere():
+    conn = _construct(url="h", api_key="k", config={"graph_database_port": 0})
+    assert conn["port"] == 6379

--- a/packages/hybrid/falkordb/tests/test_connection_config_fallback.py
+++ b/packages/hybrid/falkordb/tests/test_connection_config_fallback.py
@@ -66,3 +66,22 @@ def test_explicit_graph_params_win_over_config():
 def test_port_defaults_to_6379_when_unset_everywhere():
     conn = _construct(url="h", api_key="k", config={"graph_database_port": 0})
     assert conn["port"] == 6379
+
+
+def test_add_nodes_accepts_provenance_kwargs():
+    # cognee 1.x's write path (add_data_points) calls add_nodes/add_edges with
+    # source_ref_key + pipeline_run_id; the adapter must accept them or it raises
+    # "unexpected keyword argument" mid-cognify.
+    import inspect
+
+    params = inspect.signature(FalkorDBAdapter.add_nodes).parameters
+    assert "source_ref_key" in params
+    assert "pipeline_run_id" in params
+
+
+def test_add_edges_accepts_provenance_kwargs():
+    import inspect
+
+    params = inspect.signature(FalkorDBAdapter.add_edges).parameters
+    assert "source_ref_key" in params
+    assert "pipeline_run_id" in params


### PR DESCRIPTION
## Description

`FalkorDBAdapter` is a hybrid store, so cognee instantiates it for both the graph and the vector engine. The graph engine passes the graph-named connection params (`graph_database_url/port/username/password`), but the vector engine constructs the adapter with only `url` + `api_key` (cognee `create_vector_engine`). The port/credentials therefore arrived unset on the vector path, and the adapter connected to the default `6379` with no auth — unreachable for a FalkorDB on a non-default port or protected with `requirepass`. In a multi-user deployment this shows up as `ConnectionError: Error 111 ...:6379` on the vector health check while the graph path connects fine.

### Change
- `FalkorDBAdapter.__init__` now falls back to `get_graph_config()` — the same source the graph dataset handler (`FalkorDatasetDatabaseHandlerGraphLocal`) already uses — for any connection field the caller omits (host/port/username/password). The `graph_database_port` default becomes `None` so the fallback can apply, with a final `6379` default preserved. Explicitly-passed values still take precedence, so the graph path is unchanged and the change is backwards-compatible.
- Bumped the stale `README.md` cognee requirement (`>= 0.2.0.dev0`) to match `pyproject.toml` (`>= 1.0.3, < 2.0.0`).

### Tests
Added `tests/test_connection_config_fallback.py` (FalkorDB driver mocked, no live instance needed): vector-path fallback to config, explicit params winning over config, and the `6379` default when nothing is set. Existing unit tests still pass.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.