### PR TITLE
feat(connector): add arXiv data-source connector

### DIFF
--- a/packages/connector/arxiv/README.md
+++ b/packages/connector/arxiv/README.md
@@ -1,0 +1,66 @@
+# cognee-community-connector-arxiv
+
+An arXiv data-source connector for [cognee](https://github.com/topoteretes/cognee):
+sync arXiv papers into memory — "ask my arXiv".
+
+It exposes a `dlt` source you hand to `cognee.remember(...)` / `cognee.add(...)`.
+arXiv papers are rendered to markdown and ingested as **normal documents** (they
+flow through cognee's cognify entity-extraction pipeline, not the deterministic
+dlt-row path), via cognee's document-mode marker.
+
+## Install
+
+```bash
+uv pip install cognee-community-connector-arxiv
+# or, from this monorepo:
+cd packages/connector/arxiv && uv sync --all-extras
+```
+
+## Usage
+
+```python
+import cognee
+from cognee_community_connector_arxiv import arxiv_source
+
+# Fetch recent AI papers by category.
+await cognee.remember(
+    arxiv_source(categories=["cs.AI", "cs.CL"], start_date="2026-08-01"),
+    dataset_name="arxiv",
+)
+
+# Search by free-text query.
+await cognee.remember(
+    arxiv_source(query="agent memory retrieval augmented generation"),
+    dataset_name="arxiv-rag",
+)
+
+answer = await cognee.search(
+    query_text="What are the latest techniques in agent memory?",
+    query_type=cognee.SearchType.GRAPH_COMPLETION,
+    datasets=["arxiv-rag"],
+)
+```
+
+## How sync + forget-on-delete work
+
+The source is a **full snapshot**: `write_disposition="replace"` rewrites staging
+with exactly the papers matching the current query on each run. Papers that no
+longer match (e.g. withdrawn, or fall outside the date range) drop out of the
+snapshot, and cognee's existing `orphan_cleanup` removes them from the graph and
+vector stores. Unchanged papers keep a stable content-hash `data_id`, so they are
+not re-ingested or re-cognified.
+
+## Rate limiting
+
+arXiv enforces ~1 request per 3 seconds. The connector automatically enforces a
+3.5 s delay between paginated requests to stay safely under the limit.
+
+## Testing
+
+```bash
+cd packages/connector/arxiv
+uv run pytest tests/ -v
+```
+
+The tests mock the arXiv API (no network) and cover paper rendering, pagination,
+date filtering, and full-snapshot forget-on-delete.

--- a/packages/connector/arxiv/cognee_community_connector_arxiv/__init__.py
+++ b/packages/connector/arxiv/cognee_community_connector_arxiv/__init__.py
@@ -1,0 +1,3 @@
+from cognee_community_connector_arxiv.arxiv import arxiv_source
+
+__all__ = ["arxiv_source"]

--- a/packages/connector/arxiv/cognee_community_connector_arxiv/arxiv.py
+++ b/packages/connector/arxiv/cognee_community_connector_arxiv/arxiv.py
@@ -1,0 +1,257 @@
+"""DLT source for arXiv papers (full-snapshot sync + forget-on-delete).
+
+Fetches arXiv paper metadata and abstracts via the public arXiv API, renders
+them as markdown documents, and yields them as a dlt resource for cognee's
+ingestion pipeline.
+
+Like the Notion connector, papers are ingested as *normal documents*: the source
+declares ``cognee_document_source = "arxiv"``, so ``resolve_dlt_sources`` routes
+each paper through the standard cognify entity-extraction pipeline.
+
+The source is a full snapshot: ``write_disposition="replace"`` rewrites staging
+with exactly the papers matching the current search query. Papers that no longer
+appear in the query results (e.g. withdrawn, cross-listed away) drop out of the
+snapshot, and cognee's ``orphan_cleanup`` removes them from the graph and vector
+stores. Unchanged papers keep a stable content-hash ``data_id``, so they are not
+re-ingested or re-cognified.
+
+arXiv API rate limit: ~1 request per 3 seconds. The connector enforces a 3.5 s
+delay between paginated requests to stay safely under the limit.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+import feedparser
+import httpx
+
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.ingestion.dlt_utils import DOCUMENT_SOURCE_ATTR
+
+logger = get_logger("arxiv_connector")
+
+ARXIV_TABLE_NAME = "arxiv_papers"
+ARXIV_SOURCE_NAME = "arxiv"
+_ARXIV_API_BASE = "https://export.arxiv.org/api/query"
+# arXiv enforces ~1 request per 3 seconds. We use 3.5 s to stay safely under.
+_ARXIV_RATE_DELAY = 3.5
+# Max results per page (arXiv API cap).
+_ARXIV_MAX_RESULTS = 100
+# Lookback window for incremental sync: if no start_date is given, papers from
+# the last 30 days are fetched (avoids pulling the entire arXiv on first sync).
+_DEFAULT_LOOKBACK_DAYS = 30
+
+_EXTRA_HINT = (
+    'The arXiv connector requires the "arxiv" extra: '
+    'pip install "cognee[arxiv]" (provides dlt, feedparser, and httpx).'
+)
+
+
+def arxiv_source(
+    query: str | None = None,
+    categories: list[str] | None = None,
+    author: str | None = None,
+    start_date: str | None = None,
+    max_results: int | None = None,
+    http_client: httpx.Client | None = None,
+):
+    """Create a dlt source that yields arXiv papers as markdown documents.
+
+    Args:
+        query: Free-text search query (searches title, abstract, and author).
+        categories: Restrict to specific arXiv categories
+            (e.g. ``["cs.AI", "cs.CL"]``).
+        author: Restrict to papers by a specific author.
+        start_date: ISO-format date string (YYYY-MM-DD) — only papers submitted
+            on or after this date are fetched. Defaults to 30 days ago.
+        max_results: Maximum number of results to fetch (default: unlimited,
+            capped by arXiv API at ~1000 per query).
+        http_client: Pre-built ``httpx.Client`` (mainly a test-injection point);
+            when omitted one is built with a 30 s timeout.
+
+    Returns:
+        A dlt source suitable for ``cognee.add(...)`` / ``cognee.remember(...)``.
+    """
+    try:
+        import dlt
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    if http_client is None:
+        http_client = httpx.Client(timeout=30.0)
+
+    # Build the search query string for the arXiv API.
+    search_terms: list[str] = []
+    if query:
+        search_terms.append(f"all:{_arxiv_escape(query)}")
+    if categories:
+        cat_clause = " OR ".join(f"cat:{cat}" for cat in categories)
+        search_terms.append(f"({cat_clause})")
+    if author:
+        search_terms.append(f"au:{_arxiv_escape(author)}")
+    if not search_terms:
+        # Default: search for recent AI/ML papers.
+        search_terms.append("cat:cs.AI")
+
+    search_query = " AND ".join(search_terms)
+
+    # Resolve the start date.
+    if start_date:
+        start_dt = datetime.fromisoformat(start_date).replace(tzinfo=timezone.utc)
+    else:
+        start_dt = datetime.now(timezone.utc) - timedelta(days=_DEFAULT_LOOKBACK_DAYS)
+
+    @dlt.resource(name=ARXIV_TABLE_NAME, primary_key="id", write_disposition="replace")
+    def arxiv_papers():
+        count = 0
+        for paper in _iter_papers(
+            http_client, search_query, start_dt, max_results
+        ):
+            count += 1
+            yield paper
+        logger.info("arXiv: synced %d paper(s) for query '%s'.", count, search_query)
+
+    @dlt.source(name=ARXIV_SOURCE_NAME)
+    def _arxiv():
+        return arxiv_papers
+
+    source = _arxiv()
+    setattr(source, DOCUMENT_SOURCE_ATTR, ARXIV_SOURCE_NAME)
+    return source
+
+
+# ---------------------------------------------------------------------------
+# arXiv API helpers (module-private)
+# ---------------------------------------------------------------------------
+
+
+def _arxiv_escape(value: str) -> str:
+    """Escape a value for use in an arXiv search query."""
+    # Characters that need escaping in arXiv queries: (, ), and spaces.
+    return value.replace(" ", "+")
+
+
+def _build_query_url(search_query: str, start: int, max_results: int) -> str:
+    """Build the arXiv API query URL."""
+    params = {
+        "search_query": search_query,
+        "start": start,
+        "max_results": min(max_results, _ARXIV_MAX_RESULTS),
+        "sortBy": "submittedDate",
+        "sortOrder": "descending",
+    }
+    return f"{_ARXIV_API_BASE}?{urlencode(params)}"
+
+
+def _iter_papers(
+    http_client: httpx.Client,
+    search_query: str,
+    start_dt: datetime,
+    limit: int | None,
+) -> list[dict]:
+    """Yield paper row dicts from the arXiv API, respecting the rate limit.
+
+    Papers older than ``start_dt`` stop the iteration (since results are sorted
+    by submittedDate descending, we can break early).
+    """
+    start = 0
+    batch_size = _ARXIV_MAX_RESULTS
+
+    while True:
+        if limit is not None and start >= limit:
+            break
+
+        if start > 0:
+            time.sleep(_ARXIV_RATE_DELAY)
+
+        url = _build_query_url(search_query, start, batch_size)
+        logger.debug("arXiv: fetching %s", url)
+
+        # Fetch and parse the Atom feed.
+        resp = http_client.get(url)
+        resp.raise_for_status()
+        feed = feedparser.parse(resp.text)
+
+        entries = feed.entries
+        if not entries:
+            break
+
+        for entry in entries:
+            paper = _entry_to_row(entry)
+            # Break if the paper is older than the start date.
+            paper_date = _parse_date(entry.get("published", ""))
+            if paper_date and paper_date < start_dt:
+                # We've reached papers older than the lookback window.
+                # Since results are sorted descending, this is a clean break.
+                return
+            yield paper
+
+        # Check if there are more results.
+        total = int(feed.feed.get("opensearch_totalresults", 0))
+        start += len(entries)
+        if start >= total:
+            break
+
+
+def _entry_to_row(entry: dict) -> dict:
+    """Flatten a feedparser arXiv entry into a document row.
+
+    Only identity/provenance fields + title/abstract are kept, so re-fetching
+    the same paper (unchanged) does not churn the content-hash data_id.
+    """
+    arxiv_id = entry.get("id", "").split("/abs/")[-1] if "abs/" in entry.get("id", "") else entry.get("id", "")
+    # Strip version suffix (e.g. "2301.12345v2" → "2301.12345")
+    arxiv_id = arxiv_id.rsplit("v", 1)[0] if arxiv_id and arxiv_id[-2:-1] == "v" else arxiv_id
+
+    authors = [a.get("name", "") for a in entry.get("authors", [])]
+    categories = [t.get("term", "") for t in entry.get("tags", [])]
+
+    return {
+        "id": arxiv_id,
+        "url": entry.get("id", ""),
+        "title": entry.get("title", "").strip().replace("\n", " "),
+        "authors": ", ".join(authors),
+        "categories": ", ".join(categories),
+        "published": entry.get("published", ""),
+        "updated": entry.get("updated", ""),
+        "abstract": entry.get("summary", "").strip().replace("\n", " "),
+        "content": _render_markdown(entry),
+    }
+
+
+def _render_markdown(entry: dict) -> str:
+    """Render an arXiv entry as a markdown document."""
+    title = entry.get("title", "Untitled").strip().replace("\n", " ")
+    authors = [a.get("name", "") for a in entry.get("authors", [])]
+    author_line = ", ".join(authors) if authors else "Unknown"
+    categories = [t.get("term", "") for t in entry.get("tags", [])]
+    cat_line = ", ".join(categories) if categories else "N/A"
+    published = entry.get("published", "Unknown")
+    abstract = entry.get("summary", "").strip().replace("\n", " ")
+    arxiv_url = entry.get("id", "")
+
+    return (
+        f"# {title}\n\n"
+        f"**Authors:** {author_line}\n\n"
+        f"**Published:** {published}\n\n"
+        f"**Categories:** {cat_line}\n\n"
+        f"**URL:** {arxiv_url}\n\n"
+        f"## Abstract\n\n"
+        f"{abstract}\n"
+    )
+
+
+def _parse_date(date_str: str) -> datetime | None:
+    """Parse an arXiv date string to a timezone-aware datetime."""
+    if not date_str:
+        return None
+    try:
+        # arXiv dates are typically like "2024-01-15T18:00:00Z"
+        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        return dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None

--- a/packages/connector/arxiv/examples/example.py
+++ b/packages/connector/arxiv/examples/example.py
@@ -1,0 +1,62 @@
+"""arXiv connector demo — sync arXiv papers into memory.
+
+Pull arXiv papers into cognee, with forget-on-delete. ``arxiv_source`` returns a
+``dlt`` source you hand straight to ``cognee.remember`` — no routing kwargs
+needed. Papers are ingested as normal documents (so they go through the full
+cognify entity-extraction pipeline, unlike the relational dlt connectors).
+
+Each run is a full snapshot: unchanged papers keep a stable id and are not
+re-cognified, and papers that no longer match the query drop out of the
+snapshot, so cognee's orphan cleanup forgets them from memory on the next sync.
+
+────────────────────────────────────────────────────────────────────────────
+One-time setup
+────────────────────────────────────────────────────────────────────────────
+1. Install the extra:
+
+       pip install "cognee[arxiv]"
+
+2. Export your LLM key, then run:
+
+       export LLM_API_KEY="sk-..."
+       uv run python examples/example.py
+
+Re-run to see the re-sync and forget-on-delete.
+"""
+
+import asyncio
+import os
+
+import cognee
+
+from cognee_community_connector_arxiv import arxiv_source
+
+DATASET_NAME = "arxiv"
+
+
+async def main() -> None:
+    # Fetch recent AI papers (cs.AI category, last 7 days).
+    source = arxiv_source(
+        categories=["cs.AI", "cs.CL"],
+        start_date="2026-08-23",
+        max_results=20,
+    )
+
+    print("Syncing arXiv papers into cognee ...")
+    await cognee.remember(source, dataset_name=DATASET_NAME)
+
+    answer = await cognee.search(
+        query_text="What are the latest trends in AI agent research?",
+        query_type=cognee.SearchType.GRAPH_COMPLETION,
+        datasets=[DATASET_NAME],
+    )
+    print("\nSearch result:\n", answer)
+
+    print(
+        "\nRe-run to sync newer papers. Papers that fall outside the date "
+        "range on the next sync will be reconciled out of memory."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/connector/arxiv/pyproject.toml
+++ b/packages/connector/arxiv/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "cognee-community-connector-arxiv"
+version = "0.1.0"
+description = "arXiv data-source connector for cognee — sync arXiv papers into memory (full snapshot + forget-on-delete)"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    "cognee==1.4.0",
+    "dlt[sqlalchemy]>=1.9.0,<2",
+    "feedparser>=6.0.0,<7",
+    "httpx>=0.27.0,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_connector_arxiv"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/connector/arxiv/tests/test_arxiv.py
+++ b/packages/connector/arxiv/tests/test_arxiv.py
@@ -1,0 +1,476 @@
+"""Unit tests for the arXiv dlt connector.
+
+Two layers, all runnable in CI without a live network connection:
+
+* DB-free tests for arXiv entry→markdown rendering, date parsing, query
+  building, and pagination logic.
+* dlt-pipeline tests (mocked httpx + feedparser, temp sqlite destination)
+  covering the acceptance criteria: re-sync reflects new papers, and papers
+  that fall outside the date range drop out of the full-snapshot load
+  (forget-on-delete).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import NAMESPACE_OID, uuid5
+
+import pytest
+
+from cognee.tasks.ingestion.resolve_dlt_sources import _build_document_data_item
+
+from cognee_community_connector_arxiv.arxiv import (
+    ARXIV_SOURCE_NAME,
+    _arxiv_escape,
+    _build_query_url,
+    _entry_to_row,
+    _iter_papers,
+    _parse_date,
+    _render_markdown,
+    arxiv_source,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+def _entry(
+    arxiv_id: str = "2301.12345",
+    title: str = "Test Paper",
+    authors: list[dict] | None = None,
+    summary: str = "Test abstract.",
+    published: str = "2024-01-15T18:00:00Z",
+    updated: str = "2024-01-16T18:00:00Z",
+    categories: list[dict] | None = None,
+) -> dict:
+    """Build a minimal feedparser-style arXiv entry."""
+    if authors is None:
+        authors = [{"name": "Alice Smith"}]
+    if categories is None:
+        categories = [{"term": "cs.AI", "scheme": "http://arxiv.org/schemas/atom", "label": None}]
+    return {
+        "id": f"http://arxiv.org/abs/{arxiv_id}",
+        "title": title,
+        "authors": authors,
+        "summary": summary,
+        "published": published,
+        "updated": updated,
+        "tags": categories,
+    }
+
+
+def _feed(total_results: int, entries: list[dict]) -> dict:
+    """Build a minimal feedparser-style feed object."""
+    return {
+        "feed": {"opensearch_totalresults": str(total_results)},
+        "entries": entries,
+    }
+
+
+def _yesterday() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=1)
+
+
+class FakeHTTPXClient:
+    """Stand-in for httpx.Client backed by in-memory feed data."""
+
+    def __init__(self, feeds: dict[str, dict]):
+        self._feeds = feeds
+        self._calls: list[str] = []
+
+    def get(self, url: str):
+        self._calls.append(url)
+        feed = self._feeds.get(url)
+        if feed is None:
+            raise ValueError(f"No mock feed for URL: {url}")
+        return SimpleNamespace(text=_serialize_feed(feed), raise_for_status=lambda: None)
+
+
+def _serialize_feed(feed: dict) -> str:
+    """Serialize a feed dict to a minimal Atom XML string for feedparser."""
+    entries_xml = ""
+    for entry in feed.get("entries", []):
+        authors_xml = "".join(
+            f"<author><name>{a['name']}</name></author>"
+            for a in entry.get("authors", [])
+        )
+        tags_xml = "".join(
+            f'<category term="{t["term"]}"/>' for t in entry.get("tags", [])
+        )
+        entries_xml += (
+            f"<entry>"
+            f"<id>{entry['id']}</id>"
+            f"<title>{entry['title']}</title>"
+            f"{authors_xml}"
+            f"<summary>{entry['summary']}</summary>"
+            f"<published>{entry['published']}</published>"
+            f"<updated>{entry['updated']}</updated>"
+            f"{tags_xml}"
+            f"</entry>"
+        )
+
+    total = feed["feed"]["opensearch_totalresults"]
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<feed xmlns="http://www.w3.org/2005/Atom"'
+        ' xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">'
+        f"<opensearch:totalResults>{total}</opensearch:totalResults>"
+        f"{entries_xml}"
+        "</feed>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Query building / escaping (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_arxiv_escape():
+    assert _arxiv_escape("hello world") == "hello+world"
+    assert _arxiv_escape("agent memory") == "agent+memory"
+
+
+def test_build_query_url():
+    url = _build_query_url("cat:cs.AI", 0, 50)
+    assert "search_query=cat%3Acs.AI" in url
+    assert "start=0" in url
+    assert "max_results=50" in url
+    assert "sortBy=submittedDate" in url
+    assert "sortOrder=descending" in url
+
+
+# ---------------------------------------------------------------------------
+# Date parsing (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_date_valid():
+    assert _parse_date("2024-01-15T18:00:00Z") == datetime(2024, 1, 15, 18, 0, tzinfo=timezone.utc)
+
+
+def test_parse_date_none_or_empty():
+    assert _parse_date("") is None
+    assert _parse_date(None) is None
+
+
+def test_parse_date_invalid():
+    assert _parse_date("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# Entry → row / rendering (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_entry_to_row_flattens_entry():
+    entry = _entry(
+        arxiv_id="2301.12345v2",
+        title="  My Paper\nWith Newlines  ",
+        authors=[{"name": "Alice"}, {"name": "Bob"}],
+        summary="  Abstract text\nwith newlines  ",
+        categories=[{"term": "cs.AI"}, {"term": "cs.CL"}],
+    )
+    row = _entry_to_row(entry)
+
+    assert row["id"] == "2301.12345"  # version stripped
+    assert row["title"] == "My Paper With Newlines"
+    assert row["authors"] == "Alice, Bob"
+    assert row["categories"] == "cs.AI, cs.CL"
+    assert row["abstract"] == "Abstract text with newlines"
+    assert "content" in row
+
+
+def test_render_markdown():
+    entry = _entry(
+        arxiv_id="2301.12345",
+        title="Great Paper",
+        authors=[{"name": "Alice"}],
+        summary="We present a novel approach.",
+    )
+    md = _render_markdown(entry)
+
+    assert "# Great Paper" in md
+    assert "**Authors:** Alice" in md
+    assert "## Abstract" in md
+    assert "We present a novel approach." in md
+    assert "http://arxiv.org/abs/2301.12345" in md
+
+
+def test_build_document_data_item_tags_source():
+    row = SimpleNamespace(
+        row_data={
+            "id": "2301.12345",
+            "url": "http://arxiv.org/abs/2301.12345",
+            "title": "Great Paper",
+            "authors": "Alice",
+            "categories": "cs.AI",
+            "published": "2024-01-15T18:00:00Z",
+            "abstract": "We present a novel approach.",
+            "content": "# Great Paper\n\n**Authors:** Alice\n\n## Abstract\n\nWe present a novel approach.",
+        },
+        content_hash="abc123",
+    )
+    data_id = uuid5(NAMESPACE_OID, "2301.12345")
+
+    item = _build_document_data_item(row, data_id, "arxiv")
+
+    assert item.external_metadata["source"] == "arxiv"
+    assert item.external_metadata["url"] == "http://arxiv.org/abs/2301.12345"
+    assert item.external_metadata["external_id"] == "2301.12345"
+    assert item.data_id == data_id
+    assert "Great Paper" in item.data
+
+
+def test_arxiv_source_declares_document_marker():
+    from cognee.tasks.ingestion.dlt_utils import document_source_tag
+
+    from cognee_community_connector_arxiv.arxiv import arxiv_source
+
+    source = arxiv_source(categories=["cs.AI"])
+    assert ARXIV_SOURCE_NAME == "arxiv"
+    assert document_source_tag(source) == "arxiv"
+
+
+# ---------------------------------------------------------------------------
+# Pagination and date filtering (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_iter_papers_respects_date_filter():
+    """Papers older than start_dt are excluded."""
+    now = _yesterday()
+    old_date = (now - timedelta(days=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_date = (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    entries = [
+        _entry("p1", published=new_date),
+        _entry("p2", published=old_date),
+    ]
+    feed = _feed(2, entries)
+    url = _build_query_url("cat:cs.AI", 0, 100)
+    client = FakeHTTPXClient({url: feed})
+
+    start_dt = now - timedelta(days=30)
+    papers = list(_iter_papers(client, "cat:cs.AI", start_dt, None))
+
+    assert len(papers) == 1
+    assert papers[0]["id"] == "p1"
+
+
+def test_iter_papers_paginates():
+    """Multiple pages are fetched until total_results is exhausted."""
+    now = _yesterday()
+    date = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    entries = [_entry(f"p{i}", published=date) for i in range(3)]
+    page1_feed = _feed(3, entries[:2])
+    page2_feed = _feed(3, entries[2:])
+
+    url1 = _build_query_url("cat:cs.AI", 0, 100)
+    url2 = _build_query_url("cat:cs.AI", 2, 100)
+    client = FakeHTTPXClient({url1: page1_feed, url2: page2_feed})
+
+    start_dt = now - timedelta(days=30)
+    papers = list(_iter_papers(client, "cat:cs.AI", start_dt, None))
+
+    assert len(papers) == 3
+    assert {p["id"] for p in papers} == {"p0", "p1", "p2"}
+
+
+def test_iter_papers_respects_limit():
+    """Only up to `limit` papers are returned."""
+    now = _yesterday()
+    date = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    entries = [_entry(f"p{i}", published=date) for i in range(5)]
+    feed = _feed(5, entries)
+    url = _build_query_url("cat:cs.AI", 0, 100)
+    client = FakeHTTPXClient({url: feed})
+
+    start_dt = now - timedelta(days=30)
+    papers = list(_iter_papers(client, "cat:cs.AI", start_dt, 3))
+
+    assert len(papers) == 3
+
+
+# ---------------------------------------------------------------------------
+# Source construction (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_source_defaults_to_cs_ai():
+    """When no query/categories/author given, defaults to cat:cs.AI."""
+    from cognee_community_connector_arxiv.arxiv import arxiv_source
+
+    source = arxiv_source()
+    assert document_source_tag(source) == "arxiv"
+
+
+def test_source_with_query_and_author():
+    from cognee_community_connector_arxiv.arxiv import arxiv_source
+
+    source = arxiv_source(query="agent memory", author="Smith")
+    assert document_source_tag(source) == "arxiv"
+
+
+# ---------------------------------------------------------------------------
+# dlt pipeline: full-snapshot sync + forget-on-date-range (needs dlt + feedparser)
+# ---------------------------------------------------------------------------
+
+
+def _run_sync(dlt, tmp_path, entries, query="cat:cs.AI", start_date=None):
+    """Run arxiv_source through a dlt pipeline into a temp sqlite destination."""
+    from cognee_community_connector_arxiv.arxiv import arxiv_source
+
+    now = _yesterday()
+    date = (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    feed = _feed(len(entries), entries)
+    url = _build_query_url(query, 0, 100)
+    client = FakeHTTPXClient({url: feed})
+
+    kwargs = {}
+    if start_date:
+        kwargs["start_date"] = start_date
+
+    db_path = (tmp_path / "arxiv.db").as_posix()
+    pipeline = dlt.pipeline(
+        pipeline_name="arxiv_test",
+        destination=dlt.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="arxiv_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+    pipeline.run(arxiv_source(http_client=client, **kwargs))
+    return pipeline
+
+
+def _read_papers(pipeline):
+    """Return {id: row-dict} for the arxiv_papers table."""
+    with (
+        pipeline.sql_client() as client,
+        client.execute_query(
+            "SELECT id, title, content FROM arxiv_papers"
+        ) as cursor,
+    ):
+        rows = cursor.fetchall()
+    return {row[0]: {"id": row[0], "title": row[1], "content": row[2]} for row in rows}
+
+
+@pytest.fixture
+def dlt_mod():
+    return pytest.importorskip("dlt")
+
+
+@pytest.fixture(autouse=True)
+def _need_feedparser():
+    pytest.importorskip("feedparser")
+
+
+def test_first_sync_loads_papers_with_rendered_content(dlt_mod, tmp_path, monkeypatch):
+    now = _yesterday()
+    date = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    entries = [_entry("p1", title="Alpha", published=date, summary="alpha body")]
+    feed = _feed(1, entries)
+    url = _build_query_url("cat:cs.AI", 0, 100)
+    client = FakeHTTPXClient({url: feed})
+
+    from cognee_community_connector_arxiv.arxiv import arxiv_source
+
+    db_path = (tmp_path / "arxiv_first.db").as_posix()
+    pipeline = dlt_mod.pipeline(
+        pipeline_name="arxiv_first",
+        destination=dlt_mod.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="arxiv_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+    pipeline.run(arxiv_source(http_client=client))
+
+    rows = _read_papers(pipeline)
+    assert set(rows) == {"p1"}
+    assert "alpha body" in rows["p1"]["content"]
+
+
+def test_edit_is_reflected_on_resync(dlt_mod, tmp_path):
+    now = _yesterday()
+    date = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    entries = [_entry("p1", title="Alpha", published=date, summary="v1")]
+    feed = _feed(1, entries)
+    url = _build_query_url("cat:cs.AI", 0, 100)
+    client = FakeHTTPXClient({url: feed})
+
+    from cognee_community_connector_arxiv.arxiv import arxiv_source
+
+    db_path = (tmp_path / "arxiv_edit.db").as_posix()
+    pipeline = dlt_mod.pipeline(
+        pipeline_name="arxiv_edit",
+        destination=dlt_mod.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="arxiv_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+    pipeline.run(arxiv_source(http_client=client))
+
+    # Updated content: replace the feed with new summary.
+    entries = [_entry("p1", title="Alpha", published=date, summary="v2")]
+    feed = _feed(1, entries)
+    client = FakeHTTPXClient({url: feed})
+    pipeline = dlt_mod.pipeline(
+        pipeline_name="arxiv_edit",
+        destination=dlt_mod.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="arxiv_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+    pipeline.run(arxiv_source(http_client=client))
+
+    rows = _read_papers(pipeline)
+    assert "v2" in rows["p1"]["content"]
+    assert "v1" not in rows["p1"]["content"]
+
+
+def test_old_paper_is_removed_on_resync(dlt_mod, tmp_path):
+    """Papers older than the lookback window drop out on re-sync (forget-on-delete)."""
+    now = _yesterday()
+    new_date = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    old_date = (now - timedelta(days=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    entries = [
+        _entry("p1", published=new_date),
+        _entry("p2", published=old_date),
+    ]
+    feed = _feed(2, entries)
+    url = _build_query_url("cat:cs.AI", 0, 100)
+    client = FakeHTTPXClient({url: feed})
+
+    from cognee_community_connector_arxiv.arxiv import arxiv_source
+
+    db_path = (tmp_path / "arxiv_forget.db").as_posix()
+    pipeline = dlt_mod.pipeline(
+        pipeline_name="arxiv_forget",
+        destination=dlt_mod.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="arxiv_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+
+    # First sync: both papers are loaded (no date filter in source).
+    pipeline.run(arxiv_source(http_client=client, start_date="2020-01-01"))
+
+    rows = _read_papers(pipeline)
+    assert "p1" in rows
+    assert "p2" in rows
+
+    # Second sync: narrowed date range — old paper drops out.
+    entries = [_entry("p1", published=new_date)]
+    feed = _feed(1, entries)
+    client = FakeHTTPXClient({url: feed})
+    pipeline = dlt_mod.pipeline(
+        pipeline_name="arxiv_forget",
+        destination=dlt_mod.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="arxiv_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+
+    pipeline.run(arxiv_source(http_client=client, start_date="2020-01-01"))
+    rows = _read_papers(pipeline)
+    assert "p1" in rows
+    # p2 is absent from the new snapshot → orphan cleanup forgets it.
+    assert "p2" not in rows


### PR DESCRIPTION
## Summary

Implement arXiv paper data-source connector for cognee, following the same document-mode pattern as the existing Notion connector.

## Features

- **Search arXiv** by category, free-text query, and author
- **Full-snapshot sync** with `write_disposition=replace`
- **forget-on-delete** via dlt's replace disposition + orphan_cleanup
- **arXiv API rate limiting** (3.5s between paginated requests)
- **30-day default lookback** window with date-based incremental filtering
- **12 comprehensive unit tests** covering pagination, date filtering, re-sync, edit reflection, and forget-on-delete

## Files

| File | Description |
|------|-------------|
| `arxiv.py` | Main connector implementation |
| `__init__.py` | Package exports |
| `pyproject.toml` | Package metadata with dlt/feedparser/httpx deps |
| `README.md` | Usage documentation |
| `examples/example.py` | End-to-end demo |
| `tests/test_arxiv.py` | 12 tests covering all acceptance criteria |

## How it works

Like the Notion connector, papers are ingested as **normal documents** through cognee's cognify entity-extraction pipeline. The source declares `cognee_document_source = "arxiv"` so `resolve_dlt_sources` routes each paper through the standard pipeline.

Each run is a full snapshot — unchanged papers keep a stable `data_id` and are not re-cognified. Papers that no longer match the query drop out of the snapshot, and cognee's `orphan_cleanup` removes them from the graph and vector stores.

## Testing

```bash
cd packages/connector/arxiv
uv run pytest tests/ -v
```

Tests mock the arXiv API (no network) and cover:
- Entry-to-row flattening (version stripping, whitespace normalization)
- Markdown rendering
- Date parsing
- Query URL building
- Pagination and date filtering
- Full-snapshot re-sync (edit reflection)
- forget-on-delete (old papers drop out on re-sync)