### PR TITLE
feat: add Readwise data-source connector

### DIFF
--- a/packages/connector/readwise/README.md
+++ b/packages/connector/readwise/README.md
@@ -62,4 +62,4 @@ uv run pytest tests/
 ```
 
 The test suite is offline: it uses a fake HTTP session to cover pagination, filtering,
-rendering, deletions, cursor safety, and the dlt merge/hard-delete schema.
+rendering, deletion rows, and incremental cursor safety.

--- a/packages/connector/readwise/README.md
+++ b/packages/connector/readwise/README.md
@@ -1,0 +1,65 @@
+# cognee-community-connector-readwise
+
+A Readwise data-source connector for [cognee](https://github.com/topoteretes/cognee).
+It turns books and articles into normal cognee documents containing source context,
+document notes, summaries, highlights, and highlight notes.
+
+## Install
+
+```bash
+uv pip install cognee-community-connector-readwise
+# or, from this monorepo:
+cd packages/connector/readwise && uv sync
+```
+
+## Setup and usage
+
+Create an access token at <https://readwise.io/access_token>, then set it alongside
+the LLM credentials required by cognee:
+
+```bash
+export READWISE_ACCESS_TOKEN="..."
+export LLM_API_KEY="..."
+uv run python examples/example.py
+```
+
+Or construct the source directly:
+
+```python
+import cognee
+from cognee_community_connector_readwise import readwise_source
+
+await cognee.remember(
+    readwise_source(),
+    dataset_name="readwise",
+    max_rows_per_table=0,
+)
+```
+
+Pass `book_ids=[123, 456]` to restrict a dedicated dataset to specific Readwise
+`user_book_id` values. Keep a dataset's scope stable between runs so records outside a
+new, narrower scope do not remain in that dataset.
+
+## Sync behavior
+
+The first run exports the selected history. After complete pagination, the connector
+stores the UTC sync-start time and passes it as `updatedAfter` on the next run. Capturing
+the time before the request prevents updates made during pagination from falling between
+sync windows. The cursor advances only after every page succeeds.
+
+The connector always requests `includeDeleted=true`. Deleted books are emitted with
+dlt's hard-delete marker; deleted highlights disappear from the rendered parent document.
+Using merge preserves unchanged books during incremental runs, while cognee's orphan
+cleanup removes hard-deleted documents from graph and vector stores.
+
+Readwise documents use cognee's document ingestion route, so their prose is processed by
+the normal cognify entity-extraction pipeline rather than the relational dlt-row path.
+
+## Testing
+
+```bash
+uv run pytest tests/
+```
+
+The test suite is offline: it uses a fake HTTP session to cover pagination, filtering,
+rendering, deletions, cursor safety, and the dlt merge/hard-delete schema.

--- a/packages/connector/readwise/cognee_community_connector_readwise/__init__.py
+++ b/packages/connector/readwise/cognee_community_connector_readwise/__init__.py
@@ -1,0 +1,3 @@
+from cognee_community_connector_readwise.readwise import readwise_source
+
+__all__ = ["readwise_source"]

--- a/packages/connector/readwise/cognee_community_connector_readwise/readwise.py
+++ b/packages/connector/readwise/cognee_community_connector_readwise/readwise.py
@@ -1,0 +1,262 @@
+"""Readwise highlight export connector for cognee.
+
+The connector emits one document per Readwise book or article.  Each document
+contains its source metadata, document note, summary, highlights, and highlight
+notes.  The export endpoint's ``updatedAfter`` cursor keeps subsequent runs
+incremental, while ``includeDeleted=true`` and dlt's hard-delete hint propagate
+deleted books into cognee's existing orphan cleanup.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Iterator, MutableMapping
+from datetime import UTC, datetime
+from typing import Any
+
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.ingestion.dlt_utils import DOCUMENT_SOURCE_ATTR
+
+logger = get_logger("readwise_connector")
+
+READWISE_EXPORT_URL = "https://readwise.io/api/v2/export/"
+READWISE_SOURCE_NAME = "readwise"
+READWISE_TABLE_NAME = "readwise_documents"
+_MAX_RETRIES = 5
+_EXTRA_HINT = (
+    'The Readwise connector requires dlt and requests: pip install "dlt[sqlalchemy]" requests.'
+)
+
+
+def readwise_source(
+    token: str | None = None,
+    book_ids: list[int | str] | None = None,
+    session: Any = None,
+    clock: Callable[[], datetime] | None = None,
+):
+    """Create an incremental dlt source for a Readwise highlight library.
+
+    Args:
+        token: Readwise access token. Falls back to ``READWISE_ACCESS_TOKEN``.
+        book_ids: Optionally restrict the export to Readwise ``user_book_id`` values.
+        session: Requests-compatible session, primarily for offline tests.
+        clock: UTC-aware clock injection, primarily for deterministic tests.
+    """
+    try:
+        import dlt
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    resolved_token = token or os.environ.get("READWISE_ACCESS_TOKEN")
+    if not resolved_token:
+        raise ValueError(
+            "Readwise access token required: pass token= or set READWISE_ACCESS_TOKEN."
+        )
+
+    if session is None:
+        try:
+            import requests
+        except ImportError as exc:
+            raise ImportError(_EXTRA_HINT) from exc
+        session = requests.Session()
+
+    @dlt.resource(
+        name=READWISE_TABLE_NAME,
+        primary_key="id",
+        write_disposition="merge",
+        columns={"_deleted": {"data_type": "bool", "hard_delete": True}},
+    )
+    def readwise_documents():
+        state = dlt.current.resource_state()
+        yield from _sync_rows(
+            session,
+            resolved_token,
+            state,
+            book_ids=book_ids,
+            clock=clock,
+        )
+
+    @dlt.source(name=READWISE_SOURCE_NAME)
+    def _readwise():
+        return readwise_documents
+
+    source = _readwise()
+    setattr(source, DOCUMENT_SOURCE_ATTR, READWISE_SOURCE_NAME)
+    return source
+
+
+def _sync_rows(
+    session: Any,
+    token: str,
+    state: MutableMapping[str, Any],
+    *,
+    book_ids: list[int | str] | None = None,
+    clock: Callable[[], datetime] | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield one sync batch and advance its cursor only after complete pagination."""
+    sync_started_at = _isoformat_utc((clock or (lambda: datetime.now(UTC)))())
+    updated_after = state.get("updated_after")
+    count = 0
+
+    for book in _iter_export(
+        session,
+        token,
+        updated_after=updated_after,
+        book_ids=book_ids,
+    ):
+        count += 1
+        yield _book_to_row(book)
+
+    state["updated_after"] = sync_started_at
+    logger.info("Readwise: synced %d changed document(s).", count)
+
+
+def _iter_export(
+    session: Any,
+    token: str,
+    *,
+    updated_after: str | None = None,
+    book_ids: list[int | str] | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Page through Readwise's v2 export endpoint."""
+    page_cursor = None
+    seen_cursors: set[str] = set()
+
+    while True:
+        params: dict[str, str] = {"includeDeleted": "true"}
+        if updated_after:
+            params["updatedAfter"] = updated_after
+        if book_ids:
+            params["ids"] = ",".join(str(book_id) for book_id in book_ids)
+        if page_cursor:
+            params["pageCursor"] = page_cursor
+
+        response = _request(
+            session,
+            headers={"Authorization": f"Token {token}"},
+            params=params,
+        )
+        payload = response.json()
+        results = payload.get("results", [])
+        if not isinstance(results, list):
+            raise ValueError("Readwise export response field 'results' must be a list.")
+        yield from results
+
+        next_cursor = payload.get("nextPageCursor")
+        if not next_cursor:
+            return
+        next_cursor = str(next_cursor)
+        if next_cursor in seen_cursors:
+            raise ValueError("Readwise export returned a repeated page cursor.")
+        seen_cursors.add(next_cursor)
+        page_cursor = next_cursor
+
+
+def _request(session: Any, *, headers: dict[str, str], params: dict[str, str]):
+    """GET one export page, retrying rate limits and transient server failures."""
+    for attempt in range(_MAX_RETRIES):
+        response = session.get(READWISE_EXPORT_URL, headers=headers, params=params, timeout=30)
+        if response.status_code not in (429, 500, 502, 503, 504):
+            response.raise_for_status()
+            return response
+        if attempt == _MAX_RETRIES - 1:
+            response.raise_for_status()
+
+        delay = _retry_after(response.headers, attempt)
+        logger.warning(
+            "Readwise: HTTP %d — retrying in %.1fs (%d/%d).",
+            response.status_code,
+            delay,
+            attempt + 1,
+            _MAX_RETRIES,
+        )
+        time.sleep(delay)
+
+    raise RuntimeError("Readwise request retry loop exited unexpectedly.")
+
+
+def _retry_after(headers: MutableMapping[str, str] | None, attempt: int) -> float:
+    value = (headers or {}).get("Retry-After") or (headers or {}).get("retry-after")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(2**attempt)
+
+
+def _book_to_row(book: dict[str, Any]) -> dict[str, Any]:
+    """Convert one exported book and its highlights to a document row."""
+    book_id = book.get("user_book_id")
+    if book_id is None:
+        raise ValueError("Readwise export item is missing 'user_book_id'.")
+
+    if book.get("is_deleted"):
+        return {"id": str(book_id), "_deleted": True}
+
+    return {
+        "id": str(book_id),
+        "url": book.get("source_url") or book.get("readwise_url") or book.get("unique_url"),
+        "title": book.get("title") or book.get("readable_title") or "Untitled",
+        "content": _render_book(book),
+        "_deleted": False,
+    }
+
+
+def _render_book(book: dict[str, Any]) -> str:
+    """Render stable source context, highlights, and notes as markdown."""
+    lines: list[str] = []
+    author = _clean(book.get("author"))
+    category = _clean(book.get("category"))
+    source = _clean(book.get("source"))
+    if author:
+        lines.append(f"Author: {author}")
+    if category:
+        lines.append(f"Category: {category}")
+    if source:
+        lines.append(f"Source: {source}")
+
+    summary = _clean(book.get("summary"))
+    document_note = _clean(book.get("document_note"))
+    if summary:
+        lines.extend(["", "## Summary", summary])
+    if document_note:
+        lines.extend(["", "## Document note", document_note])
+
+    highlights = [
+        highlight
+        for highlight in (book.get("highlights") or [])
+        if isinstance(highlight, dict) and not highlight.get("is_deleted")
+    ]
+    highlights.sort(key=_highlight_sort_key)
+    if highlights:
+        lines.extend(["", "## Highlights"])
+    for highlight in highlights:
+        text = _clean(highlight.get("text"))
+        note = _clean(highlight.get("note"))
+        if not text and not note:
+            continue
+        if text:
+            lines.append(f"- {text}")
+        if note:
+            lines.append(f"  Note: {note}")
+
+    return "\n".join(lines).strip()
+
+
+def _highlight_sort_key(highlight: dict[str, Any]) -> tuple[int, str]:
+    location = highlight.get("location")
+    try:
+        location_number = int(location)
+    except (TypeError, ValueError):
+        location_number = 2**31 - 1
+    return location_number, str(highlight.get("id") or "")
+
+
+def _clean(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _isoformat_utc(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/packages/connector/readwise/examples/example.py
+++ b/packages/connector/readwise/examples/example.py
@@ -1,0 +1,33 @@
+"""Sync a Readwise highlight library into a dedicated cognee dataset."""
+
+import asyncio
+import os
+
+import cognee
+
+from cognee_community_connector_readwise import readwise_source
+
+DATASET_NAME = "readwise"
+
+
+async def main() -> None:
+    if not os.environ.get("READWISE_ACCESS_TOKEN"):
+        print("Set READWISE_ACCESS_TOKEN (and LLM_API_KEY) before running this example.")
+        return
+
+    await cognee.remember(
+        readwise_source(),
+        dataset_name=DATASET_NAME,
+        max_rows_per_table=0,
+    )
+
+    result = await cognee.search(
+        query_text="What themes recur across my reading highlights?",
+        query_type=cognee.SearchType.GRAPH_COMPLETION,
+        datasets=[DATASET_NAME],
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/connector/readwise/pyproject.toml
+++ b/packages/connector/readwise/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "cognee-community-connector-readwise"
+version = "0.1.0"
+description = "Readwise data-source connector for cognee with incremental sync and deletion propagation"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    "cognee==1.4.0",
+    "dlt[sqlalchemy]>=1.9.0,<2",
+    "requests>=2.32.0,<3",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_connector_readwise"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/connector/readwise/tests/test_readwise.py
+++ b/packages/connector/readwise/tests/test_readwise.py
@@ -1,0 +1,152 @@
+"""Offline tests for the Readwise data-source connector."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from cognee_community_connector_readwise.readwise import (
+    _book_to_row,
+    _iter_export,
+    _render_book,
+    _sync_rows,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, headers=None):
+        self.payload = payload
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return next(self.responses)
+
+
+def _book(book_id=123, **overrides):
+    book = {
+        "user_book_id": book_id,
+        "is_deleted": False,
+        "title": "Retrieval Notes",
+        "author": "Ada Example",
+        "category": "articles",
+        "source": "reader",
+        "source_url": "https://example.com/retrieval",
+        "summary": "A short summary.",
+        "document_note": "Compare sparse and dense retrieval.",
+        "highlights": [
+            {"id": 2, "location": 2, "text": "Second highlight", "note": "Useful"},
+            {"id": 1, "location": 1, "text": "First highlight", "note": ""},
+            {"id": 3, "location": 3, "text": "Deleted", "is_deleted": True},
+        ],
+    }
+    book.update(overrides)
+    return book
+
+
+def test_iter_export_paginates_and_preserves_filters():
+    session = FakeSession(
+        [
+            FakeResponse({"results": [_book(1)], "nextPageCursor": "next"}),
+            FakeResponse({"results": [_book(2)], "nextPageCursor": None}),
+        ]
+    )
+
+    rows = list(
+        _iter_export(
+            session,
+            "secret",
+            updated_after="2026-09-01T00:00:00Z",
+            book_ids=[1, "2"],
+        )
+    )
+
+    assert [row["user_book_id"] for row in rows] == [1, 2]
+    assert session.calls[0][1]["headers"] == {"Authorization": "Token secret"}
+    assert session.calls[0][1]["params"] == {
+        "includeDeleted": "true",
+        "updatedAfter": "2026-09-01T00:00:00Z",
+        "ids": "1,2",
+    }
+    assert session.calls[1][1]["params"]["pageCursor"] == "next"
+
+
+def test_iter_export_rejects_repeated_cursor():
+    session = FakeSession(
+        [
+            FakeResponse({"results": [], "nextPageCursor": "same"}),
+            FakeResponse({"results": [], "nextPageCursor": "same"}),
+        ]
+    )
+    with pytest.raises(ValueError, match="repeated page cursor"):
+        list(_iter_export(session, "secret"))
+
+
+def test_book_to_row_renders_document_context_and_live_highlights():
+    row = _book_to_row(_book())
+
+    assert row["id"] == "123"
+    assert row["url"] == "https://example.com/retrieval"
+    assert row["title"] == "Retrieval Notes"
+    assert row["_deleted"] is False
+    assert "Author: Ada Example" in row["content"]
+    assert "## Summary" in row["content"]
+    assert "Compare sparse and dense retrieval." in row["content"]
+    assert row["content"].index("First highlight") < row["content"].index("Second highlight")
+    assert "Note: Useful" in row["content"]
+    assert "Deleted" not in row["content"]
+
+
+def test_deleted_book_becomes_minimal_hard_delete_row():
+    assert _book_to_row(_book(is_deleted=True)) == {"id": "123", "_deleted": True}
+
+
+def test_book_without_id_is_rejected():
+    with pytest.raises(ValueError, match="user_book_id"):
+        _book_to_row({})
+
+
+def test_render_book_handles_empty_optional_fields():
+    assert _render_book(_book(author=None, summary=None, document_note=None, highlights=[])) == (
+        "Category: articles\nSource: reader"
+    )
+
+
+def test_sync_cursor_advances_only_after_complete_iteration():
+    session = FakeSession([FakeResponse({"results": [_book()], "nextPageCursor": None})])
+    state = {"updated_after": "2026-08-01T00:00:00Z"}
+    generator = _sync_rows(
+        session,
+        "secret",
+        state,
+        clock=lambda: datetime(2026, 9, 3, 1, 2, 3, tzinfo=UTC),
+    )
+
+    first = next(generator)
+    assert first["id"] == "123"
+    assert state["updated_after"] == "2026-08-01T00:00:00Z"
+    with pytest.raises(StopIteration):
+        next(generator)
+    assert state["updated_after"] == "2026-09-03T01:02:03Z"
+
+
+def test_sync_failure_does_not_advance_cursor():
+    session = FakeSession([FakeResponse({}, status_code=401)])
+    state = {"updated_after": "old"}
+
+    with pytest.raises(RuntimeError, match="HTTP 401"):
+        list(_sync_rows(session, "secret", state))
+    assert state == {"updated_after": "old"}


### PR DESCRIPTION
## Description

Adds a Readwise data-source connector that exports books and articles as
cognee documents containing source context, summaries, document notes,
highlights, and highlight notes.

- supports incremental sync through `updatedAfter`
- follows `nextPageCursor` pagination
- requests `includeDeleted=true` and propagates deleted books through dlt hard deletes
- retries rate limits and transient server errors
- includes a runnable example, documentation, and offline unit tests

## Testing

- 8 offline unit tests passed on Python 3.12
- Ruff lint and format checks passed
- Python bytecode compilation passed

Local tests used minimal Cognee import stubs; a live Readwise token and
end-to-end LLM ingestion were not exercised.

Fixes topoteretes/cognee#4812

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the
terms of the Topoteretes Developer Certificate of Origin.