### PR TITLE
fix(pinecone): export a callable register() so the adapter registers via import or call

### DIFF
--- a/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
+++ b/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
@@ -3,9 +3,11 @@ from typing import Any
 
 import cognee
 from cognee.shared.logging_utils import get_logger
+
 # from scrapegraph_py import Client
 # -------
 from scrapegraph_py import ScrapeGraphAI
+
 # --------
 
 logger = get_logger("ScrapegraphTask")
@@ -41,7 +43,6 @@ async def scrape_urls(
             "ScrapeGraphAI API key is required. Set the SGAI_API_KEY environment variable."
         )
 
-
     sgai = ScrapeGraphAI(api_key=api_key)
 
     # client = Client(api_key=api_key)
@@ -55,15 +56,10 @@ async def scrape_urls(
                 prompt=user_prompt,
             )
 
-            if response.status == "success": 
-                results.append(
-                    {
-                        "url": url,
-                        "content": response.data.json_data
-                    }
-                )
+            if response.status == "success":
+                results.append({"url": url, "content": response.data.json_data})
                 logger.info(f"Successfully scraped: {url}")
-            else: 
+            else:
                 results.append(
                     {
                         "url": url,

--- a/packages/vector/pinecone/README.md
+++ b/packages/vector/pinecone/README.md
@@ -25,10 +25,14 @@ To use the Pinecone adapter, you need to:
 
 ## Usage
 
-Import and register the adapter in your code:
+Register the adapter with cognee before configuring `vector_db_provider="pinecone"`.
+Importing `register` already registers the adapter as a side effect, and `register()`
+is also callable directly (both are idempotent):
 
 ```python
 from cognee_community_vector_adapter_pinecone import register
+
+register()
 ```
 
 ## Example

--- a/packages/vector/pinecone/cognee_community_vector_adapter_pinecone/__init__.py
+++ b/packages/vector/pinecone/cognee_community_vector_adapter_pinecone/__init__.py
@@ -1,3 +1,4 @@
 from .pinecone_adapter import PineconeAdapter
+from .register import register
 
-__all__ = ["PineconeAdapter"]
+__all__ = ["PineconeAdapter", "register"]

--- a/packages/vector/pinecone/cognee_community_vector_adapter_pinecone/register.py
+++ b/packages/vector/pinecone/cognee_community_vector_adapter_pinecone/register.py
@@ -2,4 +2,17 @@ from cognee.infrastructure.databases.vector import use_vector_adapter
 
 from .pinecone_adapter import PineconeAdapter
 
-use_vector_adapter("pinecone", PineconeAdapter)
+
+def register() -> None:
+    """Register the Pinecone adapter under cognee's "pinecone" vector provider.
+
+    Call once before configuring cognee with ``vector_db_provider="pinecone"``.
+    Idempotent.
+    """
+    use_vector_adapter("pinecone", PineconeAdapter)
+
+
+# Register on import so the documented ``from cognee_community_vector_adapter_pinecone
+# import register`` usage keeps working as a side effect, while ``register()`` is also
+# callable directly (see __init__.py re-export). Both are idempotent.
+register()


### PR DESCRIPTION
# fix(pinecone): export a callable register() so the adapter registers via import or call

Refs #92

## Summary
The Pinecone vector adapter can't be registered with cognee through the natural
`register()` call. `register.py` performed registration only as an import-time
side effect and `__init__.py` exported just `PineconeAdapter`, so `register` was
never re-exported on the package. As reported in #92, both
`import cognee_community_vector_adapter_pinecone as p; p.register()` and
`from cognee_community_vector_adapter_pinecone import register; register()` fail
with `module ... has no attribute 'register'` / `'module' object is not callable`,
and `cognee.add()` then raises `Unsupported vector database provider: pinecone`.

This makes `register` a real, callable, idempotent function and re-exports it,
while keeping the documented `from ... import register` side-effect working. All
three usage styles now register the adapter. This aligns Pinecone with the
`def register()` convention already used by the graph adapters (turbopuffer,
memgraph, arcadedb).

## Root cause
`use_vector_adapter("pinecone", PineconeAdapter)` ran at module import in
`register.py`, but `register` was neither a function nor re-exported from
`__init__.py` (`__all__ = ["PineconeAdapter"]`). Consequently:

- `import pkg; pkg.register()` → `__init__` imports `.pinecone_adapter` but never
  the `.register` submodule, so the provider is never registered **and**
  `pkg.register` doesn't exist → `AttributeError`, then
  `Unsupported vector database provider: pinecone` from `create_vector_engine`.
- `from pkg import register; register()` → binds `register` to a *module* object →
  `TypeError: 'module' object is not callable`.

There was no import path that both registered the adapter **and** yielded a
callable `register`.

## Solution
- `register.py`: wrap the registration in `def register() -> None` and keep a
  module-level `register()` call so the documented import-time side effect is
  preserved. `use_vector_adapter` is a plain dict assignment, so both entry points
  are idempotent.
- `__init__.py`: `from .register import register` and add it to `__all__`.
- `README.md`: document calling `register()` explicitly (the import-only form
  still works).

Deliberately **not** changed in this PR:
- The stale `cognee==0.5.5` pin in `pyproject.toml`. Every sibling vector adapter
  pins `cognee>=1.1.0,<2.0.0`, so Pinecone is the outlier and the bump is worth
  doing — but it requires regenerating both `uv.lock` and `poetry.lock` together,
  and I couldn't produce a consistent pair in my environment (no `poetry`, and
  `uv lock` resolved cognee to 1.4.0 while the sibling locks sit at 1.1.x).
  Happy to send this as a focused follow-up so the lockfiles stay in family. Let
  me know your preferred cognee version to pin against.
- Native Pinecone support in cognee core and the `embedding_provider` config
  question from the issue are cognee-core concerns, out of scope for this adapter.

## Changes
```
1acacae fix: export callable register() for the Pinecone vector adapter

 packages/vector/pinecone/README.md                        |  6 +++++-
 .../cognee_community_vector_adapter_pinecone/__init__.py  |  3 ++-
 .../cognee_community_vector_adapter_pinecone/register.py  | 15 ++++++++++++++-
 3 files changed, 21 insertions(+), 3 deletions(-)
```

## Testing performed
- `python -m py_compile` on the changed modules — OK.
- `ruff check packages/vector/pinecone/cognee_community_vector_adapter_pinecone/` — All checks passed.
- `ruff format --check` on the same path — already formatted.
- Not run: a live end-to-end import/registration against a running cognee +
  Pinecone (needs the full dependency tree and a Pinecone key; this package has no
  unit-test harness or CI workflow). The change is import-wiring only and mirrors
  the existing graph-adapter pattern. Reviewer verification against live cognee
  welcome.

## Checklist
- [x] Change is focused and minimal
- [x] Follows the project's code style / conventions (matches graph-adapter `register()`)
- [ ] Tests added or updated where appropriate (no unit-test harness exists for this package; see Testing)
- [x] Documentation updated where appropriate (README usage)
- [x] `lint` passes locally (`ruff check` on the package)
- [x] `format` passes locally (`ruff format --check` on the package)
