### PR TITLE
fix(milvus): make `get_milvus_client` directory-create loop-safe for milvus-lite

### DIFF
--- a/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
+++ b/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
@@ -3,9 +3,11 @@ from typing import Any
 
 import cognee
 from cognee.shared.logging_utils import get_logger
+
 # from scrapegraph_py import Client
 # -------
 from scrapegraph_py import ScrapeGraphAI
+
 # --------
 
 logger = get_logger("ScrapegraphTask")
@@ -41,7 +43,6 @@ async def scrape_urls(
             "ScrapeGraphAI API key is required. Set the SGAI_API_KEY environment variable."
         )
 
-
     sgai = ScrapeGraphAI(api_key=api_key)
 
     # client = Client(api_key=api_key)
@@ -55,15 +56,10 @@ async def scrape_urls(
                 prompt=user_prompt,
             )
 
-            if response.status == "success": 
-                results.append(
-                    {
-                        "url": url,
-                        "content": response.data.json_data
-                    }
-                )
+            if response.status == "success":
+                results.append({"url": url, "content": response.data.json_data})
                 logger.info(f"Successfully scraped: {url}")
-            else: 
+            else:
                 results.append(
                     {
                         "url": url,

--- a/packages/vector/milvus/cognee_community_vector_adapter_milvus/milvus_adapter.py
+++ b/packages/vector/milvus/cognee_community_vector_adapter_milvus/milvus_adapter.py
@@ -14,7 +14,6 @@ from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import (
 )
 from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
 from cognee.infrastructure.engine import DataPoint
-from cognee.infrastructure.files.storage import get_file_storage
 from cognee.shared.logging_utils import get_logger
 from pymilvus.orm.types import DataType
 
@@ -71,23 +70,16 @@ class MilvusAdapter:
             A MilvusClient instance.
         """
 
-        # Ensure the parent directory exists for local file-based Milvus databases
+        # Ensure the parent directory exists for local file-based (milvus-lite) databases.
+        # This method is sync but is called from within cognee's running event loop, so we
+        # must not drive the async file-storage helper here — doing so raised RuntimeError
+        # (run_until_complete on a running loop, and the asyncio.run fallback likewise). A
+        # local milvus-lite URI is always a real filesystem path, so os.makedirs is the
+        # loop-safe equivalent.
         if not self.url.startswith("http"):
-            # Local file path
             db_dir = os.path.dirname(self.url)
             if db_dir:
-                file_storage = get_file_storage(db_dir)
-                # This is a sync operation, but we'll handle it appropriately
-                try:
-                    import asyncio
-
-                    loop = asyncio.get_event_loop()
-                    loop.run_until_complete(file_storage.ensure_directory_exists())
-                except RuntimeError:
-                    # If no event loop is running, create a temporary one
-                    import asyncio
-
-                    asyncio.run(file_storage.ensure_directory_exists())
+                os.makedirs(db_dir, exist_ok=True)
 
         if not self.client:
             if self.api_key:

--- a/packages/vector/milvus/pyproject.toml
+++ b/packages/vector/milvus/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-milvus"
-version = "0.1.2"
+version = "0.1.3"
 description = "Milvus vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"


### PR DESCRIPTION
# fix(milvus): make get_milvus_client directory-create loop-safe for milvus-lite

Refs #113

## Summary
`MilvusAdapter.get_milvus_client()` crashes when used with a local (milvus-lite) file URI
from inside cognee's running event loop. It tried to ensure the parent directory exists by
driving cognee's async file-storage helper from a sync method: `loop.run_until_complete(...)`
raises `RuntimeError` on the already-running loop, and the `except RuntimeError` fallback calls
`asyncio.run(...)`, which *also* raises inside a running loop. This PR replaces that block with a
plain, loop-safe `os.makedirs(db_dir, exist_ok=True)`.

## Root cause
`get_milvus_client()` is synchronous but is called from `async` adapter methods
(`create_collection`, etc.) that run inside cognee's event loop. Both branches of the old
directory-ensure logic touch the event loop:
```python
loop = asyncio.get_event_loop()
loop.run_until_complete(file_storage.ensure_directory_exists())   # RuntimeError: loop already running
except RuntimeError:
    asyncio.run(file_storage.ensure_directory_exists())           # RuntimeError: asyncio.run() from running loop
```
So any local milvus-lite run fails before a collection can be created. Server URIs (`http...`)
skip the block and were unaffected.

## Solution
A local milvus-lite URI is always a real filesystem path, so ensuring its parent directory needs
no async storage abstraction:
```python
if not self.url.startswith("http"):
    db_dir = os.path.dirname(self.url)
    if db_dir:
        os.makedirs(db_dir, exist_ok=True)
```
`os` was already imported; the now-unused `get_file_storage` import is removed. Version bumped
`0.1.2 → 0.1.3` per the repo's fix-bump convention.

## Scope note (the other half of #113)
The issue also surfaces a `KeyError: 'milvus'` under `ENABLE_BACKEND_ACCESS_CONTROL=True`, because
Milvus ships no `DatasetDatabaseHandler`. I deliberately left that out of this PR: while
investigating I found the adapter doesn't currently scope its connection to `database_name` (the
`MilvusClient` is created without `db_name`) and `prune()` drops *every* collection on the
connection — so simply mirroring the Qdrant handler (dataset → `vector_database_name`, delete →
`prune()`) would make deleting one dataset wipe all of them. Doing multi-tenant Milvus correctly
needs a real per-dataset isolation model (server `db_name` create/drop vs. per-file milvus-lite)
that should be validated against a live instance. I've left a separate comment on #113 to align
with maintainers on the intended isolation model before building it, rather than ship a data-loss
risk here. Happy to follow up with that PR once the design is agreed.

## Changes
```
0cd6d0a fix(milvus): make get_milvus_client directory-create loop-safe for milvus-lite

 .../milvus_adapter.py                 | 22 +++++++---------------
 packages/vector/milvus/pyproject.toml |  2 +-
 2 files changed, 8 insertions(+), 16 deletions(-)
```

## Testing performed
- `python -m py_compile` on the changed module — OK.
- `ruff check` / `ruff format --check` on the package — clean.
- Not run: the package's CI scripts (`examples/example.py`, `tests/test_milvus.py`) exercise this
  path with a local URI, but need LLM/embedding keys and (for the example) a reachable Milvus;
  those secrets aren't available to a fork PR locally. The change is a self-contained,
  loop-safe directory create.

## Checklist
- [x] Change is focused and minimal
- [x] Follows the project's code style / conventions
- [ ] Tests added or updated where appropriate (CI validates via example/test scripts; see Testing)
- [x] Documentation updated where appropriate (n/a — no public API change)
- [x] `lint` passes locally (`ruff check` on the package)
- [x] `format` passes locally (`ruff format --check` on the package)
