### PR TITLE
feat(turso): scaffold hybrid adapter package

### DIFF
--- a/packages/hybrid/turso/README.md
+++ b/packages/hybrid/turso/README.md
@@ -1,0 +1,29 @@
+# Cognee Community Hybrid Adapter — Turso/libSQL
+
+> Initial scaffold for Issue #125.
+
+This package will provide a Turso/libSQL backend for both graph and vector
+operations in Cognee.
+
+## Planned architecture
+
+- **Graph:** nodes and edges represented in libSQL tables.
+- **Vector:** embeddings stored using libSQL vector capabilities.
+- **Hybrid:** one backend registered for both graph and vector operations.
+- **Embedded mode:** local `file:` database URIs.
+- **Remote mode:** future support for libSQL servers and Turso Cloud.
+- **Dataset isolation:** potentially one database file/database per dataset.
+
+## Current status
+
+The package structure and public import surface are scaffolded.
+
+The concrete implementation of Cognee's `GraphDBInterface` and
+`VectorDBInterface`, registration hooks, tests, and examples are still
+in progress.
+
+## Development
+
+This package is being implemented for:
+
+- `topoteretes/cognee-community#125`

--- a/packages/hybrid/turso/cognee_community_hybrid_adapter_turso/__init__.py
+++ b/packages/hybrid/turso/cognee_community_hybrid_adapter_turso/__init__.py
@@ -1,0 +1,10 @@
+"""
+Cognee community hybrid adapter for Turso/libSQL.
+
+The adapter is intended to provide graph and vector storage through a
+single libSQL/Turso backend.
+"""
+
+from .register import register
+
+__all__ = ["register"]

--- a/packages/hybrid/turso/cognee_community_hybrid_adapter_turso/register.py
+++ b/packages/hybrid/turso/cognee_community_hybrid_adapter_turso/register.py
@@ -1,0 +1,15 @@
+"""
+Adapter registration for the Turso/libSQL hybrid backend.
+"""
+
+
+def register() -> None:
+    """
+    Register the Turso adapter with cognee.
+
+    Full graph/vector registration will be added as the concrete adapter
+    implementation is completed.
+    """
+    raise NotImplementedError(
+        "Turso/libSQL adapter registration is scaffolded but not yet implemented."
+    )

--- a/packages/hybrid/turso/cognee_community_hybrid_adapter_turso/turso_adapter.py
+++ b/packages/hybrid/turso/cognee_community_hybrid_adapter_turso/turso_adapter.py
@@ -1,0 +1,26 @@
+"""
+Turso/libSQL hybrid adapter.
+
+Issue #125 defines this adapter as a single backend intended to implement
+both cognee's graph and vector database contracts.
+
+This initial scaffold intentionally does not claim interface compatibility
+until the concrete libSQL storage implementation is complete.
+"""
+
+
+class TursoAdapter:
+    """
+    Placeholder for the Turso/libSQL hybrid adapter.
+
+    Planned responsibilities:
+    - graph nodes and edges stored in libSQL tables
+    - vector embeddings stored using libSQL vector capabilities
+    - graph and vector operations exposed through cognee interfaces
+    - optional per-dataset isolation using separate embedded database files
+    """
+
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError(
+            "TursoAdapter is currently a package scaffold; implementation is pending."
+        )

--- a/packages/hybrid/turso/examples/example.py
+++ b/packages/hybrid/turso/examples/example.py
@@ -1,0 +1,16 @@
+"""
+Planned Turso/libSQL Cognee example.
+
+The full add -> cognify -> search workflow will be added together with
+the concrete graph and vector adapter implementation.
+"""
+
+
+def main():
+    raise NotImplementedError(
+        "The Turso adapter example requires the concrete adapter implementation."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/hybrid/turso/pyproject.toml
+++ b/packages/hybrid/turso/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "cognee-community-hybrid-adapter-turso"
+version = "0.1.0"
+description = "Turso/libSQL hybrid graph and vector database adapter for cognee"
+authors = [
+    {name = "Cognee Community"},
+]
+dependencies = [
+    "cognee>=1.4.2,<2.0.0",
+]
+readme = "README.md"
+requires-python = ">=3.10,<3.14"
+
+[project.optional-dependencies]
+libsql = [
+    "libsql-experimental>=0.0.55",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/hybrid/turso/tests/test_package_scaffold.py
+++ b/packages/hybrid/turso/tests/test_package_scaffold.py
@@ -1,0 +1,9 @@
+"""
+Smoke tests for the Turso adapter package scaffold.
+"""
+
+from cognee_community_hybrid_adapter_turso import register
+
+
+def test_register_is_exposed():
+    assert callable(register)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

Initial implementation scaffold for the Turso/libSQL hybrid adapter proposed in #125.

This pull request establishes the package structure and public import surface required for a future Turso/libSQL adapter that will support both graph and vector database operations through a single backend.

### What is included

- Added `packages/hybrid/turso/`
- Added the `cognee-community-hybrid-adapter-turso` package definition
- Added the public Python package:
  `cognee_community_hybrid_adapter_turso`
- Added an initial `TursoAdapter` design scaffold
- Added the adapter registration surface
- Added package documentation describing the intended architecture
- Added an example placeholder for the future add → cognify → search workflow
- Added an import-surface smoke test

### Intended architecture

The full implementation will provide:

- Graph storage using libSQL tables for nodes and edges
- Vector storage using libSQL/Turso vector capabilities
- A single backend usable as both Cognee's graph and vector adapter
- Embedded local database support
- Future remote libSQL/Turso support
- Potential per-dataset database isolation

### Scope of this PR

This PR intentionally establishes the package structure before introducing the complete adapter implementation.

The concrete implementation of Cognee's graph and vector interfaces, backend registration behavior, integration tests, and the runnable end-to-end example remain follow-up work.

This keeps the initial contribution focused and makes the implementation stages easier to review independently.

### Validation performed

- `python -m compileall` completed successfully for:
  - adapter package
  - tests
  - examples
- `ruff check packages/hybrid/turso` passed
- `ruff format --check packages/hybrid/turso` passed
- `git diff --check` completed without whitespace errors

### Related issue

Related to #125.

This PR does not claim to fully resolve #125 yet.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
