### PR TITLE
chore: bump cognee to 1.4.2

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 This directory contains GitHub Actions workflows for testing community adapters
 against the pinned cognee version (see each package's `pyproject.toml`,
-currently `cognee==1.4.1`).
+currently `cognee==1.4.2`).
 
 ## Test tiers
 

--- a/packages/graph/arcadedb/cognee_community_graph_adapter_arcadedb/__init__.py
+++ b/packages/graph/arcadedb/cognee_community_graph_adapter_arcadedb/__init__.py
@@ -7,7 +7,7 @@ driver is used under the hood.
 
 from .arcadedb_adapter import ArcadeDBAdapter
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["ArcadeDBAdapter", "register"]
 
 

--- a/packages/graph/arcadedb/poetry.lock
+++ b/packages/graph/arcadedb/poetry.lock
@@ -805,14 +805,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4892,4 +4892,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "3e977b1d910dd8191f3f4d82b4f708f6bf776e27c849afe6e0287ddf2378c49c"
+content-hash = "ee6ab09f9423eb562c9a8060ddee4239453eb4af47d8cbb17ccd9992a88366ac"

--- a/packages/graph/arcadedb/pyproject.toml
+++ b/packages/graph/arcadedb/pyproject.toml
@@ -6,8 +6,8 @@ authors = [
     {name = "Luca Garulli", email = "l.garulli@arcadedata.com"},
 ]
 dependencies = [
-    "cognee[neo4j]==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee[neo4j]==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/graph/arcadedb/pyproject.toml
+++ b/packages/graph/arcadedb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-graph-adapter-arcadedb"
-version = "0.1.0"
+version = "0.2.0"
 description = "ArcadeDB graph database adapter for cognee"
 authors = [
     {name = "Luca Garulli", email = "l.garulli@arcadedata.com"},

--- a/packages/graph/arcadedb/uv.lock
+++ b/packages/graph/arcadedb/uv.lock
@@ -609,7 +609,7 @@ neo4j = [
 
 [[package]]
 name = "cognee-community-graph-adapter-arcadedb"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee", extra = ["neo4j"] },

--- a/packages/graph/arcadedb/uv.lock
+++ b/packages/graph/arcadedb/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -597,9 +597,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [package.optional-dependencies]
@@ -620,7 +620,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", extras = ["neo4j"], specifier = "==1.4.1" },
+    { name = "cognee", extras = ["neo4j"], specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "starlette", specifier = ">=0.48.0" },

--- a/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/__init__.py
+++ b/packages/graph/memgraph/cognee_community_graph_adapter_memgraph/__init__.py
@@ -5,7 +5,7 @@ This package provides a Memgraph graph database adapter for the Cognee framework
 
 from .memgraph_adapter import MemgraphAdapter
 
-__version__ = "0.1.4"
+__version__ = "0.2.0"
 __all__ = ["MemgraphAdapter", "register"]
 
 

--- a/packages/graph/memgraph/poetry.lock
+++ b/packages/graph/memgraph/poetry.lock
@@ -758,14 +758,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4619,4 +4619,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<=3.13"
-content-hash = "2d248f642433d71eddade8d7598352360a20181375d90aeddd071a98dbb14141"
+content-hash = "eedf186d232975014be12715c4773309626c53bee3fe1bad7dc5e1929fe30bb9"

--- a/packages/graph/memgraph/pyproject.toml
+++ b/packages/graph/memgraph/pyproject.toml
@@ -6,8 +6,8 @@ authors = [
     {name = "Cognee Team", email = "hello@cognee.ai"},
 ]
 dependencies = [
-    "cognee[neo4j]==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee[neo4j]==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/graph/memgraph/pyproject.toml
+++ b/packages/graph/memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-graph-adapter-memgraph"
-version = "0.1.4"
+version = "0.2.0"
 description = "Memgraph graph database adapter for cognee"
 authors = [
     {name = "Cognee Team", email = "hello@cognee.ai"},

--- a/packages/graph/memgraph/uv.lock
+++ b/packages/graph/memgraph/uv.lock
@@ -627,7 +627,7 @@ neo4j = [
 
 [[package]]
 name = "cognee-community-graph-adapter-memgraph"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee", extra = ["neo4j"] },

--- a/packages/graph/memgraph/uv.lock
+++ b/packages/graph/memgraph/uv.lock
@@ -565,7 +565,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -615,9 +615,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [package.optional-dependencies]
@@ -638,7 +638,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", extras = ["neo4j"], specifier = "==1.4.1" },
+    { name = "cognee", extras = ["neo4j"], specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "starlette", specifier = ">=0.48.0" },

--- a/packages/graph/networkx/poetry.lock
+++ b/packages/graph/networkx/poetry.lock
@@ -767,14 +767,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4505,4 +4505,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "e1b4c9bfb7f888d54962a4f211e0fac176717c3fa6c9016d9464fb54bb4da7ba"
+content-hash = "02c30956b49ba9829119b0b73e257bdbac4dbd732b60624497b297570b980d04"

--- a/packages/graph/networkx/pyproject.toml
+++ b/packages/graph/networkx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-graph-adapter-networkx"
-version = "1.0.3"
+version = "1.1.0"
 description = "Networkx graph database adapter for cognee"
 readme = "README.md"
 requires-python =  ">=3.11,<=3.13"

--- a/packages/graph/networkx/pyproject.toml
+++ b/packages/graph/networkx/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python =  ">=3.11,<=3.13"
 dependencies = [
     "networkx>=3.4.2,<4",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/graph/networkx/uv.lock
+++ b/packages/graph/networkx/uv.lock
@@ -538,7 +538,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-graph-adapter-networkx"
-version = "1.0.3"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/graph/networkx/uv.lock
+++ b/packages/graph/networkx/uv.lock
@@ -483,7 +483,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -531,9 +531,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "networkx", specifier = ">=3.4.2,<4" },

--- a/packages/graph/pggraph/cognee_community_graph_adapter_pggraph/__init__.py
+++ b/packages/graph/pggraph/cognee_community_graph_adapter_pggraph/__init__.py
@@ -2,7 +2,7 @@
 
 from .pggraph_adapter import PgGraphAdapter
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["PgGraphAdapter", "register"]
 
 

--- a/packages/graph/pggraph/pyproject.toml
+++ b/packages/graph/pggraph/pyproject.toml
@@ -8,8 +8,8 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<=3.13"
 dependencies = [
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "asyncpg>=0.29.0",

--- a/packages/graph/pggraph/pyproject.toml
+++ b/packages/graph/pggraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-graph-adapter-pggraph"
-version = "0.1.0"
+version = "0.2.0"
 description = "Experimental pgGraph graph database adapter for cognee"
 authors = [
     {name = "Cognee Community"},

--- a/packages/graph/pggraph/uv.lock
+++ b/packages/graph/pggraph/uv.lock
@@ -597,7 +597,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -647,9 +647,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -673,7 +673,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "starlette", specifier = ">=0.48.0" },

--- a/packages/graph/pggraph/uv.lock
+++ b/packages/graph/pggraph/uv.lock
@@ -654,7 +654,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-graph-adapter-pggraph"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/packages/graph/spanner/cognee_community_graph_adapter_spanner/__init__.py
+++ b/packages/graph/spanner/cognee_community_graph_adapter_spanner/__init__.py
@@ -6,7 +6,7 @@ using Spanner Graph (GQL) for knowledge graphs and GraphRAG pipelines.
 
 from .spanner_adapter import SpannerGraphAdapter
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["SpannerGraphAdapter", "register"]
 
 

--- a/packages/graph/spanner/pyproject.toml
+++ b/packages/graph/spanner/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-graph-adapter-spanner"
-version = "0.1.0"
+version = "0.2.0"
 description = "Google Cloud Spanner Graph database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/packages/graph/spanner/pyproject.toml
+++ b/packages/graph/spanner/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "google-cloud-spanner>=3.49.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/graph/turbopuffer/pyproject.toml
+++ b/packages/graph/turbopuffer/pyproject.toml
@@ -5,8 +5,8 @@ description = "TurboPuffer graph adapter for cognee (graph emulated on TurboPuff
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "turbopuffer>=0.5.0",

--- a/packages/graph/turbopuffer/pyproject.toml
+++ b/packages/graph/turbopuffer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-graph-adapter-turbopuffer"
-version = "0.1.0"
+version = "0.2.0"
 description = "TurboPuffer graph adapter for cognee (graph emulated on TurboPuffer namespaces + attributes)"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/packages/graph/turingdb/poetry.lock
+++ b/packages/graph/turingdb/poetry.lock
@@ -1314,14 +1314,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -5767,4 +5767,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "1c975d177d21a20a763d4623b375828d96e988a718091f669172d7c7a2e856ae"
+content-hash = "00993b5bfda183a3083540c6742cf3f47b4e03bc3fdde70c91a2d2df18cb056e"

--- a/packages/graph/turingdb/pyproject.toml
+++ b/packages/graph/turingdb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-graph-adapter-turingdb"
-version = "0.1.1"
+version = "0.2.0"
 description = "Turingdb graph database adapter for cognee"
 readme = "README.md"
 requires-python =  ">=3.11,<=3.13"

--- a/packages/graph/turingdb/pyproject.toml
+++ b/packages/graph/turingdb/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python =  ">=3.11,<=3.13"
 dependencies = [
     "turingdb>=1.22.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/graph/turingdb/uv.lock
+++ b/packages/graph/turingdb/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -612,9 +612,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "starlette", specifier = ">=0.48.0" },

--- a/packages/graph/turingdb/uv.lock
+++ b/packages/graph/turingdb/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-graph-adapter-turingdb"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/hybrid/arcadedb/pyproject.toml
+++ b/packages/hybrid/arcadedb/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "aiohttp>=3.9.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/hybrid/arcadedb/pyproject.toml
+++ b/packages/hybrid/arcadedb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-hybrid-adapter-arcadedb"
-version = "0.4.0"
+version = "0.5.0"
 description = "ArcadeDB hybrid database adapter for Cognee (graph + vector)"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/hybrid/duckdb/poetry.lock
+++ b/packages/hybrid/duckdb/poetry.lock
@@ -799,14 +799,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4985,4 +4985,4 @@ dev = ["build", "mypy", "twine"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<=3.13"
-content-hash = "de8997d0a59cd474ba0913530134789d13de18aa86b5a2edf96c61402626c9c6"
+content-hash = "bab6eb2c1c7fd8896211d2c68f1f1644cf55f3a64cddfc093b668e29efa9baae"

--- a/packages/hybrid/duckdb/pyproject.toml
+++ b/packages/hybrid/duckdb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognee-community-hybrid-adapter-duckdb"
-version = "0.1.4"
+version = "0.2.0"
 description = "DuckDB vector adapter for Cognee with planned graph support"
 readme = "README.md"
 requires-python = ">=3.10,<=3.13"

--- a/packages/hybrid/duckdb/pyproject.toml
+++ b/packages/hybrid/duckdb/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "duckdb>=1.3.2,<1.5.5",  # duckpgq community extension is not yet published for 1.5.5

--- a/packages/hybrid/duckdb/uv.lock
+++ b/packages/hybrid/duckdb/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-hybrid-adapter-duckdb"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/hybrid/duckdb/uv.lock
+++ b/packages/hybrid/duckdb/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -625,9 +625,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "duckdb", specifier = ">=1.3.2,<1.5.5" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },

--- a/packages/hybrid/falkordb/poetry.lock
+++ b/packages/hybrid/falkordb/poetry.lock
@@ -741,14 +741,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4711,4 +4711,4 @@ dev = ["mypy", "types-requests"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "5846cfbc6281feb3827278cafe4068dc159ff3412bc563a6a5f232c1c5b91af5"
+content-hash = "466ff8c03b55b82ce1cc1cba39e169a355cf27cfdb9fd52429a55318b9943711"

--- a/packages/hybrid/falkordb/pyproject.toml
+++ b/packages/hybrid/falkordb/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "falkordb>=1.0.9,<2.0.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/hybrid/falkordb/pyproject.toml
+++ b/packages/hybrid/falkordb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-hybrid-adapter-falkor"
-version = "0.3.0"
+version = "0.4.0"
 description = "Falkor hybrid database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/hybrid/falkordb/uv.lock
+++ b/packages/hybrid/falkordb/uv.lock
@@ -498,7 +498,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -546,9 +546,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -571,7 +571,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "falkordb", specifier = ">=1.0.9,<2.0.0" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },

--- a/packages/hybrid/falkordb/uv.lock
+++ b/packages/hybrid/falkordb/uv.lock
@@ -553,7 +553,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-hybrid-adapter-falkor"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/hybrid/helixdb/README.md
+++ b/packages/hybrid/helixdb/README.md
@@ -2,7 +2,7 @@
 
 A community [cognee](https://github.com/topoteretes/cognee) adapter that uses
 [HelixDB](https://www.helix-db.com/) as both the **graph** and the **vector**
-store (hybrid adapter). Requires **cognee 1.4.1**.
+store (hybrid adapter). Requires **cognee 1.4.2**.
 
 HelixDB uses pre-compiled HQL queries; the adapter deploys a generic schema
 (`CogneeNode` / `CogneeEdge` / `CogneeVector`) and a fixed set of query

--- a/packages/hybrid/helixdb/pyproject.toml
+++ b/packages/hybrid/helixdb/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "helix-py>=0.2.30",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/hybrid/helixdb/pyproject.toml
+++ b/packages/hybrid/helixdb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-hybrid-adapter-helixdb"
-version = "0.1.0"
+version = "0.2.0"
 description = "HelixDB hybrid graph-vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/azureaisearch/poetry.lock
+++ b/packages/vector/azureaisearch/poetry.lock
@@ -829,14 +829,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4572,4 +4572,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<=3.13,>=3.10"
-content-hash = "849b8cc91b11db176a957589e43c7bac69b4a417b75b0a0411baa54b8803617f"
+content-hash = "c9c7e50b0848bff9888270778367326be7c98579a47f444ce79497171d313a2d"

--- a/packages/vector/azureaisearch/pyproject.toml
+++ b/packages/vector/azureaisearch/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-azure"
-version = "0.0.2"
+version = "0.1.0"
 description = "Azure AI search vector database adapter for cognee"
 readme = "README.md"
 requires-python = "<=3.13,>=3.10"

--- a/packages/vector/azureaisearch/pyproject.toml
+++ b/packages/vector/azureaisearch/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = "<=3.13,>=3.10"
 dependencies = [
     "azure-search-documents>=11.4.0",
     "azure-core>=1.29.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
 ]

--- a/packages/vector/azureaisearch/uv.lock
+++ b/packages/vector/azureaisearch/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -628,9 +628,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -648,7 +648,7 @@ dependencies = [
 requires-dist = [
     { name = "azure-core", specifier = ">=1.29.0" },
     { name = "azure-search-documents", specifier = ">=11.4.0" },
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "litellm", specifier = "==1.89.2" },
 ]
 

--- a/packages/vector/azureaisearch/uv.lock
+++ b/packages/vector/azureaisearch/uv.lock
@@ -635,7 +635,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-azure"
-version = "0.0.2"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },

--- a/packages/vector/milvus/poetry.lock
+++ b/packages/vector/milvus/poetry.lock
@@ -778,14 +778,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -5098,4 +5098,4 @@ dev = ["mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "492b25d702d2a3143e3e72c5086f3a5f28de3a03f79d333fdfa2dbf65f0df1a1"
+content-hash = "cc49be7b3aa5240cb2ef786199a9dd128983524b974ddf30eca18702a48309b4"

--- a/packages/vector/milvus/pyproject.toml
+++ b/packages/vector/milvus/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.11,<=3.13"
 dependencies = [
     "pymilvus>=2.5.0,<3",
     "milvus-lite>=2.4.0; sys_platform != 'win32'",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/vector/milvus/pyproject.toml
+++ b/packages/vector/milvus/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-milvus"
-version = "0.1.2"
+version = "0.2.0"
 description = "Milvus vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/milvus/uv.lock
+++ b/packages/vector/milvus/uv.lock
@@ -529,7 +529,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-milvus"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/milvus/uv.lock
+++ b/packages/vector/milvus/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -522,9 +522,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -547,7 +547,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "milvus-lite", marker = "sys_platform != 'win32'", specifier = ">=2.4.0" },

--- a/packages/vector/moss/pyproject.toml
+++ b/packages/vector/moss/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-moss"
-version = "0.1.1"
+version = "0.2.0"
 description = "Moss vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/packages/vector/moss/pyproject.toml
+++ b/packages/vector/moss/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "moss>=1.0.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "python-dotenv>=0.19.0"

--- a/packages/vector/opengauss/pyproject.toml
+++ b/packages/vector/opengauss/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-opengauss"
-version = "0.1.0"
+version = "0.2.0"
 description = "openGauss DataVec vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/opengauss/pyproject.toml
+++ b/packages/vector/opengauss/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "psycopg2-binary>=2.9.9",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
 ]

--- a/packages/vector/opengauss/uv.lock
+++ b/packages/vector/opengauss/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-opengauss"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/opengauss/uv.lock
+++ b/packages/vector/opengauss/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -545,9 +545,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -569,7 +569,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
 ]

--- a/packages/vector/opensearch/poetry.lock
+++ b/packages/vector/opensearch/poetry.lock
@@ -772,14 +772,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4564,4 +4564,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<=3.13,>=3.10"
-content-hash = "532ed7223a1207dace48a7c7f3836555537672931b3df0f93c71e5282522c6f4"
+content-hash = "ec6bf3f1d0ce7985b153a6483c6cfdbad49bba6f00f01534b6cb374300a0f5fd"

--- a/packages/vector/opensearch/pyproject.toml
+++ b/packages/vector/opensearch/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = "<=3.13,>=3.10"
 dependencies = [
     "opensearch-py==3.0.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/vector/opensearch/pyproject.toml
+++ b/packages/vector/opensearch/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-opensearch"
-version = "0.1.2"
+version = "0.2.0"
 description = "OpenSearch vector database adapter for cognee"
 readme = "README.md"
 requires-python = "<=3.13,>=3.10"

--- a/packages/vector/opensearch/uv.lock
+++ b/packages/vector/opensearch/uv.lock
@@ -595,7 +595,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-opensearch"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/opensearch/uv.lock
+++ b/packages/vector/opensearch/uv.lock
@@ -538,7 +538,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -588,9 +588,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -607,7 +607,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "opensearch-py", specifier = "==3.0.0" },

--- a/packages/vector/pinecone/poetry.lock
+++ b/packages/vector/pinecone/poetry.lock
@@ -804,14 +804,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -5167,4 +5167,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "60104daee591f4b85202128ca94f4c67ead0c0025aaa4c8b51efffe8686c4540"
+content-hash = "f720437347d35356902e1b2c25fb596dc751fd22ab0f3219a591a397056c2417"

--- a/packages/vector/pinecone/pyproject.toml
+++ b/packages/vector/pinecone/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-pinecone"
-version = "0.1.2"
+version = "0.2.0"
 description = "Pinecone vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/pinecone/pyproject.toml
+++ b/packages/vector/pinecone/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "pinecone>=3.0.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/vector/pinecone/uv.lock
+++ b/packages/vector/pinecone/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-pinecone"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/pinecone/uv.lock
+++ b/packages/vector/pinecone/uv.lock
@@ -491,7 +491,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -539,9 +539,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -558,7 +558,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "pinecone", specifier = ">=3.0.0" },

--- a/packages/vector/qdrant/poetry.lock
+++ b/packages/vector/qdrant/poetry.lock
@@ -753,14 +753,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4746,4 +4746,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "61089b5b9a7295455330a218f81298df240403347e295f954717f82a58f6f77c"
+content-hash = "f7e2c827b4eaacb7b47b42aabc72a409cd95a6a4d255970254f047c35e06a2a1"

--- a/packages/vector/qdrant/pyproject.toml
+++ b/packages/vector/qdrant/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "qdrant-client>=1.18.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/vector/qdrant/pyproject.toml
+++ b/packages/vector/qdrant/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-qdrant"
-version = "0.3.0"
+version = "0.4.0"
 description = "Qdrant vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/qdrant/uv.lock
+++ b/packages/vector/qdrant/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -522,9 +522,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -541,7 +541,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "qdrant-client", specifier = ">=1.18.0" },

--- a/packages/vector/qdrant/uv.lock
+++ b/packages/vector/qdrant/uv.lock
@@ -529,7 +529,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-qdrant"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/redis/README.md
+++ b/packages/vector/redis/README.md
@@ -155,7 +155,7 @@ config.set_vector_db_config(
 
 - Python >= 3.11, <= 3.13
 - redisvl >= 0.6.0, <= 1.0.0
-- cognee == 1.4.1
+- cognee == 1.4.2
 
 ## Advanced Usage
 

--- a/packages/vector/redis/poetry.lock
+++ b/packages/vector/redis/poetry.lock
@@ -753,14 +753,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4648,4 +4648,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "59d9e95224ed93e5f885a6baed3206aa8698014a230ef6987c322a4fd3ffbc4e"
+content-hash = "36fc73c9b38d5b571a59fbabbb4c0a46be900e8843e8fc421d51613a6be536af"

--- a/packages/vector/redis/pyproject.toml
+++ b/packages/vector/redis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-redis"
-version = "0.2.1"
+version = "0.3.0"
 description = "Redis vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/redis/pyproject.toml
+++ b/packages/vector/redis/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "redisvl>=0.6.0,<=1.0.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/vector/redis/uv.lock
+++ b/packages/vector/redis/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -543,9 +543,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -562,7 +562,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "redisvl", specifier = ">=0.6.0,<=1.0.0" },

--- a/packages/vector/redis/uv.lock
+++ b/packages/vector/redis/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-redis"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/singlestore/poetry.lock
+++ b/packages/vector/singlestore/poetry.lock
@@ -814,14 +814,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4869,4 +4869,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "c229cd303cc6bc001bbe6ddf277fc85ceb7804bfbf1b830a6adfc6b66f998448"
+content-hash = "4406a2f3213e03637b1a95f81032a15439033404fb644c1d1c0317aec4ff640b"

--- a/packages/vector/singlestore/pyproject.toml
+++ b/packages/vector/singlestore/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-singlestore"
-version = "0.1.0"
+version = "0.2.0"
 description = "SingleStore vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/singlestore/pyproject.toml
+++ b/packages/vector/singlestore/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "singlestoredb>=1.16.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/vector/singlestore/uv.lock
+++ b/packages/vector/singlestore/uv.lock
@@ -482,7 +482,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -530,9 +530,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -549,7 +549,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "singlestoredb", specifier = ">=1.16.0" },

--- a/packages/vector/singlestore/uv.lock
+++ b/packages/vector/singlestore/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-singlestore"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/turbopuffer/poetry.lock
+++ b/packages/vector/turbopuffer/poetry.lock
@@ -813,14 +813,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -5142,4 +5142,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "0d989fe290b977f44377994bc92befab2f2837f94493233da2a6de31bfd57c3e"
+content-hash = "4947f2fd91f68189fbbe7b85870789a08fc02c00cbbdb3e261a44b81793b573e"

--- a/packages/vector/turbopuffer/pyproject.toml
+++ b/packages/vector/turbopuffer/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "turbopuffer>=0.5.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "python-dotenv>=1.0.0",

--- a/packages/vector/turbopuffer/pyproject.toml
+++ b/packages/vector/turbopuffer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-turbopuffer"
-version = "0.2.1"
+version = "0.3.0"
 description = "Turbopuffer vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/turbopuffer/uv.lock
+++ b/packages/vector/turbopuffer/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-turbopuffer"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/turbopuffer/uv.lock
+++ b/packages/vector/turbopuffer/uv.lock
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -533,9 +533,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -551,7 +551,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "turbopuffer", specifier = ">=0.5.0" },

--- a/packages/vector/valkey/README.md
+++ b/packages/vector/valkey/README.md
@@ -75,7 +75,7 @@ config.set_vector_db_config(
 
 - Python >= 3.11, <= 3.13
 - valkey-glide >= 2.1.0
-- cognee == 1.4.1
+- cognee == 1.4.2
 
 ## Advanced Usage
 

--- a/packages/vector/valkey/poetry.lock
+++ b/packages/vector/valkey/poetry.lock
@@ -804,14 +804,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -5430,4 +5430,4 @@ test = ["pytest", "pytest-asyncio", "valkey-glide"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "0a6bb082f14f0c107bf9d6183825552d6ace4d36591823d282f265dc9dd28a24"
+content-hash = "225457572e51454cdcecf79cd5079fa1ae8a50711fb34609bab29f9656dc22f7"

--- a/packages/vector/valkey/pyproject.toml
+++ b/packages/vector/valkey/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-valkey"
-version = "0.1.3"
+version = "0.2.0"
 description = "Valkey vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/valkey/pyproject.toml
+++ b/packages/vector/valkey/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "valkey-glide>=2.1.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "numpy>=1.24.0"

--- a/packages/vector/valkey/uv.lock
+++ b/packages/vector/valkey/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-valkey"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/valkey/uv.lock
+++ b/packages/vector/valkey/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -540,9 +540,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.1" },
     { name = "numpy", specifier = ">=1.24.0" },

--- a/packages/vector/weaviate/README.md
+++ b/packages/vector/weaviate/README.md
@@ -123,7 +123,7 @@ export VECTOR_DB_KEY="your-api-key"
 
 - Python >= 3.11, <= 3.13
 - weaviate-client >= 4.9.6, < 5.0.0
-- cognee == 1.4.1
+- cognee == 1.4.2
 
 ## Features
 

--- a/packages/vector/weaviate/poetry.lock
+++ b/packages/vector/weaviate/poetry.lock
@@ -768,14 +768,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc"},
-    {file = "cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9"},
+    {file = "cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d"},
+    {file = "cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f"},
 ]
 
 [package.dependencies]
@@ -4726,4 +4726,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<=3.13"
-content-hash = "d2090c49bd80a3182d8b92acbc3c374408b7e9c005ad109dfbb4ad5d374db3ec"
+content-hash = "1292264fc40a871888bc097fb5b8928015e2d9a563f9f711a0262a148e742f94"

--- a/packages/vector/weaviate/pyproject.toml
+++ b/packages/vector/weaviate/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-community-vector-adapter-weaviate"
-version = "0.1.2"
+version = "0.2.0"
 description = "Weaviate vector database adapter for cognee"
 readme = "README.md"
 requires-python = ">=3.11,<=3.13"

--- a/packages/vector/weaviate/pyproject.toml
+++ b/packages/vector/weaviate/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11,<=3.13"
 dependencies = [
     "weaviate-client>=4.9.6,<5.0.0",
-    "cognee==1.4.1",
-    # Transitive via cognee; pinned to the version cognee 1.4.1 locks (litellm
+    "cognee==1.4.2",
+    # Transitive via cognee; pinned to the version cognee 1.4.2 locks (litellm
     # 1.96.x published cp310-only wheels, uninstallable on the CI's Python 3.11).
     "litellm==1.89.2",
     "starlette>=0.48.0",

--- a/packages/vector/weaviate/uv.lock
+++ b/packages/vector/weaviate/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "cognee-community-vector-adapter-weaviate"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/packages/vector/weaviate/uv.lock
+++ b/packages/vector/weaviate/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -534,9 +534,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/93/1277ebad661581e4eee8182e80cb898d26ae8f60f8aae2cf33329281c4db/cognee-1.4.1.tar.gz", hash = "sha256:9206075539935ef0adfab82cf410af6799e83c42969ba7c8fae5065de9aba7c9", size = 26990336, upload-time = "2026-07-31T21:28:41.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/cf0da41e9dbe28f4d1c8f1f8c3d0e4fbc224fe9f1a281e9a189fdfac5ba4/cognee-1.4.2.tar.gz", hash = "sha256:ca94b26d674c66ad11bdf4bde24881f7b6a6044bdc029cf673c79a6f07f2631f", size = 27031477, upload-time = "2026-08-08T18:02:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8f/509d4fa55140129ae3f93a013f44f82e0842ef60e2f58168c2a38ae3e0a1/cognee-1.4.1-py3-none-any.whl", hash = "sha256:4c94285589db5a585365bf4bf9cfc8481494d7a8dec2e38d50f14484f69f48dc", size = 7448815, upload-time = "2026-07-31T21:28:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/f3c62c5c872314bb24fa6a81a0e8987ac313655e0e4c41b1ba8f703092eb/cognee-1.4.2-py3-none-any.whl", hash = "sha256:8fd91bed9ec87155970d5c3d79996701076bfedb87bf1a1f056a18e857a1f57d", size = 7496972, upload-time = "2026-08-08T18:02:29.899Z" },
 ]
 
 [[package]]
@@ -553,7 +553,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = "==1.4.1" },
+    { name = "cognee", specifier = "==1.4.2" },
     { name = "instructor", specifier = ">=1.11" },
     { name = "litellm", specifier = "==1.89.2" },
     { name = "starlette", specifier = ">=0.48.0" },


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->
This PR bumps the pinned cognee version to 1.4.2 in adapters.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
