### PR TITLE
fix(memgraph): accept cognee 1.3.0 provenance kwargs on add_nodes/add_edges

### DIFF
--- a/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/__init__.py
+++ b/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/__init__.py
@@ -5,7 +5,7 @@ This package provides a Memgraph graph database adapter for the Cognee framework
 
 from .memgraph_adapter import MemgraphAdapter
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["MemgraphAdapter", "register"]
 
 

--- a/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/memgraph_adapter.py
+++ b/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/memgraph_adapter.py
@@ -178,7 +178,12 @@ class MemgraphAdapter(GraphDBInterface):
         }
         return await self.query(query, params)
 
-    async def add_nodes(self, nodes: list[DataPoint]) -> None:
+    async def add_nodes(
+        self,
+        nodes: list[DataPoint],
+        source_ref_key: Optional[str] = None,
+        pipeline_run_id: Optional[str] = None,
+    ) -> None:
         """
         Add multiple nodes to the database in a single operation.
 
@@ -187,6 +192,11 @@ class MemgraphAdapter(GraphDBInterface):
 
             - nodes (list[DataPoint]): A list of DataPoint objects representing the nodes to
               add.
+            - source_ref_key (Optional[str]): Graph-provenance source ref (cognee 1.3.0). Accepted
+              for interface compatibility and ignored — Memgraph does not fold provenance today.
+              (default None)
+            - pipeline_run_id (Optional[str]): Run id paired with the provenance stamp. Accepted
+              and ignored by this backend. (default None)
 
         Returns:
         --------
@@ -420,7 +430,12 @@ class MemgraphAdapter(GraphDBInterface):
 
         return await self.query(query, params)
 
-    async def add_edges(self, edges: list[tuple[str, str, str, dict[str, Any]]]) -> None:
+    async def add_edges(
+        self,
+        edges: list[tuple[str, str, str, dict[str, Any]]],
+        source_ref_key: Optional[str] = None,
+        pipeline_run_id: Optional[str] = None,
+    ) -> None:
         """
         Batch add multiple edges between nodes, enforcing specified relationships.
 
@@ -429,6 +444,11 @@ class MemgraphAdapter(GraphDBInterface):
 
             - edges (list[tuple[str, str, str, dict[str, Any]]): A list of tuples containing
               specifications for each edge to add.
+            - source_ref_key (Optional[str]): Graph-provenance source ref (cognee 1.3.0). Accepted
+              for interface compatibility and ignored — Memgraph does not fold provenance today.
+              (default None)
+            - pipeline_run_id (Optional[str]): Run id paired with the provenance stamp. Accepted
+              and ignored by this backend. (default None)
 
         Returns:
         --------

--- a/packages/graph/memgraph/pyproject.toml
+++ b/packages/graph/memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-graph-adapter-memgraph"
-version = "0.1.4"
+version = "0.2.0"
 description = "Memgraph graph database adapter for cognee"
 authors = [
     {name = "Cognee Team", email = "hello@cognee.ai"},

--- a/packages/graph/memgraph/tests/test_cognee_1_3_interface_compat.py
+++ b/packages/graph/memgraph/tests/test_cognee_1_3_interface_compat.py
@@ -1,0 +1,30 @@
+"""cognee 1.3.0 interface-compatibility tests for MemgraphAdapter.
+
+cognee's non-hybrid write path calls ``add_nodes`` / ``add_edges`` with the
+``source_ref_key`` and ``pipeline_run_id`` provenance keyword arguments
+(``cognee/tasks/storage/add_data_points.py``). Memgraph is a graph-only adapter,
+so it takes that branch; without these parameters cognify raises
+``TypeError: add_nodes() got an unexpected keyword argument 'source_ref_key'``.
+
+These are pure signature checks — no running Memgraph server required.
+"""
+
+import inspect
+
+from cognee_community_graph_adapter_memgraph.memgraph_adapter import MemgraphAdapter
+
+PROVENANCE_KWARGS = ("source_ref_key", "pipeline_run_id")
+
+
+def test_add_nodes_accepts_provenance_kwargs():
+    params = inspect.signature(MemgraphAdapter.add_nodes).parameters
+    for kw in PROVENANCE_KWARGS:
+        assert kw in params, f"add_nodes must accept '{kw}' (cognee 1.3.0 non-hybrid path)"
+        assert params[kw].default is None, f"add_nodes '{kw}' must default to None"
+
+
+def test_add_edges_accepts_provenance_kwargs():
+    params = inspect.signature(MemgraphAdapter.add_edges).parameters
+    for kw in PROVENANCE_KWARGS:
+        assert kw in params, f"add_edges must accept '{kw}' (cognee 1.3.0 non-hybrid path)"
+        assert params[kw].default is None, f"add_edges '{kw}' must default to None"

--- a/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
+++ b/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
@@ -3,9 +3,11 @@ from typing import Any
 
 import cognee
 from cognee.shared.logging_utils import get_logger
+
 # from scrapegraph_py import Client
 # -------
 from scrapegraph_py import ScrapeGraphAI
+
 # --------
 
 logger = get_logger("ScrapegraphTask")
@@ -41,7 +43,6 @@ async def scrape_urls(
             "ScrapeGraphAI API key is required. Set the SGAI_API_KEY environment variable."
         )
 
-
     sgai = ScrapeGraphAI(api_key=api_key)
 
     # client = Client(api_key=api_key)
@@ -55,15 +56,10 @@ async def scrape_urls(
                 prompt=user_prompt,
             )
 
-            if response.status == "success": 
-                results.append(
-                    {
-                        "url": url,
-                        "content": response.data.json_data
-                    }
-                )
+            if response.status == "success":
+                results.append({"url": url, "content": response.data.json_data})
                 logger.info(f"Successfully scraped: {url}")
-            else: 
+            else:
                 results.append(
                     {
                         "url": url,


### PR DESCRIPTION
# fix(memgraph): accept cognee 1.3.0 provenance kwargs on add_nodes/add_edges

Closes #103

## Summary
The Memgraph graph adapter fails during `cognify()` on current cognee because
`add_nodes` / `add_edges` don't accept the `source_ref_key` / `pipeline_run_id`
provenance keyword arguments that cognee 1.3.0 passes on the non-hybrid graph
write path. This PR adds those two optional parameters (accept-and-ignore, since
Memgraph doesn't fold graph provenance today), aligning the adapter with the
`GraphDBInterface` signatures, and bumps the package version so a release can ship
the accumulated fixes (including the earlier `get_neighborhood` addition that was
merged to `main` but never published as > 0.1.4 — the literal subject of #103).

## Root cause
cognee's write path (`cognee/tasks/storage/add_data_points.py`) branches on
`use_hybrid = unified.has_capability(EngineCapability.HYBRID_WRITE)`:

```python
if use_hybrid:
    await graph_engine.add_nodes_with_vectors(nodes)
else:
    await graph_engine.add_nodes(
        nodes, source_ref_key=fold_source_ref_key, pipeline_run_id=fold_run_arg
    )
```

Memgraph is a graph-only adapter (no `HYBRID_WRITE`, no `add_nodes_with_vectors`),
so it takes the `else` branch and is called **by keyword** with `source_ref_key` /
`pipeline_run_id`. The adapter's signatures were `add_nodes(self, nodes)` /
`add_edges(self, edges)`, so cognify raised
`TypeError: add_nodes() got an unexpected keyword argument 'source_ref_key'`
(then the same for `add_edges`). The `GraphDBInterface` abstract signatures already
declare both params (defaulting to `None`); the adapter had simply drifted behind.

Note: this is distinct from — and downstream of — the originally reported
`get_neighborhood` error. That method was already added on `main`, but the package
still declared `version = "0.1.4"` (identical to the broken PyPI release), so
`pip install` users kept getting the pre-fix code. The version bump here is what
lets a publish actually resolve the installed-user report.

## Solution
- `memgraph_adapter.py`: add `source_ref_key: Optional[str] = None` and
  `pipeline_run_id: Optional[str] = None` to `add_nodes` and `add_edges`. They are
  accepted for interface compatibility and ignored — Memgraph has no
  graph-provenance schema, and on the non-hybrid path the folded values are `None`,
  so nothing is lost. Method bodies are unchanged. (`Optional` was already imported.)
- `pyproject.toml`: `0.1.4 → 0.2.0`; `__init__.py`: `__version__ "0.1.0" → "0.2.0"`
  (the two were also out of sync). Matches the version-bump-on-fix convention used
  by the recently merged FalkorDB PR #143.
- `tests/test_cognee_1_3_interface_compat.py`: a server-free signature-inspection
  test asserting both methods accept the two provenance kwargs with `None` defaults
  — a fast regression guard against re-drift.

**Note for maintainers:** actually unblocking `pip install` users (the original
#103 report) needs a PyPI **publish** of `0.2.0` — that's a repo-owned release step,
not something this PR can do.

## Changes
```
e541f58 fix(memgraph): accept cognee 1.3.0 provenance kwargs on add_nodes/add_edges

 .../__init__.py                                    |  2 +-
 .../memgraph_adapter.py                            | 24 +++++++++++++++--
 packages/graph/memgraph/pyproject.toml             |  2 +-
 .../tests/test_cognee_1_3_interface_compat.py      | 30 ++++++++++++++++++++++
 4 files changed, 54 insertions(+), 4 deletions(-)
```

## Testing performed
- `python -m py_compile` on the changed modules and the new test — OK.
- `ruff check` on the package + new test — All checks passed.
- `ruff format --check` — already formatted.
- New signature-inspection test is provably correct by construction (it asserts the
  exact params this PR adds); I could not execute it here because it imports the
  full `cognee` + `neo4j` stack, which isn't installed in my environment.
- Not run: the package's end-to-end CI check (`examples/example.py` against a live
  Memgraph + LLM). That job exercises this exact non-hybrid `add_nodes`/`add_edges`
  path, so it is the real integration coverage for the fix once CI runs on the PR.

## Checklist
- [x] Change is focused and minimal
- [x] Follows the project's code style / conventions (accept-and-ignore matches the interface docstring + neo4j reference)
- [x] Tests added or updated where appropriate (server-free signature regression test)
- [x] Documentation updated where appropriate (docstrings for the new params)
- [x] `lint` passes locally (`ruff check` on the package)
- [x] `format` passes locally (`ruff format --check` on the package)
