### PR TITLE
ci: pin `ruff` to 0.15.22 for deterministic lint/format

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Run Linting
         uses: astral-sh/ruff-action@v2
+        with:
+          version: "0.15.22"
 
   format-check:
     name: Run Formatting Check
@@ -40,5 +42,6 @@ jobs:
       - name: Run Formatting Check
         uses: astral-sh/ruff-action@v2
         with:
+          version: "0.15.22"
           args: "format --check"
 

--- a/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
+++ b/packages/task/scrapegraph_tasks/cognee_community_tasks_scrapegraph/scrapegraph_task.py
@@ -3,9 +3,11 @@ from typing import Any
 
 import cognee
 from cognee.shared.logging_utils import get_logger
+
 # from scrapegraph_py import Client
 # -------
 from scrapegraph_py import ScrapeGraphAI
+
 # --------
 
 logger = get_logger("ScrapegraphTask")
@@ -41,7 +43,6 @@ async def scrape_urls(
             "ScrapeGraphAI API key is required. Set the SGAI_API_KEY environment variable."
         )
 
-
     sgai = ScrapeGraphAI(api_key=api_key)
 
     # client = Client(api_key=api_key)
@@ -55,15 +56,10 @@ async def scrape_urls(
                 prompt=user_prompt,
             )
 
-            if response.status == "success": 
-                results.append(
-                    {
-                        "url": url,
-                        "content": response.data.json_data
-                    }
-                )
+            if response.status == "success":
+                results.append({"url": url, "content": response.data.json_data})
                 logger.info(f"Successfully scraped: {url}")
-            else: 
+            else:
                 results.append(
                     {
                         "url": url,


### PR DESCRIPTION
## Problem

The Ruff workflow (`.github/workflows/ruff.yml`) uses `astral-sh/ruff-action@v2` with no `version`, which defaults to `latest`. When **ruff 0.16.0** was released it changed formatting rules, so `Run Formatting Check` started failing on **~25 pre-existing files** across the repo — including on `main` — with no code change. Because the version floats, CI lint/format results depend on *when* a run happens, not on the code, and every open PR is currently red on formatting.

## Fix

- Pin both `ruff-action` jobs to `0.15.22` (the version CI was last green on), so results are deterministic and depend only on the code.
- Apply the outstanding ruff fixes to `packages/task/scrapegraph_tasks/.../scrapegraph_task.py` (un-sorted imports `I001` + trailing whitespace `W291`) so `main` is fully clean under the pinned version.

After this, `ruff check .` and `ruff format --check .` both pass cleanly across the repo (verified locally with 0.15.22: all checks pass, 0 files need reformatting).

## Why pin rather than reformat to 0.16.0

Reformatting the ~25 files to satisfy 0.16.0 would be a large diff that re-breaks on the next ruff release. Pinning makes a ruff upgrade a deliberate, reviewable change (bump the pin + a repo-wide `ruff format` in one PR) instead of an implicit break on release day. Happy to send that upgrade PR separately if you'd prefer to move to 0.16.0.

## Testing

- `ruff@0.15.22 check .` → All checks passed
- `ruff@0.15.22 format --check .` → 210 files already formatted, 0 to reformat