### PR TITLE
feat: add Stack Overflow connector

### DIFF
--- a/packages/connector/stack-overflow/README.md
+++ b/packages/connector/stack-overflow/README.md
@@ -1,0 +1,84 @@
+# cognee-community-connector-stack-overflow
+
+A Stack Overflow data-source connector for [cognee](https://github.com/topoteretes/cognee):
+sync questions and answers into memory — "ask my Q&A".
+
+It exposes a `dlt` source you hand to `cognee.remember(...)`, reusing cognee's existing DLT
+ingestion path — so you get **incremental re-sync** (upsert by question id, `merge` write
+disposition, last-activity-date cursor) and **forget-on-delete** (questions removed from Stack
+Overflow are emitted as hard-deletes and purged from memory on the next sync) with no core
+changes.
+
+## Install
+
+```bash
+pip install cognee-community-connector-stack-overflow
+# or, from this monorepo:
+cd packages/connector/stack-overflow && uv sync --all-extras
+```
+
+## Usage
+
+```python
+import cognee
+from cognee_community_connector_stack_overflow import stack_overflow_source
+
+await cognee.remember(
+    stack_overflow_source(
+        tags=["python", "dlt"],
+        api_key="your_stack_apps_key",   # optional; reads STACKOVERFLOW_API_KEY env var
+        include_answers=True,
+    ),
+    dataset_name="stackoverflow_python",
+    primary_key="question_id",
+    write_disposition="merge",  # incremental upsert by question id
+    max_rows_per_table=0,       # unlimited: orphan-cleanup sees the whole corpus
+)
+
+answer = await cognee.search(
+    query_text="How do I use dlt to ingest incremental data?",
+    query_type=cognee.SearchType.GRAPH_COMPLETION,
+    datasets=["stackoverflow_python"],
+)
+```
+
+Re-running `remember(...)` with the same dataset syncs only questions changed since the last
+run and forgets questions that were deleted. See `examples/example.py` for the full flow.
+
+> **`write_disposition="merge"` is required** — the add pipeline defaults to `"replace"`,
+> which would wipe the synced dataset on the second sync.
+
+## How sync + forget-on-delete work
+
+Incremental sync uses the question's `last_activity_date` Unix timestamp, persisted in dlt's
+per-resource state. On each re-run only questions with activity since that cursor are fetched
+and re-embedded. Deleted/migrated questions are detected by sweeping the previously-known id
+set against the `/questions/{ids}` endpoint; missing ids are emitted as hard-delete markers,
+dlt removes those rows on `merge`, and cognee's `orphan_cleanup` purges them from the graph,
+vector, and relational stores.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `tags` | `list[str] \| None` | `None` | Stack Overflow tags to filter by (AND). E.g. `["python", "pandas"]`. |
+| `user_id` | `int \| None` | `None` | Fetch only questions posted by this user id. |
+| `api_key` | `str \| None` | `None` | Stack Apps API key. Falls back to `STACKOVERFLOW_API_KEY` env var. |
+| `include_answers` | `bool` | `True` | Include accepted + top answers in the `content` field. |
+
+## Setup
+
+1. (Optional) Register a Stack Apps application at https://stackapps.com/apps/oauth/register
+   to get an API key and raise the daily quota from 300 to 10 000 requests.
+2. Export `STACKOVERFLOW_API_KEY=your_key` or pass it directly.
+3. Set your `LLM_API_KEY` like any other cognee run.
+
+## Testing
+
+```bash
+uv run pytest tests/
+```
+
+The tests mock the Stack Exchange API (no live key required) and include an end-to-end run
+that drives the source through a real `dlt` merge to prove a delete marker physically removes
+the row.

--- a/packages/connector/stack-overflow/cognee_community_connector_stack_overflow/__init__.py
+++ b/packages/connector/stack-overflow/cognee_community_connector_stack_overflow/__init__.py
@@ -1,0 +1,3 @@
+from cognee_community_connector_stack_overflow.stack_overflow import stack_overflow_source
+
+__all__ = ["stack_overflow_source"]

--- a/packages/connector/stack-overflow/cognee_community_connector_stack_overflow/stack_overflow.py
+++ b/packages/connector/stack-overflow/cognee_community_connector_stack_overflow/stack_overflow.py
@@ -1,0 +1,368 @@
+"""Stack Overflow connector for cognee — a ``dlt`` source that turns Q&A into memory.
+
+Sync Stack Overflow questions (and their accepted/top answers) from a given set
+of tags or a specific user's activity into cognee, incrementally and with
+forget-on-deletion.  Built entirely on the existing DLT ingestion subsystem;
+the resource produced here is handed directly to :func:`cognee.remember`::
+
+    import cognee
+    from cognee_community_connector_stack_overflow import stack_overflow_source
+
+    await cognee.remember(
+        stack_overflow_source(tags=["python", "dlt"]),
+        dataset_name="stackoverflow_python",
+        primary_key="question_id",
+        write_disposition="merge",   # incremental upsert by question id
+        max_rows_per_table=0,        # 0 = no row cap
+    )
+
+Design
+------
+* **Auth** — optional Stack Apps API key (``STACKOVERFLOW_API_KEY`` env var).
+  Without a key the public API allows 300 requests/day; with a registered key
+  the quota rises to 10 000.  No OAuth is required for read-only access.
+* **Primary key** — the Stack Overflow ``question_id``.  Combined with
+  ``write_disposition="merge"`` this gives idempotent upserts.
+* **Incremental cursor** — the ``fromdate`` Unix timestamp of the most-recently
+  seen question.  Each run lists questions modified since the cursor so only
+  the delta is re-embedded.  The cursor is persisted in dlt's per-resource
+  state, so re-running ``remember`` resumes where it left off.
+* **Forget-on-delete** — the Stack Exchange API exposes a ``/questions/{ids}``
+  endpoint; each sync sweeps the previously-known id set and emits hard-delete
+  markers for ids that are no longer returned (deleted or migrated).  dlt
+  removes those rows on ``merge``; cognee's ``orphan_cleanup`` then purges
+  them from the graph, vector, and relational stores.
+* **Content** — question title + body (HTML-stripped) + accepted / top-voted
+  answer bodies are concatenated into a single ``content`` field so a plain
+  ``remember()`` call routes all text through chunking + LLM graph extraction.
+* **Filtering** — restrict by ``tags`` (AND-query), ``user_id`` (questions
+  asked by a specific user), or both.  Leave both ``None`` to pull the overall
+  "newest" feed (not recommended for large sites).
+
+.. note::
+   Stack Exchange API responses are gzip-compressed automatically; ``requests``
+   decompresses them transparently when ``Accept-Encoding: gzip`` is sent
+   (the default).
+
+.. note::
+   The Stack Exchange API paginates with ``page`` / ``pagesize``; max page size
+   is 100.  ``has_more`` in the response indicates whether to fetch the next page.
+"""
+
+from __future__ import annotations
+
+import html
+import os
+import re
+import time
+from collections.abc import Iterator
+from typing import Any
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("stack_overflow_connector")
+
+_STACK_API_BASE = "https://api.stackexchange.com/2.3"
+_SITE = "stackoverflow"
+_PAGE_SIZE = 100
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+def _make_session() -> Any:
+    """Build a ``requests`` session.  Lazily imported so it's optional."""
+    try:
+        import requests
+    except ImportError as exc:
+        raise ImportError(
+            'The Stack Overflow connector requires "requests". '
+            'Install the extra:\n    pip install "cognee[stack-overflow]"'
+        ) from exc
+
+    session = requests.Session()
+    session.headers.update({"Accept-Encoding": "gzip", "Accept": "application/json"})
+    return session
+
+
+def _api_get(session: Any, path: str, params: dict) -> dict:
+    """GET a Stack Exchange API endpoint and return the decoded JSON."""
+    url = f"{_STACK_API_BASE}{path}"
+    response = session.get(url, params=params)
+    response.raise_for_status()
+    return response.json()
+
+
+def _paginate_questions(session: Any, path: str, params: dict) -> Iterator[dict]:
+    """Yield every question item across all pages for a Stack Exchange query."""
+    page = 1
+    while True:
+        data = _api_get(session, path, {**params, "page": page, "pagesize": _PAGE_SIZE})
+        yield from data.get("items", [])
+        if not data.get("has_more", False):
+            break
+        page += 1
+        # Respect backoff / throttle hints from the API.
+        backoff = data.get("backoff")
+        if backoff:
+            logger.warning("Stack Exchange API backoff: sleeping %s seconds", backoff)
+            time.sleep(int(backoff))
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+def _strip_html(raw: str | None) -> str:
+    """Strip HTML tags, unescape entities, and collapse whitespace."""
+    if not raw:
+        return ""
+    return _WS_RE.sub(" ", html.unescape(_TAG_RE.sub(" ", raw))).strip()
+
+
+def _build_content(question: dict, answers: list[dict]) -> str:
+    """Concatenate question title, body, and top answer(s) into a single text block."""
+    parts: list[str] = []
+    title = question.get("title", "")
+    if title:
+        parts.append(f"Q: {_strip_html(title)}")
+    body = _strip_html(question.get("body", ""))
+    if body:
+        parts.append(body)
+    for answer in answers:
+        answer_body = _strip_html(answer.get("body", ""))
+        if answer_body:
+            label = "Accepted answer:" if answer.get("is_accepted") else "Answer:"
+            parts.append(f"{label}\n{answer_body}")
+    return "\n\n".join(parts)
+
+
+def _question_to_row(question: dict, answers: list[dict]) -> dict[str, Any]:
+    """Flatten a Stack Overflow question (+ answers) into a dlt row."""
+    tags = question.get("tags") or []
+    return {
+        "question_id": question["question_id"],
+        "title": _strip_html(question.get("title")),
+        "link": question.get("link", ""),
+        "tags": ",".join(tags),
+        "score": question.get("score", 0),
+        "answer_count": question.get("answer_count", 0),
+        "is_answered": question.get("is_answered", False),
+        "view_count": question.get("view_count", 0),
+        "creation_date": question.get("creation_date", 0),
+        "last_activity_date": question.get("last_activity_date", 0),
+        "owner_display_name": (question.get("owner") or {}).get("display_name", ""),
+        "content": _build_content(question, answers),
+        "_deleted": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Answer fetching
+# ---------------------------------------------------------------------------
+def _fetch_answers(session: Any, question_id: int, api_key: str | None) -> list[dict]:
+    """Return the accepted answer (if any) plus up to 2 highest-scored answers."""
+    params: dict[str, Any] = {
+        "site": _SITE,
+        "order": "desc",
+        "sort": "votes",
+        "filter": "withbody",
+    }
+    if api_key:
+        params["key"] = api_key
+    try:
+        data = _api_get(session, f"/questions/{question_id}/answers", params)
+    except Exception:
+        logger.warning("Could not fetch answers for question %s — skipping", question_id)
+        return []
+
+    items = data.get("items", [])
+    accepted = [a for a in items if a.get("is_accepted")]
+    top = [a for a in items if not a.get("is_accepted")][:2]
+    return accepted + top
+
+
+# ---------------------------------------------------------------------------
+# Sync helpers
+# ---------------------------------------------------------------------------
+def full_backfill(
+    session: Any,
+    state: dict,
+    tags: list[str] | None,
+    user_id: int | None,
+    api_key: str | None,
+    include_answers: bool,
+) -> Iterator[dict]:
+    """Yield all matching questions and record the seen-id set + cursor in ``state``."""
+    params: dict[str, Any] = {
+        "site": _SITE,
+        "order": "desc",
+        "sort": "activity",
+        "filter": "withbody",
+    }
+    if api_key:
+        params["key"] = api_key
+    if tags:
+        params["tagged"] = ";".join(tags)
+
+    path = f"/users/{user_id}/questions" if user_id else "/questions"
+
+    seen_ids: set[int] = set()
+    max_ts = 0
+
+    for question in _paginate_questions(session, path, params):
+        qid = question["question_id"]
+        seen_ids.add(qid)
+        ts = question.get("last_activity_date", 0)
+        if ts > max_ts:
+            max_ts = ts
+        answers = _fetch_answers(session, qid, api_key) if include_answers else []
+        yield _question_to_row(question, answers)
+
+    state["seen_ids"] = list(seen_ids)
+    if max_ts:
+        state["cursor"] = max_ts
+
+
+def incremental_fetch(
+    session: Any,
+    state: dict,
+    tags: list[str] | None,
+    user_id: int | None,
+    api_key: str | None,
+    include_answers: bool,
+) -> Iterator[dict]:
+    """Yield questions modified since the cursor and emit delete markers for removed ids."""
+    cursor: int = state.get("cursor", 0)
+    prev_ids: set[int] = set(state.get("seen_ids", []))
+
+    params: dict[str, Any] = {
+        "site": _SITE,
+        "order": "desc",
+        "sort": "activity",
+        "filter": "withbody",
+        "fromdate": cursor,
+    }
+    if api_key:
+        params["key"] = api_key
+    if tags:
+        params["tagged"] = ";".join(tags)
+
+    path = f"/users/{user_id}/questions" if user_id else "/questions"
+
+    seen_ids: set[int] = set(prev_ids)
+    max_ts = cursor
+
+    for question in _paginate_questions(session, path, params):
+        qid = question["question_id"]
+        seen_ids.add(qid)
+        ts = question.get("last_activity_date", 0)
+        if ts > max_ts:
+            max_ts = ts
+        answers = _fetch_answers(session, qid, api_key) if include_answers else []
+        yield _question_to_row(question, answers)
+
+    # Sweep for deletions: check ids seen before that no longer appear in the API.
+    deleted_ids = _find_deleted_ids(session, prev_ids, api_key)
+    for qid in deleted_ids:
+        seen_ids.discard(qid)
+        yield {"question_id": qid, "_deleted": True}
+
+    state["seen_ids"] = list(seen_ids)
+    if max_ts > cursor:
+        state["cursor"] = max_ts
+
+
+def _find_deleted_ids(
+    session: Any, candidate_ids: set[int], api_key: str | None
+) -> list[int]:
+    """Return ids from ``candidate_ids`` that the API no longer returns (deleted/migrated)."""
+    if not candidate_ids:
+        return []
+
+    deleted: list[int] = []
+    ids_list = list(candidate_ids)
+    # The /questions/{ids} endpoint accepts up to 100 semicolon-joined ids.
+    for i in range(0, len(ids_list), 100):
+        chunk = ids_list[i : i + 100]
+        ids_str = ";".join(str(x) for x in chunk)
+        params: dict[str, Any] = {"site": _SITE, "filter": "total"}
+        if api_key:
+            params["key"] = api_key
+        try:
+            data = _api_get(session, f"/questions/{ids_str}", params)
+        except Exception:
+            logger.warning("Could not sweep ids %s for deletions — skipping", ids_str)
+            continue
+        returned_ids = {item["question_id"] for item in data.get("items", [])}
+        deleted.extend(qid for qid in chunk if qid not in returned_ids)
+
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Public factory
+# ---------------------------------------------------------------------------
+def stack_overflow_source(
+    tags: list[str] | None = None,
+    user_id: int | None = None,
+    api_key: str | None = None,
+    include_answers: bool = True,
+) -> Any:
+    """Return a dlt resource that syncs Stack Overflow questions into cognee.
+
+    Parameters
+    ----------
+    tags:
+        List of Stack Overflow tags to filter by (AND logic).  E.g.
+        ``["python", "pandas"]``.  Leave ``None`` to fetch all questions
+        (or all questions for ``user_id`` if provided).
+    user_id:
+        Numeric Stack Overflow user id.  When set, fetches questions posted
+        by that user (optionally filtered by ``tags``).
+    api_key:
+        Stack Apps API key.  Falls back to the ``STACKOVERFLOW_API_KEY``
+        environment variable.  Optional but raises the daily quota from 300
+        to 10 000 requests.
+    include_answers:
+        When ``True`` (default), the accepted answer and up to two top-voted
+        answers are fetched and concatenated into the ``content`` field.
+        Set to ``False`` to ingest question-only for faster syncs.
+    """
+    try:
+        import dlt
+    except ImportError as exc:
+        raise ImportError(
+            'The Stack Overflow connector requires "dlt". '
+            'Install it with: pip install "dlt[sqlalchemy]"'
+        ) from exc
+
+    resolved_key = api_key or os.environ.get("STACKOVERFLOW_API_KEY")
+
+    @dlt.resource(
+        name="stack_overflow_questions",
+        primary_key="question_id",
+        write_disposition="merge",
+        columns={
+            "_deleted": {
+                "data_type": "bool",
+                "hard_delete": True,
+            }
+        },
+    )
+    def _resource() -> Iterator[dict]:
+        session = _make_session()
+        state = dlt.current.resource_state()
+
+        if state.get("cursor"):
+            yield from incremental_fetch(
+                session, state, tags, user_id, resolved_key, include_answers
+            )
+        else:
+            yield from full_backfill(
+                session, state, tags, user_id, resolved_key, include_answers
+            )
+
+    return _resource()

--- a/packages/connector/stack-overflow/examples/example.py
+++ b/packages/connector/stack-overflow/examples/example.py
@@ -1,0 +1,91 @@
+"""Stack Overflow connector demo — "ask my Q&A".
+
+Pull Stack Overflow questions and answers into cognee memory, incrementally,
+with forget-on-delete.
+
+This example is built on cognee's DLT ingestion subsystem:
+``stack_overflow_source`` returns a ``dlt`` resource you hand straight to
+``cognee.remember``.  The first run backfills all questions for the given
+tags; re-running ``remember`` syncs only questions modified since the last
+run, and questions that disappear (deleted / migrated) are forgotten from
+memory on the next sync.
+
+────────────────────────────────────────────────────────────────────────────
+One-time setup
+────────────────────────────────────────────────────────────────────────────
+1. Install the extra:
+
+       pip install cognee-community-connector-stack-overflow
+
+2. (Optional) Register a Stack Apps application at
+   https://stackapps.com/apps/oauth/register
+   to obtain a ``key``.  Without it the public API allows 300 requests/day;
+   with a key the quota rises to 10 000.
+
+3. Export the key (optional):
+
+       export STACKOVERFLOW_API_KEY="your_key_here"
+
+4. Set your LLM key (``LLM_API_KEY``) in ``.env`` like any other cognee example.
+
+Run it:
+
+    python examples/example.py
+"""
+
+import asyncio
+import os
+
+import cognee
+
+from cognee_community_connector_stack_overflow import stack_overflow_source
+
+DATASET_NAME = "stackoverflow_python"
+
+SO_REMEMBER_KWARGS = {
+    "primary_key": "question_id",
+    "write_disposition": "merge",
+    "max_rows_per_table": 0,
+}
+
+
+async def main():
+    api_key = os.environ.get("STACKOVERFLOW_API_KEY")
+
+    # Start from a clean slate so the demo is reproducible.
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    print("=== Initial sync (full backfill) ===")
+    await cognee.remember(
+        stack_overflow_source(
+            tags=["python", "dlt"],
+            api_key=api_key,
+            include_answers=True,
+        ),
+        dataset_name=DATASET_NAME,
+        **SO_REMEMBER_KWARGS,
+    )
+
+    answer = await cognee.search(
+        query_text="How do I use dlt with Python to ingest data?",
+        query_type=cognee.SearchType.GRAPH_COMPLETION,
+        datasets=[DATASET_NAME],
+    )
+    print("Recall:", answer)
+
+    print("\n=== Incremental re-sync (only changed/removed questions processed) ===")
+    await cognee.remember(
+        stack_overflow_source(
+            tags=["python", "dlt"],
+            api_key=api_key,
+            include_answers=True,
+        ),
+        dataset_name=DATASET_NAME,
+        **SO_REMEMBER_KWARGS,
+    )
+    print("Done — only changed questions were re-processed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/connector/stack-overflow/pyproject.toml
+++ b/packages/connector/stack-overflow/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "cognee-community-connector-stack-overflow"
+version = "0.1.0"
+description = "Stack Overflow data-source connector for cognee — sync questions and answers into memory (incremental + forget-on-delete)"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    "cognee==1.3.0",
+    "dlt[sqlalchemy]>=1.9.0,<2",
+    "requests>=2.31.0,<3",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_connector_stack_overflow"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/connector/stack-overflow/tests/test_stack_overflow.py
+++ b/packages/connector/stack-overflow/tests/test_stack_overflow.py
@@ -1,0 +1,305 @@
+"""Unit tests for the Stack Overflow connector.
+
+The Stack Exchange API is fully mocked — no network access and no API key
+required, so these run in CI. Coverage:
+
+  - HTML stripping and content building (title + body + answers)
+  - full backfill yields every question and records cursor + id set in state
+  - incremental re-sync yields ONLY questions modified since the cursor
+  - deleted/migrated questions become hard-delete markers (forget-on-delete)
+  - the dlt resource is wired with merge + question_id PK + hard_delete column
+  - a dlt end-to-end run proves a delete marker physically removes the row
+"""
+
+import pytest
+
+from cognee_community_connector_stack_overflow.stack_overflow import (
+    _build_content,
+    _find_deleted_ids,
+    _strip_html,
+    full_backfill,
+    incremental_fetch,
+    stack_overflow_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake Stack Exchange API
+# ---------------------------------------------------------------------------
+def _make_question(qid, *, title="A title", body="<p>Body text</p>", ts=1000, tags=None):
+    return {
+        "question_id": qid,
+        "title": title,
+        "body": body,
+        "link": f"https://stackoverflow.com/questions/{qid}",
+        "tags": tags or ["python"],
+        "score": 5,
+        "answer_count": 1,
+        "is_answered": True,
+        "view_count": 100,
+        "creation_date": ts,
+        "last_activity_date": ts,
+        "owner": {"display_name": "testuser"},
+    }
+
+
+def _make_answer(*, body="Answer body", is_accepted=False, score=3):
+    return {"body": body, "is_accepted": is_accepted, "score": score}
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    """Minimal stand-in for a ``requests`` session hitting Stack Exchange."""
+
+    def __init__(self, questions=None, answers_by_id=None, deleted_ids=None):
+        self.questions = questions or []
+        self.answers_by_id = answers_by_id or {}
+        self.deleted_ids = set(deleted_ids or [])
+        self.calls = []
+
+    def get(self, url, params=None):
+        params = params or {}
+        self.calls.append((url, dict(params)))
+
+        if "/answers" in url:
+            qid = int(url.split("/questions/")[1].split("/")[0])
+            items = self.answers_by_id.get(qid, [])
+            return FakeResponse({"items": items, "has_more": False})
+
+        if "/questions/" in url and "answers" not in url:
+            # Deletion-sweep endpoint: /questions/{ids}
+            ids_part = url.split("/questions/")[1]
+            requested = {int(x) for x in ids_part.split(";")}
+            # Return only non-deleted items.
+            items = [
+                {"question_id": qid}
+                for qid in requested
+                if qid not in self.deleted_ids
+            ]
+            return FakeResponse({"items": items, "has_more": False})
+
+        # /questions list endpoint
+        from_date = int(params.get("fromdate", 0))
+        items = [q for q in self.questions if q["last_activity_date"] >= from_date]
+        return FakeResponse({"items": items, "has_more": False})
+
+
+# ---------------------------------------------------------------------------
+# Parsing tests
+# ---------------------------------------------------------------------------
+def test_strip_html_removes_tags():
+    assert _strip_html("<p>Hello <b>world</b></p>") == "Hello world"
+
+
+def test_strip_html_unescapes_entities():
+    assert "&amp;" not in _strip_html("a &amp; b")
+    assert "a & b" == _strip_html("a &amp; b")
+
+
+def test_strip_html_handles_none():
+    assert _strip_html(None) == ""
+
+
+def test_build_content_includes_title_and_body():
+    question = {"title": "How do I?", "body": "<p>details</p>"}
+    content = _build_content(question, [])
+    assert "How do I?" in content
+    assert "details" in content
+
+
+def test_build_content_includes_accepted_answer():
+    question = {"title": "Q", "body": "body"}
+    answers = [_make_answer(body="<p>The fix is X</p>", is_accepted=True)]
+    content = _build_content(question, answers)
+    assert "Accepted answer:" in content
+    assert "The fix is X" in content
+
+
+def test_build_content_labels_non_accepted():
+    question = {"title": "Q", "body": ""}
+    answers = [_make_answer(body="<p>Partial answer</p>", is_accepted=False)]
+    content = _build_content(question, answers)
+    assert "Answer:" in content
+
+
+# ---------------------------------------------------------------------------
+# Full backfill tests
+# ---------------------------------------------------------------------------
+def test_full_backfill_yields_all_questions():
+    questions = [_make_question(1, ts=500), _make_question(2, ts=600)]
+    session = FakeSession(questions=questions)
+    state: dict = {}
+
+    rows = list(full_backfill(session, state, tags=None, user_id=None, api_key=None, include_answers=False))
+
+    assert len(rows) == 2
+    assert {r["question_id"] for r in rows} == {1, 2}
+
+
+def test_full_backfill_records_cursor():
+    questions = [_make_question(1, ts=500), _make_question(2, ts=700)]
+    session = FakeSession(questions=questions)
+    state: dict = {}
+
+    list(full_backfill(session, state, tags=None, user_id=None, api_key=None, include_answers=False))
+
+    assert state["cursor"] == 700
+
+
+def test_full_backfill_records_seen_ids():
+    questions = [_make_question(10), _make_question(20)]
+    session = FakeSession(questions=questions)
+    state: dict = {}
+
+    list(full_backfill(session, state, tags=None, user_id=None, api_key=None, include_answers=False))
+
+    assert set(state["seen_ids"]) == {10, 20}
+
+
+def test_full_backfill_deleted_flag_is_false():
+    session = FakeSession(questions=[_make_question(1)])
+    state: dict = {}
+    rows = list(full_backfill(session, state, tags=None, user_id=None, api_key=None, include_answers=False))
+    assert rows[0]["_deleted"] is False
+
+
+# ---------------------------------------------------------------------------
+# Incremental fetch tests
+# ---------------------------------------------------------------------------
+def test_incremental_fetch_only_returns_new_questions():
+    q_old = _make_question(1, ts=500)
+    q_new = _make_question(2, ts=900)
+    session = FakeSession(questions=[q_old, q_new])
+    state = {"cursor": 800, "seen_ids": [1]}
+
+    rows = list(incremental_fetch(session, state, tags=None, user_id=None, api_key=None, include_answers=False))
+
+    returned_ids = {r["question_id"] for r in rows if not r.get("_deleted")}
+    # Only q_new (ts=900) is >= fromdate=800
+    assert 2 in returned_ids
+
+
+def test_incremental_fetch_advances_cursor():
+    q_new = _make_question(3, ts=1200)
+    session = FakeSession(questions=[q_new])
+    state = {"cursor": 1000, "seen_ids": []}
+
+    list(incremental_fetch(session, state, tags=None, user_id=None, api_key=None, include_answers=False))
+
+    assert state["cursor"] == 1200
+
+
+def test_incremental_fetch_emits_delete_marker_for_removed_question():
+    # Question 99 was seen before but is now deleted (not returned by API).
+    session = FakeSession(questions=[], deleted_ids={99})
+    state = {"cursor": 500, "seen_ids": [99]}
+
+    rows = list(incremental_fetch(session, state, tags=None, user_id=None, api_key=None, include_answers=False))
+
+    delete_rows = [r for r in rows if r.get("_deleted")]
+    assert any(r["question_id"] == 99 for r in delete_rows)
+
+
+def test_incremental_fetch_removes_deleted_from_seen_ids():
+    session = FakeSession(questions=[], deleted_ids={5})
+    state = {"cursor": 500, "seen_ids": [5, 6]}
+
+    list(incremental_fetch(session, state, tags=None, user_id=None, api_key=None, include_answers=False))
+
+    assert 5 not in state["seen_ids"]
+    assert 6 in state["seen_ids"]
+
+
+# ---------------------------------------------------------------------------
+# find_deleted_ids tests
+# ---------------------------------------------------------------------------
+def test_find_deleted_ids_returns_missing():
+    session = FakeSession(deleted_ids={42})
+    deleted = _find_deleted_ids(session, {42, 43}, api_key=None)
+    assert 42 in deleted
+    assert 43 not in deleted
+
+
+def test_find_deleted_ids_empty_input():
+    session = FakeSession()
+    assert _find_deleted_ids(session, set(), api_key=None) == []
+
+
+# ---------------------------------------------------------------------------
+# Answer fetching tests
+# ---------------------------------------------------------------------------
+def test_backfill_with_answers_includes_answer_content():
+    question = _make_question(1, title="How to parse JSON?", body="<p>question</p>")
+    answers = [_make_answer(body="<p>Use json.loads()</p>", is_accepted=True)]
+    session = FakeSession(questions=[question], answers_by_id={1: answers})
+    state: dict = {}
+
+    rows = list(full_backfill(session, state, tags=None, user_id=None, api_key=None, include_answers=True))
+
+    assert "json.loads" in rows[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# dlt resource wiring test
+# ---------------------------------------------------------------------------
+def test_resource_has_correct_primary_key():
+    """The dlt resource must declare question_id as PK and merge disposition."""
+    pytest.importorskip("dlt")
+    resource = stack_overflow_source(tags=["python"])
+    assert resource.write_disposition == "merge"
+    assert list(resource.compute_table_schema().get("columns", {}).keys())
+    columns = resource.compute_table_schema().get("columns", {})
+    assert columns.get("question_id", {}).get("primary_key") is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end dlt merge test (proves hard-delete physically removes the row)
+# ---------------------------------------------------------------------------
+def test_e2e_delete_marker_removes_row(tmp_path, monkeypatch):
+    """A hard-delete marker from the connector must physically remove the dlt row."""
+    dlt = pytest.importorskip("dlt")
+
+    import cognee_community_connector_stack_overflow.stack_overflow as mod
+
+    q1 = _make_question(101, ts=100)
+    q2 = _make_question(102, ts=200)
+    fake_session = FakeSession(questions=[q1, q2])
+
+    monkeypatch.setattr(mod, "_make_session", lambda: fake_session)
+
+    db_path = tmp_path / "test.duckdb"
+    pipeline = dlt.pipeline(
+        pipeline_name="so_test",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="so_data",
+    )
+
+    # First run: ingest both questions.
+    resource = stack_overflow_source(tags=["python"])
+    pipeline.run(resource, primary_key="question_id", write_disposition="merge")
+
+    # Second run: q1 is now deleted.
+    fake_session2 = FakeSession(questions=[], deleted_ids={101})
+    monkeypatch.setattr(mod, "_make_session", lambda: fake_session2)
+
+    resource2 = stack_overflow_source(tags=["python"])
+    pipeline.run(resource2, primary_key="question_id", write_disposition="merge")
+
+    import duckdb
+
+    conn = duckdb.connect(str(db_path))
+    rows = conn.execute("SELECT question_id FROM so_data.stack_overflow_questions").fetchall()
+    conn.close()
+    ids = {r[0] for r in rows}
+    assert 101 not in ids, "Deleted question should have been removed by dlt merge"
+    assert 102 in ids


### PR DESCRIPTION
Adds a new community connector that syncs Stack Overflow questions and answers into cognee memory via the Stack Exchange API.

- Incremental sync using last_activity_date as cursor
- Forget-on-delete via id sweep + hard-delete markers
- Accepted + top answers folded into content field
- Optional API key (STACKOVERFLOW_API_KEY) for higher quota
- Filter by tags and/or user_id
- Unit tests with fully mocked API, including e2e dlt merge test

<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
