### PR TITLE
fix(codify): give extract_code_parts a per-call node cache

### DIFF
--- a/packages/task/codify_tasks/cognee_community_tasks_codify/get_local_dependencies.py
+++ b/packages/task/codify_tasks/cognee_community_tasks_codify/get_local_dependencies.py
@@ -234,7 +234,7 @@ def find_node(nodes: list[Node], condition: callable) -> Node:
 async def extract_code_parts(
     tree_root: Node,
     script_path: str,
-    existing_nodes: list[DataPoint] = {},  # noqa: B006
+    existing_nodes: dict[str, DataPoint] | None = None,
 ) -> AsyncGenerator[DataPoint, None]:
     """
     Extract code parts from a given AST node tree asynchronously.
@@ -252,14 +252,21 @@ async def extract_code_parts(
 
         - tree_root (Node): The root node of the AST tree containing code parts to extract.
         - script_path (str): The file path of the script from which the AST was generated.
-        - existing_nodes (list[DataPoint]): A dictionary that holds already extracted
-          DataPoint nodes to avoid duplicates. (default {})
+        - existing_nodes (dict[str, DataPoint] | None): A dictionary that holds already
+          extracted DataPoint nodes to avoid duplicates within this call. Defaults to a fresh
+          empty dict per call. (default None)
 
     Returns:
     --------
 
         Yields DataPoint nodes representing imported modules, functions, and classes.
     """
+    # Use a per-call cache. A mutable default ({}) would be shared across every call, which
+    # deduplicates same-named definitions across different files and leaks the file_path of
+    # whichever file was parsed first.
+    if existing_nodes is None:
+        existing_nodes = {}
+
     for child_node in tree_root.children:
         if child_node.type == "import_statement" or child_node.type == "import_from_statement":
             parts = child_node.text.decode("utf-8").split()

--- a/packages/task/codify_tasks/tests/test_extract_code_parts_isolation.py
+++ b/packages/task/codify_tasks/tests/test_extract_code_parts_isolation.py
@@ -1,0 +1,49 @@
+"""Regression test for per-call isolation in extract_code_parts.
+
+extract_code_parts used a mutable default argument (`existing_nodes={}`), so the same dict was
+reused across every call. Definitions with the same name in different files therefore deduplicated
+against each other, and the nodes yielded for later files kept the ``file_path`` of whichever file
+was parsed first. This test parses two separate files that both define ``shared`` and asserts that
+the parts yielded for the second file carry the second file's path.
+
+It runs entirely in-process with tree-sitter, so it needs no LLM provider or network access.
+"""
+
+import asyncio
+
+import tree_sitter_python as tspython
+from cognee_community_tasks_codify.get_local_dependencies import extract_code_parts
+from tree_sitter import Language, Parser
+
+SOURCE = "def shared():\n    pass\n"
+
+
+def _parse_root(source: str):
+    parser = Parser(Language(tspython.language()))
+    return parser.parse(source.encode("utf-8")).root_node
+
+
+async def _collect(root, script_path: str) -> list:
+    return [part async for part in extract_code_parts(root, script_path=script_path)]
+
+
+async def test_same_named_definitions_in_different_files_are_isolated():
+    # Parse file A first so a shared cache would already contain "shared" when file B is parsed.
+    await _collect(_parse_root(SOURCE), script_path="/proj/a.py")
+    parts_b = await _collect(_parse_root(SOURCE), script_path="/proj/b.py")
+
+    assert parts_b, "no code parts were extracted from the second file"
+    foreign = [p for p in parts_b if getattr(p, "file_path", None) != "/proj/b.py"]
+    assert not foreign, (
+        "definitions from the second file carry a foreign file_path (shared-state leak): "
+        f"{[getattr(p, 'file_path', None) for p in foreign]}"
+    )
+
+
+async def _main() -> None:
+    await test_same_named_definitions_in_different_files_are_isolated()
+    print("PASSED: test_same_named_definitions_in_different_files_are_isolated")
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())


### PR DESCRIPTION
## Description

Closes #140.

`extract_code_parts` used a **mutable default argument** for its dedup cache:

```python
existing_nodes: list[DataPoint] = {},  # noqa: B006
```

In Python the default `{}` is created once and shared by every call. `existing_nodes` is a name-keyed cache (`existing_nodes["import " + function_name]`, `existing_nodes[function_node_name]`, etc.), and the only caller invokes the function without passing it — so every file parsed reuses the same dict. That means:

- same-named definitions in different files (`def main()` in two files) dedup against each other, and
- the nodes yielded for later files keep the `file_path` of whichever file was parsed first,

which corrupts the extracted code graph. The `# noqa: B006` was suppressing the exact lint rule (flake8-bugbear B006) that flags this. The parameter was also annotated `list[DataPoint]` while being used as a dict.

### The fix

Default `existing_nodes` to `None` and build a fresh dict per call:

```python
existing_nodes: dict[str, DataPoint] | None = None,
...
if existing_nodes is None:
    existing_nodes = {}
```

This also removes the now-unnecessary `# noqa` and corrects the annotation/docstring. Scoped to the one function.

## Acceptance Criteria

- Each call to `extract_code_parts` starts with an empty cache.
- Definitions with the same name in different files no longer collide, and every yielded node carries its own file's `file_path`.
- A regression test covers this.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Added `packages/task/codify_tasks/tests/test_extract_code_parts_isolation.py`. It parses two files that both define `shared` and asserts the parts yielded for the second file carry its own path. It runs entirely in-process with tree-sitter (no LLM/network), and is runnable directly (`python tests/test_extract_code_parts_isolation.py`).

Verified locally that it fails on the old code and passes with the fix:

| | Before the fix | After the fix |
| --- | --- | --- |
| `test_same_named_definitions_in_different_files_are_isolated` | FAIL — *"definitions from the second file carry a foreign file_path (shared-state leak): ['/proj/a.py']"* | PASS |

```
$ python tests/test_extract_code_parts_isolation.py
PASSED: test_same_named_definitions_in_different_files_are_isolated
```

`ruff check` and `ruff format --check` are clean on both files. Note: the existing `test_codify.yml` workflow installs `cognee-community-tasks-codify` from PyPI (not local source) and runs the pipeline example, so it wouldn't exercise this test against the local change — happy to wire up a source-installed test job if that's useful.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
