### PR TITLE
fix(arcadedb): serialize related graph queries

### DIFF
--- a/packages/graph/arcadedb/cognee_community_graph_adapter_arcadedb/arcadedb_adapter.py
+++ b/packages/graph/arcadedb/cognee_community_graph_adapter_arcadedb/arcadedb_adapter.py
@@ -5,7 +5,6 @@ neo4j async Python driver. The Cypher queries are standard OpenCypher, compatibl
 with ArcadeDB's 97.8% TCK compliance.
 """
 
-import asyncio
 import json
 from collections import defaultdict
 from contextlib import asynccontextmanager
@@ -340,9 +339,10 @@ class ArcadeDBAdapter(GraphDBInterface):
         return [result["successor"] for result in results]
 
     async def get_neighbors(self, node_id: str) -> list[dict[str, Any]]:
-        predecessors, successors = await asyncio.gather(
-            self.get_predecessors(node_id), self.get_successors(node_id)
-        )
+        # Execute reads sequentially. ArcadeDB can reject concurrent requests
+        # with ConcurrentModificationException under load.
+        predecessors = await self.get_predecessors(node_id)
+        successors = await self.get_successors(node_id)
         return predecessors + successors
 
     async def get_node(self, node_id: str) -> Optional[dict[str, Any]]:
@@ -374,9 +374,12 @@ class ArcadeDBAdapter(GraphDBInterface):
         RETURN node, relation, neighbour
         """
 
-        predecessors, successors = await asyncio.gather(
-            self.query(predecessors_query, {"node_id": str(node_id)}),
-            self.query(successors_query, {"node_id": str(node_id)}),
+        # Execute reads sequentially to avoid concurrent database requests.
+        predecessors = await self.query(
+            predecessors_query, {"node_id": str(node_id)}
+        )
+        successors = await self.query(
+            successors_query, {"node_id": str(node_id)}
         )
 
         connections = []

--- a/packages/graph/arcadedb/tests/unit/test_serial_query_execution.py
+++ b/packages/graph/arcadedb/tests/unit/test_serial_query_execution.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import pytest
+
+from cognee_community_graph_adapter_arcadedb.arcadedb_adapter import ArcadeDBAdapter
+
+
+class RecordingAdapter(ArcadeDBAdapter):
+    def __init__(self):
+        self.calls = []
+        self.active_queries = 0
+        self.max_active_queries = 0
+
+    async def query(self, query, params=None):
+        self.calls.append((query, params))
+        self.active_queries += 1
+        self.max_active_queries = max(
+            self.max_active_queries, self.active_queries
+        )
+
+        await asyncio.sleep(0)
+
+        self.active_queries -= 1
+
+        if "MATCH (node)<-[relation]" in query:
+            return []
+
+        if "MATCH (node)-[relation]->(neighbour)" in query:
+            return []
+
+        return []
+
+
+@pytest.mark.asyncio
+async def test_get_connections_executes_queries_sequentially():
+    adapter = RecordingAdapter()
+
+    result = await adapter.get_connections("node-1")
+
+    assert result == []
+    assert len(adapter.calls) == 2
+    assert adapter.max_active_queries == 1
+
+
+class NeighborAdapter(RecordingAdapter):
+    async def get_predecessors(self, node_id):
+        self.active_queries += 1
+        self.max_active_queries = max(
+            self.max_active_queries, self.active_queries
+        )
+
+        await asyncio.sleep(0)
+
+        self.active_queries -= 1
+        return [{"id": "predecessor"}]
+
+    async def get_successors(self, node_id):
+        self.active_queries += 1
+        self.max_active_queries = max(
+            self.max_active_queries, self.active_queries
+        )
+
+        await asyncio.sleep(0)
+
+        self.active_queries -= 1
+        return [{"id": "successor"}]
+
+
+@pytest.mark.asyncio
+async def test_get_neighbors_executes_queries_sequentially():
+    adapter = NeighborAdapter()
+
+    result = await adapter.get_neighbors("node-1")
+
+    assert result == [
+        {"id": "predecessor"},
+        {"id": "successor"},
+    ]
+    assert adapter.max_active_queries == 1


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->
## Summary

Addresses the concurrent-query portion of #156 by serializing related graph-read operations in the ArcadeDB adapter.

### Changes

- Execute predecessor and successor lookups sequentially in `get_neighbors`
- Execute predecessor and successor connection queries sequentially in `get_connections`
- Remove the now-unused `asyncio` import
- Add regression tests verifying that these operations do not execute concurrently

## Validation

- `uv run --with pytest-asyncio pytest tests/unit/test_serial_query_execution.py -v`
  - 2 passed
- `uv run --with pytest-asyncio pytest tests/unit/test_contract.py -v`
  - 2 passed
- `uvx ruff check cognee_community_graph_adapter_arcadedb/arcadedb_adapter.py tests/unit/test_serial_query_execution.py`
  - All checks passed

## Notes

This PR specifically addresses the concurrent request failures reported in #156. Other issues mentioned in the report, including deletion failures and newer ArcadeDB schema compatibility, are outside the scope of this change.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
