### PR TITLE
fix(falkordb): align hybrid adapter with cognee 1.3.0 interfaces

### DIFF
--- a/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
+++ b/packages/hybrid/falkordb/cognee_community_hybrid_adapter_falkor/falkor_adapter.py
@@ -96,15 +96,41 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         database_name: str | None = "cognee_graph",
         **kwargs,
     ):
+        # ``create_vector_engine`` builds this adapter on the vector path as
+        # ``adapter(url=..., api_key=..., embedding_engine=..., database_name=...)``
+        # with no port kwarg, so a non-default FalkorDB port only reaches us
+        # embedded in the URL (e.g. ``VECTOR_DB_URL="myhost:6380"``). Parse a
+        # trailing ``:port`` out of the host so those deployments are reachable
+        # instead of always dialing ``:6379``.
+        resolved_host = url if url else graph_database_url
+        default_port = graph_database_port if graph_database_port else 6379
+        host, port = self._split_host_port(resolved_host, default_port)
         self.driver = FalkorDB(
-            host=url if url else graph_database_url,
-            port=graph_database_port if graph_database_port else 6379,
+            host=host,
+            port=port,
             username=graph_database_username,
             password=graph_database_password,
         )
         self.embedding_engine = get_embedding_engine() if not embedding_engine else embedding_engine
         self.graph_name = database_name if database_name else "cognee_graph"
         self.api_key = api_key
+
+    @staticmethod
+    def _split_host_port(raw_host: Any, default_port: int) -> Tuple[Any, int]:
+        """Split a bare ``host:port`` string into ``(host, port)``.
+
+        Only a plain ``host:port`` (single colon, all-digit port) is parsed; a
+        scheme-qualified URL (``redis://...``) or an IPv6 literal (multiple
+        colons) is left untouched with ``default_port``, so this is safe and
+        backward compatible — a bare host keeps the default port.
+        """
+        if not isinstance(raw_host, str):
+            return raw_host, default_port
+        if "://" not in raw_host and raw_host.count(":") == 1:
+            candidate_host, _, candidate_port = raw_host.partition(":")
+            if candidate_port.isdigit():
+                return candidate_host, int(candidate_port)
+        return raw_host, default_port
 
     @staticmethod
     def _coerce_stored_value(value: Any) -> Any:
@@ -135,8 +161,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
             # FalkorDB arrays must hold primitives (and reject null elements);
             # if any element isn't one, store the whole array as a JSON string.
             if all(
-                item is not None and isinstance(item, (bool, int, float, str))
-                for item in coerced
+                item is not None and isinstance(item, (bool, int, float, str)) for item in coerced
             ):
                 return coerced
             return json.dumps(value, default=str)
@@ -159,10 +184,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         still coerced.
         """
         if isinstance(value, dict):
-            return {
-                key: FalkorDBAdapter._coerce_stored_value(val)
-                for key, val in value.items()
-            }
+            return {key: FalkorDBAdapter._coerce_stored_value(val) for key, val in value.items()}
         if isinstance(value, (list, tuple)):
             return [FalkorDBAdapter._coerce_param_value(item) for item in value]
         if isinstance(value, Enum):
@@ -181,10 +203,7 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         nested map/array in a model-extracted entity rejects the whole query and
         aborts the pipeline run.
         """
-        return {
-            key: FalkorDBAdapter._coerce_param_value(value)
-            for key, value in params.items()
-        }
+        return {key: FalkorDBAdapter._coerce_param_value(value) for key, value in params.items()}
 
     # TODO: This should return a list of results, not a single result
     async def query(self, query: str, params: dict = None) -> list:
@@ -697,7 +716,12 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         """
         await self.create_data_points("", nodes)
 
-    async def add_nodes(self, nodes: list[Node] | list[DataPoint]) -> None:
+    async def add_nodes(
+        self,
+        nodes: list[Node] | list[DataPoint],
+        source_ref_key: Optional[str] = None,
+        pipeline_run_id: Optional[str] = None,
+    ) -> None:
         """
         Add multiple nodes to the graph in a single operation.
 
@@ -712,6 +736,17 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
 
             - nodes (Union[List[Node], List[DataPoint]]): A list of Node tuples
                                 or DataPoint objects to be added to the graph.
+            - source_ref_key (Optional[str]): Graph-provenance key passed by
+                cognee 1.3.0's ``add_data_points`` write path.
+            - pipeline_run_id (Optional[str]): Graph-provenance run id passed by
+                the same path.
+
+        The two provenance kwargs are part of the ``GraphDBInterface`` contract
+        in cognee 1.3.0; accepting them avoids the ``TypeError`` cognify raised
+        against the previous ``add_nodes(self, nodes)`` signature. They are
+        intentionally accepted-and-ignored: on FalkorDB the values are always
+        ``None`` today (``mark_graph_provenance_if_empty`` is unsupported), so
+        ignoring them is lossless. Stamping provenance is left for a follow-up.
         """
         if not nodes:
             return
@@ -786,7 +821,12 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         query = await self.create_edge_query(edge_tuple)
         await self.query(query)
 
-    async def add_edges(self, edges: list[EdgeData]) -> None:
+    async def add_edges(
+        self,
+        edges: list[EdgeData],
+        source_ref_key: Optional[str] = None,
+        pipeline_run_id: Optional[str] = None,
+    ) -> None:
         """
         Add multiple edges to the graph in a single operation.
 
@@ -799,6 +839,14 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
         -----------
 
             - edges (List[EdgeData]): A list of EdgeData objects representing edges to be added.
+            - source_ref_key (Optional[str]): Graph-provenance key passed by
+                cognee 1.3.0's ``add_data_points`` write path.
+            - pipeline_run_id (Optional[str]): Graph-provenance run id passed by
+                the same path.
+
+        As with :meth:`add_nodes`, the provenance kwargs are part of the
+        cognee 1.3.0 ``GraphDBInterface`` contract and are accepted-and-ignored
+        (always ``None`` on FalkorDB today) to avoid a ``TypeError`` on cognify.
         """
         if not edges:
             return
@@ -1268,6 +1316,54 @@ class FalkorDBAdapter(VectorDBInterface, GraphDBInterface):
             {
                 "node_ids": [str(data_point) for data_point in data_point_ids],
             },
+        )
+
+    async def remove_belongs_to_set_tags(
+        self,
+        tags: List[str],
+        node_ids: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Strip the given scope tags from every node's ``belongs_to_set`` array and
+        delete nodes whose ``belongs_to_set`` becomes empty as a result.
+
+        Implements the ``VectorDBInterface`` contract that cognee's
+        ``delete_session_qa_vectors`` relies on. Without this override the adapter
+        inherited the base-class no-op, so session QA vectors on FalkorDB were
+        never cleaned up and accumulated indefinitely.
+
+        Parameters:
+        -----------
+
+            - tags (List[str]): Scope tags to remove from ``belongs_to_set``.
+            - node_ids (Optional[List[str]]): When provided, scope the detag to
+              rows whose id is in the list (reconciles shared rows that lose one
+              tag); otherwise every matching node is considered.
+        """
+        if not tags:
+            return
+
+        id_filter = ""
+        params: dict[str, Any] = {"tags": tags}
+        if node_ids is not None:
+            id_filter = " AND n.id IN $node_ids"
+            params["node_ids"] = node_ids
+
+        # Match only nodes actually carrying one of the tags (so pre-existing
+        # empty sets are untouched), strip the tags, then delete the ones left
+        # empty by this operation — in a single pass so the delete stays scoped
+        # to affected nodes.
+        await self.query(
+            f"""
+            MATCH (n)
+            WHERE any(t IN $tags WHERE t IN coalesce(n.belongs_to_set, [])){id_filter}
+            SET n.belongs_to_set =
+                [x IN coalesce(n.belongs_to_set, []) WHERE NOT x IN $tags]
+            WITH n
+            WHERE size(coalesce(n.belongs_to_set, [])) = 0
+            DETACH DELETE n
+            """,
+            params,
         )
 
     async def delete_node(self, node_id: str) -> None:

--- a/packages/hybrid/falkordb/pyproject.toml
+++ b/packages/hybrid/falkordb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-hybrid-adapter-falkor"
-version = "0.3.0"
+version = "0.3.2"
 description = "Falkor hybrid database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/hybrid/falkordb/tests/test_cognee_1_3_interface_compat.py
+++ b/packages/hybrid/falkordb/tests/test_cognee_1_3_interface_compat.py
@@ -1,0 +1,141 @@
+"""Unit tests for cognee 1.3.0 interface-compatibility fixes (issue #142).
+
+Covers three version-skew gaps in ``FalkorDBAdapter``, all with a mocked
+FalkorDB driver — no live database required:
+
+1. ``add_nodes`` / ``add_edges`` accept the ``source_ref_key`` /
+   ``pipeline_run_id`` provenance kwargs cognee 1.3.0 passes.
+2. The vector-engine construction path honours a ``host:port`` URL instead of
+   always dialing ``:6379``.
+3. ``remove_belongs_to_set_tags`` is overridden (no longer a base-class no-op).
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from cognee_community_hybrid_adapter_falkor.falkor_adapter import FalkorDBAdapter
+
+
+def _make_adapter_capturing_queries():
+    """Adapter with a mocked driver that records (query, params) calls."""
+    adapter = object.__new__(FalkorDBAdapter)
+    adapter.graph_name = "test_graph"
+
+    mock_result = MagicMock()
+    mock_result.result_set = []
+
+    mock_graph = MagicMock()
+    mock_graph.query.return_value = mock_result
+
+    mock_driver = MagicMock()
+    mock_driver.select_graph.return_value = mock_graph
+
+    adapter.driver = mock_driver
+    return adapter, mock_graph
+
+
+# --- Defect 1: provenance kwargs accepted ------------------------------------
+
+
+def test_add_nodes_accepts_provenance_kwargs():
+    """add_nodes must not raise TypeError on cognee 1.3.0's provenance kwargs."""
+    adapter, _ = _make_adapter_capturing_queries()
+    # Empty list short-circuits; the point is that the call binds without a
+    # ``unexpected keyword argument`` TypeError.
+    asyncio.run(adapter.add_nodes([], source_ref_key="ref", pipeline_run_id="run"))
+
+
+def test_add_edges_accepts_provenance_kwargs():
+    """add_edges must not raise TypeError on cognee 1.3.0's provenance kwargs."""
+    adapter, _ = _make_adapter_capturing_queries()
+    asyncio.run(adapter.add_edges([], source_ref_key="ref", pipeline_run_id="run"))
+
+
+# --- Defect 2: host:port parsing ---------------------------------------------
+
+
+def test_split_host_port_parses_bare_host_port():
+    assert FalkorDBAdapter._split_host_port("myhost:6380", 6379) == ("myhost", 6380)
+
+
+def test_split_host_port_bare_host_keeps_default():
+    assert FalkorDBAdapter._split_host_port("localhost", 6379) == ("localhost", 6379)
+
+
+def test_split_host_port_ignores_scheme_url():
+    # A scheme'd URL is left untouched (default port).
+    assert FalkorDBAdapter._split_host_port("redis://h:6380", 6379) == (
+        "redis://h:6380",
+        6379,
+    )
+
+
+def test_split_host_port_ignores_ipv6_literal():
+    # Multiple colons => not a bare host:port; leave untouched.
+    assert FalkorDBAdapter._split_host_port("::1", 6379) == ("::1", 6379)
+
+
+def test_split_host_port_non_string_passthrough():
+    assert FalkorDBAdapter._split_host_port(None, 6379) == (None, 6379)
+
+
+def test_init_honours_port_from_url():
+    """The vector path passes only url=...; a :port in it must reach FalkorDB."""
+    with (
+        patch("cognee_community_hybrid_adapter_falkor.falkor_adapter.FalkorDB") as mock_falkor,
+        patch(
+            "cognee_community_hybrid_adapter_falkor.falkor_adapter.get_embedding_engine"
+        ) as mock_embed,
+    ):
+        mock_embed.return_value = MagicMock()
+        FalkorDBAdapter(url="myhost:6380")
+
+    _, kwargs = mock_falkor.call_args
+    assert kwargs["host"] == "myhost"
+    assert kwargs["port"] == 6380
+
+
+def test_init_bare_host_uses_default_port():
+    with (
+        patch("cognee_community_hybrid_adapter_falkor.falkor_adapter.FalkorDB") as mock_falkor,
+        patch(
+            "cognee_community_hybrid_adapter_falkor.falkor_adapter.get_embedding_engine"
+        ) as mock_embed,
+    ):
+        mock_embed.return_value = MagicMock()
+        FalkorDBAdapter(url="localhost")
+
+    _, kwargs = mock_falkor.call_args
+    assert kwargs["host"] == "localhost"
+    assert kwargs["port"] == 6379
+
+
+# --- Defect 3: remove_belongs_to_set_tags ------------------------------------
+
+
+def test_remove_belongs_to_set_tags_empty_is_noop():
+    """No tags => no query issued."""
+    adapter, mock_graph = _make_adapter_capturing_queries()
+    asyncio.run(adapter.remove_belongs_to_set_tags([]))
+    mock_graph.query.assert_not_called()
+
+
+def test_remove_belongs_to_set_tags_issues_strip_and_delete():
+    adapter, mock_graph = _make_adapter_capturing_queries()
+    asyncio.run(adapter.remove_belongs_to_set_tags(["Dev"]))
+
+    mock_graph.query.assert_called_once()
+    query, params = mock_graph.query.call_args[0]
+    assert "belongs_to_set" in query
+    assert "DETACH DELETE" in query
+    assert params["tags"] == ["Dev"]
+    assert "node_ids" not in params
+
+
+def test_remove_belongs_to_set_tags_scoped_by_node_ids():
+    adapter, mock_graph = _make_adapter_capturing_queries()
+    asyncio.run(adapter.remove_belongs_to_set_tags(["Dev"], node_ids=["abc"]))
+
+    query, params = mock_graph.query.call_args[0]
+    assert "n.id IN $node_ids" in query
+    assert params["node_ids"] == ["abc"]


### PR DESCRIPTION
# fix(falkordb): align hybrid adapter with cognee 1.3.0 interfaces

Closes #142

## Summary
`cognee-community-hybrid-adapter-falkor` had drifted from three interfaces in cognee 1.3.0.
This PR brings `FalkorDBAdapter` back in line with all three — a `TypeError` that breaks every
`cognify`, a dropped-port bug on the vector-engine path, and a silent no-op in session-vector
cleanup — and bumps the package version so the fix actually reaches users. All three were
reported together in #142 with host-side workarounds; this moves the fixes into the adapter where
they belong. Verified against a local `topoteretes/cognee` checkout pinned at 1.3.0.

## Root cause
1. **`add_nodes` / `add_edges` reject provenance kwargs.** cognee 1.3.0's `GraphDBInterface`
   declares `add_nodes(nodes, source_ref_key=None, pipeline_run_id=None)` /
   `add_edges(edges, source_ref_key=None, pipeline_run_id=None)`, and the non-hybrid
   `add_data_points` write path calls them with those kwargs. The adapter's signatures were
   `add_nodes(self, nodes)` / `add_edges(self, edges)`, so any `cognify` raised
   `TypeError: FalkorDBAdapter.add_nodes() got an unexpected keyword argument 'source_ref_key'`.
   (Falkor always takes this separate graph+vector path because `HYBRID_PROVIDERS` is empty in core.)
2. **Dropped port.** `create_vector_engine` builds community adapters as
   `adapter(url=..., api_key=..., embedding_engine=..., database_name=...)` — no port kwarg — so the
   adapter fell back to `graph_database_port=6379`. A FalkorDB on a non-default port was unreachable
   on the vector path (per-dataset vector handler, session-vector indexing) with
   `Error 61 connecting to localhost:6379`.
3. **`remove_belongs_to_set_tags` no-op.** cognee's `delete_session_qa_vectors` strips a scope tag via
   `VectorDBInterface.remove_belongs_to_set_tags`. The adapter never overrode it, so it inherited the
   base-class no-op and session QA vectors on FalkorDB were never cleaned up — they accumulated
   indefinitely (a retention problem for session-memory content, not just bloat).

## Solution
1. Add `source_ref_key` / `pipeline_run_id` to `add_nodes` / `add_edges`. They are always `None` on
   FalkorDB today (`mark_graph_provenance_if_empty` is unsupported), so they're accepted-and-ignored —
   lossless; actually stamping provenance is left for a follow-up.
2. In `__init__`, parse a trailing `:port` out of the host (new `_split_host_port` helper) so
   `VECTOR_DB_URL="myhost:6380"` reaches FalkorDB on the right port. Guarded to a bare `host:port`
   (single colon, all-digit port) — scheme URLs and IPv6 literals are left untouched, so a bare host
   still defaults to 6379 (backward compatible).
3. Override `remove_belongs_to_set_tags(tags, node_ids=None)`: strip the tags from every node whose
   `belongs_to_set` contains one of them (optionally scoped to `node_ids`) and `DETACH DELETE` nodes
   left empty, in a single pass so the delete stays scoped to affected nodes — matching the
   interface contract and the LanceDB reference behaviour.

Package version bumped `0.3.0` → `0.3.2` (past the published `0.3.1` users are on) so the fix ships.

## Changes
```
79deb0d fix(falkordb): align hybrid adapter with cognee 1.3.0 interfaces

 .../falkor_adapter.py                              | 124 ++++++++++++++++--
 packages/hybrid/falkordb/pyproject.toml            |   2 +-
 .../tests/test_cognee_1_3_interface_compat.py      | 141 +++++++++++++++++++++
 3 files changed, 252 insertions(+), 15 deletions(-)
```

## Testing performed
- Added `tests/test_cognee_1_3_interface_compat.py` (12 mock-driver unit tests, no live DB): provenance
  kwargs accepted on `add_nodes`/`add_edges`; `_split_host_port` and `__init__` port parsing incl.
  bare-host / scheme-URL / IPv6 / non-string edge cases; `remove_belongs_to_set_tags` empty-no-op,
  strip+delete query, and `node_ids` scoping.
- Ran the package's unit suite against a local cognee-1.3.0 + falkordb env: **55 passed, 1 skipped**
  (all 12 new tests + existing mock-driver tests).
- `ruff check .` and `ruff format --check .` pass on the changed files.
- The three `async def` end-to-end tests in `test_falkordb.py` (`cognee.add` → `cognify` → search)
  were **not run locally** — they need the live FalkorDB service + LLM keys that the
  `test_falkordb.yml` CI job provides. They are unaffected by these changes.

## DCO
I certify that this contribution complies with the Developer Certificate of Origin.
Signed-off-by: sahilkanger <sahilkanger1999@gmail.com>

## Checklist
- [x] Change is focused and minimal
- [x] Follows the project's code style / conventions
- [x] Tests added or updated where appropriate
- [x] Documentation updated where appropriate (n/a — behaviour aligned to existing interfaces)
- [x] `lint` passes locally (`ruff check .`)
- [x] `format` passes locally (`ruff format --check .`)
