### PR TITLE
feat(connector): add Todoist data-source connector (cognee#4815)

### DIFF
--- a/packages/connector/todoist/README.md
+++ b/packages/connector/todoist/README.md
@@ -1,0 +1,106 @@
+# cognee-community-connector-todoist
+
+[Todoist](https://todoist.com) data-source connector for
+[cognee](https://github.com/topoteretes/cognee) — sync your projects, tasks,
+and comments into memory, incrementally and with forget-on-delete. "Ask my
+todo list."
+
+Part of the cognee hackathon connector push (topoteretes/cognee#4815).
+
+## Features
+
+- **Incremental sync** — the first run is a full backfill; every later run
+  posts the recorded Sync API `sync_token` and fetches exactly what changed.
+- **Forget-on-delete** — deleted projects/tasks/comments disappear from the
+  graph on the next sync. Deletions surface via Sync-API tombstones
+  (`is_deleted=1` rows in the delta) *and* the activities feed (which also
+  cascades a deleted project to its tracked tasks).
+- **Document ingestion** — each row becomes a normal text document that flows
+  through cognee's cognify entity-extraction pipeline (same treatment as the
+  Notion / Google Drive connectors), so tasks are searchable and linkable,
+  not just key-value rows.
+- **Stable content hashes** — volatile metadata (due date, priority, labels,
+  ordering) is deliberately excluded from document content, so editing them
+  does not trigger a pointless re-cognify.
+- **Retries with backoff** — rate-limit (429), server (5xx), timeout, and
+  network errors are retried; auth failures fail fast.
+
+## Installation
+
+```bash
+pip install "cognee[todoist]"
+# or, from this repository:
+uv pip install ./packages/connector/todoist
+```
+
+## Setup
+
+1. Create an API token at <https://app.todoist.com/app/settings/integrations>
+   (Settings → Integrations → Developer).
+2. Export it:
+
+   ```bash
+   export TODOIST_API_TOKEN="..."
+   ```
+
+## Usage
+
+```python
+import cognee
+from cognee_community_connector_todoist import todoist_source
+
+await cognee.remember(
+    todoist_source(),
+    dataset_name="my_todoist",
+    primary_key="id",
+    write_disposition="merge",  # REQUIRED — see below
+    max_rows_per_table=0,  # REQUIRED for a real account
+)
+
+answer = await cognee.recall("What do I need to do this week?")
+```
+
+> **`write_disposition="merge"` is mandatory.** The add pipeline defaults to
+> `"replace"` (drop + reload the table each run); on the second, incremental
+> sync that would wipe everything but the small delta.
+
+> **`max_rows_per_table=0`** lifts cognee's 50-row read cap so orphan cleanup
+> compares against the *whole* synced corpus.
+
+A runnable version lives in [`examples/example.py`](examples/example.py).
+
+## What gets ingested
+
+| Entity   | Kind       | Document                                        |
+| -------- | ---------- | ----------------------------------------------- |
+| Project  | `project`  | name + description                              |
+| Task     | `task`     | task name + description                         |
+| Comment  | `comment`  | comment body (parent kind noted in the title)   |
+
+Due dates, priorities, labels, and ordering are intentionally **not** part of
+the document text (they would churn the content hash without adding meaning).
+
+## Deleting data
+
+- Delete a task/comment/project in Todoist → it is removed from cognee's
+  graph, vector, and relational stores on the next sync (dlt hard-delete +
+  cognee's orphan cleanup).
+- Delete the whole dataset locally with `cognee.forget(...)` /
+  `cognee.prune()`.
+
+## Tests
+
+```bash
+uv run pytest packages/connector/todoist/tests -q
+```
+
+All tests run offline: Todoist API access is faked, and the dlt pipeline runs
+against a temporary SQLite destination.
+
+## Notes & limitations
+
+- The activities deletion feed is the source of truth for "vanished" objects.
+  Todoist keeps activities for a limited window; if a device stays offline for
+  longer than that, delete and rebuild the dataset to reconcile.
+- The connector only issues reads against the Sync API and never mutates your
+  Todoist data.

--- a/packages/connector/todoist/cognee_community_connector_todoist/__init__.py
+++ b/packages/connector/todoist/cognee_community_connector_todoist/__init__.py
@@ -1,0 +1,3 @@
+from cognee_community_connector_todoist.todoist import todoist_source
+
+__all__ = ["todoist_source"]

--- a/packages/connector/todoist/cognee_community_connector_todoist/todoist.py
+++ b/packages/connector/todoist/cognee_community_connector_todoist/todoist.py
@@ -1,0 +1,410 @@
+"""DLT source for Todoist (sync-token incremental sync + forget-on-delete).
+
+Pulls Todoist projects, tasks, and comments into cognee incrementally — "ask
+my todo list".  The source is a single dlt resource meant to be handed
+directly to :func:`cognee.remember`::
+
+    import cognee
+    from cognee_community_connector_todoist import todoist_source
+
+    await cognee.remember(
+        todoist_source(token="..."),
+        dataset_name="my_todoist",
+        primary_key="id",
+        write_disposition="merge",   # REQUIRED (see .. important:: below)
+        max_rows_per_table=0,        # REQUIRED for a real account (see .. note:: below)
+    )
+
+.. important::
+   ``write_disposition="merge"`` is **mandatory**.  The add pipeline defaults
+   to ``"replace"`` (drop + reload the table each run); on the second,
+   incremental sync that would wipe everything but the small delta.  Always
+   pass ``"merge"``.
+
+Design
+------
+* **Auth** — Todoist API token (read-only usage: the connector only issues
+  GET/POST reads against the Sync API).  Pass ``token=`` or set
+  ``TODOIST_API_TOKEN``.
+* **Primary key** — the Todoist object ``id``.  Combined with
+  ``write_disposition="merge"`` this gives idempotent upserts across all three
+  entity kinds (projects / tasks / comments) in one staging table.
+* **Incremental cursor** — Todoist Sync API's ``sync_token``.  The first run
+  uses ``sync_token="*"`` (full backfill); every later run posts the token
+  persisted in dlt's resource state and receives exactly what changed since.
+* **Forget-on-delete** — deletions surface two ways and both are handled:
+  (1) the Sync API returns tombstones for recently deleted objects (rows with
+  ``is_deleted=1``), which are re-emitted as hard-delete markers; (2) the
+  activities feed is polled for ``deleted`` events since the last sync, which
+  covers objects that age out of the delta window.  Deleted rows are removed
+  from the dlt destination on ``merge`` and cognee's existing
+  ``orphan_cleanup`` then purges them from the graph, vector, and relational
+  stores.  When a project is deleted, its tasks (tracked in resource state)
+  are hard-deleted with it — Todoist does not reliably emit per-task events
+  for a cascade.
+* **Document mode** — the resource declares ``cognee_document_source =
+  "todoist"`` (the same marker notion/google-drive use), so each row flows
+  through the standard cognify entity-extraction pipeline as a normal text
+  document instead of the deterministic dlt-row schema-context path.
+
+.. note::
+   cognee's ``ingest_dlt_source`` reads at most ``max_rows_per_table`` rows
+   from the dlt destination (default 50).  For a real account pass
+   ``max_rows_per_table=0`` (unlimited) so orphan-cleanup compares against the
+   *whole* synced corpus rather than a truncated window.
+
+Privacy
+-------
+This reads the content of your tasks and comments.  It is **opt-in**: nothing
+is fetched until you construct a source and call ``remember``.  Use a
+dedicated dataset so you can ``cognee.forget`` the whole thing in one call.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.ingestion.dlt_utils import DOCUMENT_SOURCE_ATTR
+
+logger = get_logger("todoist_connector")
+
+# dlt resource / staging-table name for Todoist objects (all three kinds live
+# in one table, discriminated by the ``kind`` column).
+TODOIST_SOURCE_NAME = "todoist"
+TODOIST_TABLE_NAME = "todoist"
+
+_SYNC_URL = "https://api.todoist.com/sync/v9/sync"
+_ACTIVITIES_URL = "https://api.todoist.com/sync/v9/activities"
+
+# Retry budget for rate-limited / transient Todoist API responses.
+_MAX_RETRIES = 5
+
+# Page size for the activities (deletion-feed) endpoint.
+_ACTIVITIES_PAGE = 100
+
+_EXTRA_HINT = (
+    'The Todoist connector requires the "todoist" extra: pip install "cognee[todoist]" '
+    "(provides dlt and httpx)."
+)
+
+# Sync API resource types that map to the three entity kinds we ingest.
+_SYNC_RESOURCE_TYPES = '["projects", "items", "notes"]'
+
+# object_type (activities feed / sync payload) -> row ``kind``.
+_OBJECT_KINDS = {"item": "task", "note": "comment", "project": "project"}
+
+
+def todoist_source(
+    token: str | None = None,
+    client: Any = None,
+):
+    """Create a dlt resource that yields Todoist projects/tasks/comments.
+
+    Args:
+        token: Todoist API token. Falls back to ``TODOIST_API_TOKEN``.
+        client: Pre-built client with ``sync()``/``deleted_events()``
+            (mainly a test-injection point); when omitted a
+            :class:`TodoistSyncClient` is built from the token above.
+
+    Returns:
+        A dlt resource suitable for ``cognee.remember(...)`` with
+        ``write_disposition="merge"``.
+    """
+    try:
+        import dlt
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    if client is None:
+        resolved_token = token or os.environ.get("TODOIST_API_TOKEN")
+        if not resolved_token:
+            raise ValueError("Todoist API token required: pass token= or set TODOIST_API_TOKEN.")
+        client = TodoistSyncClient(resolved_token)
+
+    @dlt.resource(
+        name=TODOIST_TABLE_NAME,
+        primary_key="id",
+        write_disposition="merge",
+        # _deleted is a boolean hard-delete marker (matching gmail.py /
+        # google_drive.py): rows where it is True are removed from the dlt
+        # destination on merge, which propagates the deletion through
+        # cognee's orphan_cleanup.
+        columns={"_deleted": {"data_type": "bool", "hard_delete": True}},
+    )
+    def todoist():
+        resource_state = dlt.current.resource_state()
+        yield from _sync(client, resource_state)
+
+    # Opt into the document ingestion path (row -> text document -> cognify).
+    # resolve_dlt_sources reads this marker; it never imports this connector.
+    setattr(todoist, DOCUMENT_SOURCE_ATTR, TODOIST_SOURCE_NAME)
+    return todoist
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+class TodoistSyncClient:
+    """Minimal Todoist Sync API client over httpx, with retry/backoff.
+
+    Exposes exactly the two operations the connector needs: ``sync`` (delta or
+    full snapshot) and ``deleted_events`` (the activities deletion feed).  Any
+    object with the same two methods can be injected in its place (tests).
+    """
+
+    def __init__(
+        self,
+        token: str,
+        sync_url: str = _SYNC_URL,
+        activities_url: str = _ACTIVITIES_URL,
+        timeout: float = 30.0,
+    ):
+        self._token = token
+        self._sync_url = sync_url
+        self._activities_url = activities_url
+        self._timeout = timeout
+
+    def sync(self, sync_token: str) -> dict:
+        """Fetch the current delta (or full snapshot when ``sync_token='*'``)."""
+        return self._post(
+            self._sync_url,
+            data={"sync_token": sync_token, "resource_types": _SYNC_RESOURCE_TYPES},
+        )
+
+    def deleted_events(self, since: str | None = None) -> list[dict]:
+        """Return all recorded ``deleted`` activities, optionally after ``since``.
+
+        Paginates the whole deleted-events feed (the endpoint's default page is
+        small) and filters by event date client-side, so callers get a
+        stable, complete view regardless of server-side paging.
+        """
+        events: list[dict] = []
+        offset = 0
+        while True:
+            batch = self._post(
+                self._activities_url,
+                data={
+                    "object_event_type": "deleted",
+                    "limit": _ACTIVITIES_PAGE,
+                    "offset": offset,
+                },
+            ).get("events", [])
+            events.extend(batch)
+            if len(batch) < _ACTIVITIES_PAGE:
+                break
+            offset += _ACTIVITIES_PAGE
+        if since is None:
+            return events
+        cutoff = _parse_ts(since)
+        return [e for e in events if _parse_ts(e.get("event_date")) >= cutoff]
+
+    def _post(self, url: str, data: dict) -> dict:
+        """POST with Authorization header, retrying transient failures."""
+        import httpx
+
+        for attempt in range(_MAX_RETRIES):
+            try:
+                resp = httpx.post(
+                    url,
+                    data=data,
+                    headers={"Authorization": f"Bearer {self._token}"},
+                    timeout=self._timeout,
+                )
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as exc:
+                if attempt == _MAX_RETRIES - 1 or not _is_transient(exc):
+                    raise
+                delay = _retry_after(getattr(exc, "response", None), attempt)
+                logger.warning(
+                    "Todoist: %s — retrying in %.1fs (%d/%d).",
+                    exc,
+                    delay,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                time.sleep(delay)
+
+
+def _is_transient(exc: Exception) -> bool:
+    """True for rate-limit / server / timeout / network errors worth retrying."""
+    import httpx
+
+    if isinstance(exc, httpx.TransportError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in (429, 500, 502, 503, 504)
+    return False
+
+
+def _retry_after(response: Any, attempt: int) -> float:
+    """Seconds to wait before retrying: the Retry-After header, else backoff."""
+    header = None
+    if response is not None:
+        header = response.headers.get("retry-after") or response.headers.get("Retry-After")
+    try:
+        return float(header)
+    except (TypeError, ValueError):
+        return float(2**attempt)
+
+
+# ---------------------------------------------------------------------------
+# Row builders (pure — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _project_row(project: dict) -> dict:
+    """Flatten a Sync-API project into a document row."""
+    pid = project.get("id") or ""
+    return {
+        "id": pid,
+        "kind": "project",
+        "url": f"https://app.todoist.com/app/project/{pid}",
+        "title": project.get("name") or "",
+        "content": project.get("description") or project.get("name") or "",
+        "_deleted": False,
+    }
+
+
+def _task_row(item: dict) -> dict:
+    """Flatten a Sync-API item (task) into a document row.
+
+    Volatile fields (due date, priority, labels, order) are deliberately left
+    out of ``content`` so a metadata-only edit does not churn the content-hash
+    data_id and trigger a pointless re-cognify.
+    """
+    tid = item.get("id") or ""
+    name = item.get("content") or ""
+    description = (item.get("description") or "").strip()
+    content = f"{name}\n\n{description}" if description else name
+    return {
+        "id": tid,
+        "kind": "task",
+        "url": f"https://app.todoist.com/app/task/{tid}",
+        "title": name,
+        "content": content,
+        "_deleted": False,
+    }
+
+
+def _note_row(note: dict) -> dict:
+    """Flatten a Sync-API note (comment) into a document row."""
+    nid = note.get("id") or ""
+    if note.get("item_id"):
+        parent = "task"
+    elif note.get("project_id"):
+        parent = "project"
+    else:
+        parent = "item"
+    return {
+        "id": nid,
+        "kind": "comment",
+        "url": "",
+        "title": f"Comment on {parent}",
+        "content": note.get("content") or "",
+        "_deleted": False,
+    }
+
+
+def _tombstone_row(object_id: str, object_type: str | None = None) -> dict:
+    """A hard-delete marker row for a deleted object."""
+    return {"id": object_id, "kind": _OBJECT_KINDS.get(object_type or "", ""), "_deleted": True}
+
+
+def _extract_deleted(events: list[dict]) -> Iterator[dict]:
+    """Map activities ``deleted`` events to hard-delete marker rows.
+
+    Only the three tracked object kinds are emitted; anything else (e.g.
+    reminder or note-attachment deletions) is ignored.
+    """
+    for event in events:
+        object_type = event.get("object_type")
+        if event.get("event_type") != "deleted" or object_type not in _OBJECT_KINDS:
+            continue
+        object_id = event.get("object_id")
+        if object_id:
+            yield _tombstone_row(object_id, object_type)
+
+
+# ---------------------------------------------------------------------------
+# Sync strategies (pure given client + state dict — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _sync(client: Any, state: dict) -> Iterator[dict]:
+    """Run one sync pass against ``client``, recording cursors in ``state``.
+
+    The first run (no ``sync_token`` in state) does a full backfill with
+    ``sync_token="*"``; later runs receive exactly what changed.  Deletes come
+    from both the delta payload's tombstones and the activities feed.  The
+    sync_token and the sync-start wall clock are recorded *before* rows are
+    consumed so no change falls into the gap between fetch and commit.
+    """
+    started_at = _utcnow_iso()
+    delta = client.sync(state.get("sync_token") or "*")
+
+    project_tasks: dict[str, list[str]] = state.setdefault("project_tasks", {})
+    feed_deletions = list(_extract_deleted(client.deleted_events(state.get("last_sync_started"))))
+
+    for project in delta.get("projects", []):
+        if project.get("is_deleted"):
+            # A cascade deletion: the project's tasks must go with it.
+            for task_id in project_tasks.pop(project["id"], []):
+                yield _tombstone_row(task_id, "item")
+            yield _tombstone_row(project["id"], "project")
+            continue
+        yield _project_row(project)
+
+    for item in delta.get("items", []):
+        if item.get("is_deleted"):
+            yield _tombstone_row(item["id"], "item")
+            continue
+        owner = project_tasks.setdefault(item.get("project_id") or "", [])
+        if item["id"] not in owner:
+            owner.append(item["id"])
+        yield _task_row(item)
+
+    for note in delta.get("notes", []):
+        if note.get("is_deleted"):
+            yield _tombstone_row(note["id"], "note")
+            continue
+        yield _note_row(note)
+
+    for tomb in feed_deletions:
+        # A deleted project cascades to its tasks (tracked in state) — Todoist
+        # does not reliably emit per-task events for the cascade.
+        if tomb["id"] in project_tasks:
+            for task_id in project_tasks.pop(tomb["id"], []):
+                yield _tombstone_row(task_id, "item")
+            yield _tombstone_row(tomb["id"], "project")
+        else:
+            yield tomb
+
+    state["sync_token"] = delta.get("sync_token")
+    state["last_sync_started"] = started_at
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    """Parse a Todoist/ISO-8601 timestamp ('...Z' or '...+00:00') to UTC."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/packages/connector/todoist/examples/example.py
+++ b/packages/connector/todoist/examples/example.py
@@ -1,0 +1,78 @@
+"""Todoist connector demo — turn your todo list into memory.
+
+Pull Todoist projects, tasks, and comments into cognee, incrementally and with
+forget-on-delete. ``todoist_source`` returns a ``dlt`` resource you hand
+straight to ``cognee.remember``. Rows are ingested as normal documents (so they
+go through the full cognify entity-extraction pipeline).
+
+The first run is a full backfill; every later run fetches only what changed
+since the last sync (Todoist's ``sync_token``) and propagates deletions, so
+tasks you complete-and-delete upstream disappear from memory on the next sync.
+
+────────────────────────────────────────────────────────────────────────────
+Privacy / opt-in
+────────────────────────────────────────────────────────────────────────────
+This reads the content of your tasks and comments. It is strictly opt-in —
+nothing is fetched until you run this script. Use a dedicated dataset so you
+can wipe it with a single ``cognee.forget``.
+
+────────────────────────────────────────────────────────────────────────────
+One-time setup
+────────────────────────────────────────────────────────────────────────────
+1. Install the extra:
+
+       pip install "cognee[todoist]"      # or: uv sync --extra todoist
+
+2. Create an API token at https://app.todoist.com/app/settings/integrations
+   (Settings → Integrations → Developer).
+3. Export the token and your LLM key, then run:
+
+       export TODOIST_API_TOKEN="..."
+       export LLM_API_KEY="sk-..."
+       uv run python packages/connector/todoist/examples/example.py
+
+Re-run after completing/deleting a task to see the incremental re-sync and
+forget-on-delete.
+"""
+
+import asyncio
+
+import cognee
+
+from cognee_community_connector_todoist import todoist_source
+
+
+async def main():
+    source = todoist_source()  # reads TODOIST_API_TOKEN
+
+    print("=== Initial sync (full backfill) ===")
+    result = await cognee.remember(
+        source,
+        dataset_name="todoist_demo",
+        primary_key="id",
+        # "merge" is required: it's what makes re-runs incremental and what
+        # makes deletions propagate via orphan cleanup. The default
+        # ("replace") would wipe the synced corpus on every run.
+        write_disposition="merge",
+        # The DLT ingestion default caps a table at 50 rows; real accounts
+        # exceed that, so lift the cap.
+        max_rows_per_table=0,
+    )
+    print(result)
+
+    answer = await cognee.recall("What do I need to do this week?")
+    print("Recall:", answer)
+
+    print("\n=== Incremental re-sync (only changes/deletions are processed) ===")
+    result = await cognee.remember(
+        todoist_source(),
+        dataset_name="todoist_demo",
+        primary_key="id",
+        write_disposition="merge",
+        max_rows_per_table=0,
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/connector/todoist/pyproject.toml
+++ b/packages/connector/todoist/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "cognee-community-connector-todoist"
+version = "0.1.0"
+description = "Todoist data-source connector for cognee — sync your projects, tasks, and comments into memory (incremental sync-token + forget-on-delete)"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    # Requires cognee "document-mode" (DOCUMENT_SOURCE_ATTR + resolve_dlt_sources
+    # routing rows through cognify instead of the dlt-schema path), first shipped
+    # in cognee 1.4.0.
+    "cognee==1.4.0",
+    "dlt[sqlalchemy]>=1.9.0,<2",
+    "httpx>=0.27.0,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_connector_todoist"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/connector/todoist/tests/test_todoist.py
+++ b/packages/connector/todoist/tests/test_todoist.py
@@ -1,0 +1,476 @@
+"""Unit tests for the Todoist dlt connector.
+
+Three layers, all runnable in CI without a live Todoist token:
+
+* DB-free tests for row building, the deletion-feed mapping, timestamp
+  parsing, and error classification.
+* Sync-strategy tests driving ``_sync`` with an in-memory fake client,
+  covering the incremental cursor contract and both deletion paths.
+* dlt-pipeline tests (fake client, temp sqlite destination) covering the
+  acceptance criteria: first-run backfill, incremental re-sync picks up only
+  changes, and deleted objects vanish from staging (forget-on-delete).
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import NAMESPACE_OID, uuid5
+
+import httpx
+import pytest
+
+import cognee_community_connector_todoist.todoist as todoist_mod
+from cognee_community_connector_todoist.todoist import (
+    TODOIST_SOURCE_NAME,
+    TodoistSyncClient,
+    _extract_deleted,
+    _is_transient,
+    _note_row,
+    _parse_ts,
+    _project_row,
+    _sync,
+    _task_row,
+    _tombstone_row,
+    todoist_source,
+)
+
+NOW = datetime(2026, 9, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _ts(hours_ago: float = 0.0) -> str:
+    dt = datetime(2026, 9, 1, 12, 0, 0, tzinfo=UTC) - timedelta(hours=hours_ago)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f000Z")
+
+
+def _ts_at(minutes: float) -> str:
+    """A timestamp NOW + ``minutes`` — for events between sync runs."""
+    dt = NOW + timedelta(minutes=minutes)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f000Z")
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch):
+    """Pin _utcnow_iso to a clock that advances 10 minutes per sync run.
+
+    Sync runs then happen at 12:10, 12:20, ... and events created with
+    ``_ts_at`` can be placed deterministically between them.
+    """
+    calls = {"n": 0}
+
+    def fake_now():
+        calls["n"] += 1
+        return (NOW + timedelta(minutes=10 * calls["n"])).isoformat()
+
+    monkeypatch.setattr(todoist_mod, "_utcnow_iso", fake_now)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+def _project(pid="P1", name="Inbox project", description=""):
+    return {"id": pid, "name": name, "description": description}
+
+
+def _task(tid="T1", content="Buy milk", description="", project_id="P1", is_deleted=0):
+    return {
+        "id": tid,
+        "project_id": project_id,
+        "content": content,
+        "description": description,
+        "priority": 3,
+        "due": {"date": "2026-09-10"},
+        "is_deleted": is_deleted,
+    }
+
+
+def _note(nid="N1", content="Called the store", item_id="T1", project_id=None, is_deleted=0):
+    return {
+        "id": nid,
+        "content": content,
+        "item_id": item_id,
+        "project_id": project_id,
+        "is_deleted": is_deleted,
+    }
+
+
+def _deleted_event(object_type, object_id, minutes=15.0):
+    """A deletion event by default placed after the first sync run (12:10)."""
+    return {
+        "object_type": object_type,
+        "event_type": "deleted",
+        "object_id": object_id,
+        "event_date": _ts_at(minutes),
+    }
+
+
+class FakeTodoist:
+    """Stand-in for TodoistSyncClient backed by in-memory fixtures."""
+
+    def __init__(self, projects=None, items=None, notes=None, deletions=None):
+        self.projects = projects or []
+        self.items = items or []
+        self.notes = notes or []
+        self.deletions = deletions or []
+        self.sync_calls: list[str] = []
+        self.since_seen: list[str | None] = []
+        self._token_seq = 0
+
+    def sync(self, sync_token: str) -> dict:
+        self.sync_calls.append(sync_token)
+        self._token_seq += 1
+        return {
+            "projects": self.projects,
+            "items": self.items,
+            "notes": self.notes,
+            "sync_token": f"tok-{self._token_seq}",
+        }
+
+    def deleted_events(self, since: str | None = None) -> list[dict]:
+        self.since_seen.append(since)
+        if since is None:
+            return list(self.deletions)
+        cutoff = _parse_ts(since)
+        return [e for e in self.deletions if _parse_ts(e.get("event_date")) >= cutoff]
+
+
+# ---------------------------------------------------------------------------
+# Row building (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_project_row_flattens_project():
+    row = _project_row(_project(pid="P1", name="Work", description="All work tasks"))
+    assert row == {
+        "id": "P1",
+        "kind": "project",
+        "url": "https://app.todoist.com/app/project/P1",
+        "title": "Work",
+        "content": "All work tasks",
+        "_deleted": False,
+    }
+
+
+def test_project_row_falls_back_to_name_when_no_description():
+    row = _project_row(_project(pid="P1", name="Work"))
+    assert row["content"] == "Work"
+
+
+def test_task_row_includes_description_and_skips_volatile_fields():
+    row = _task_row(_task(tid="T1", content="Buy milk", description="skim, 2 liters"))
+    assert row["id"] == "T1"
+    assert row["kind"] == "task"
+    assert row["url"] == "https://app.todoist.com/app/task/T1"
+    assert row["title"] == "Buy milk"
+    assert "Buy milk" in row["content"]
+    assert "skim, 2 liters" in row["content"]
+    # Volatile metadata must not churn the content-hash data_id.
+    assert "priority" not in row["content"]
+    assert "due" not in row["content"]
+
+
+def test_note_row_infers_parent_kind():
+    assert _note_row(_note(item_id="T1"))["title"] == "Comment on task"
+    assert _note_row(_note(item_id=None, project_id="P1"))["title"] == "Comment on project"
+    assert _note_row(_note(item_id=None, project_id=None))["title"] == "Comment on item"
+    assert _note_row(_note(content="hi"))["content"] == "hi"
+
+
+def test_tombstone_row_maps_object_kinds():
+    assert _tombstone_row("T1", "item")["kind"] == "task"
+    assert _tombstone_row("N1", "note")["kind"] == "comment"
+    assert _tombstone_row("P1", "project")["kind"] == "project"
+    assert _tombstone_row("X1")["kind"] == ""
+    tomb = _tombstone_row("T1", "item")
+    assert tomb["_deleted"] is True
+
+
+def test_extract_deleted_keeps_only_tracked_kinds_and_deleted_events():
+    events = [
+        _deleted_event("item", "T1"),
+        _deleted_event("note", "N1"),
+        _deleted_event("project", "P1"),
+        # updated/completed events are not deletions.
+        {"object_type": "item", "event_type": "updated", "object_id": "T2"},
+        {"object_type": "reminder", "event_type": "deleted", "object_id": "R1"},
+    ]
+    rows = list(_extract_deleted(events))
+    assert sorted(r["id"] for r in rows) == ["N1", "P1", "T1"]
+
+
+# ---------------------------------------------------------------------------
+# Timestamp / error classification (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ts_handles_both_suffixes():
+    assert _parse_ts("2026-09-01T12:00:00.000000Z") == _parse_ts("2026-09-01T12:00:00.000000+00:00")
+    assert _parse_ts("garbage") is None
+    assert _parse_ts(None) is None
+
+
+def test_is_transient_classification():
+    def status_error(code):
+        req = httpx.Request("POST", "https://api.todoist.com/sync/v9/sync")
+        resp = httpx.Response(code, request=req)
+        return httpx.HTTPStatusError("err", request=req, response=resp)
+
+    assert _is_transient(status_error(429)) is True
+    assert _is_transient(status_error(503)) is True
+    assert _is_transient(status_error(401)) is False
+    assert _is_transient(httpx.ConnectTimeout("t")) is True
+    assert _is_transient(ValueError()) is False
+
+
+# ---------------------------------------------------------------------------
+# Sync strategies (pure, fake client)
+# ---------------------------------------------------------------------------
+
+
+def test_first_sync_uses_full_snapshot_token():
+    client = FakeTodoist(items=[_task()])
+    state: dict = {}
+    rows = list(_sync(client, state))
+    assert client.sync_calls == ["*"]
+    assert [r["id"] for r in rows if r["kind"] == "task"] == ["T1"]
+    assert state["sync_token"] == "tok-1"
+    assert state["last_sync_started"]
+
+
+def test_incremental_sync_reuses_recorded_sync_token():
+    client = FakeTodoist(items=[_task()])
+    state: dict = {}
+    list(_sync(client, state))
+
+    # Second run: the connector must ask for the delta, not a new backfill.
+    delta = list(_sync(client, state))
+    assert client.sync_calls == ["*", "tok-1"]
+    assert delta  # unchanged fixtures still re-yield from the delta payload
+    assert state["sync_token"] == "tok-2"
+
+
+def test_delta_tombstone_marks_rows_deleted():
+    client = FakeTodoist(items=[_task(tid="T1", is_deleted=1)])
+    rows = list(_sync(client, {}))
+    tomb = next(r for r in rows if r["id"] == "T1")
+    assert tomb["_deleted"] is True
+
+
+def test_activities_feed_provides_deletions_with_since_filter(frozen_clock):
+    # A deletion at 12:15 (between the two runs) and one at 11:00 (before both).
+    deletions = [
+        _deleted_event("item", "T1", minutes=15.0),
+        _deleted_event("item", "T9", minutes=-60.0),
+    ]
+    client = FakeTodoist(items=[_task(tid="T1")], deletions=deletions)
+    state: dict = {}
+    list(_sync(client, state))
+    # First run has no baseline: the whole feed is consulted.
+    assert client.since_seen[0] is None
+
+    # Second run: only events at/after the first run's sync start are applied.
+    rows = list(_sync(client, state))
+    assert client.since_seen[1] is not None
+    tomb_ids = [r["id"] for r in rows if r.get("_deleted")]
+    assert "T1" in tomb_ids  # deleted between the runs
+    assert "T9" not in tomb_ids  # predates the baseline, already reconciled
+
+
+def test_deleted_project_cascades_to_its_tasks(frozen_clock):
+    client = FakeTodoist(items=[_task(tid="T1", project_id="P1")])
+    state: dict = {}
+    list(_sync(client, state))  # full backfill records P1 -> [T1]
+
+    # Second run: the project was deleted upstream between the two runs.
+    client2 = FakeTodoist(deletions=[_deleted_event("project", "P1", minutes=15.0)])
+    rows = list(_sync(client2, state))
+
+    tomb_ids = [r["id"] for r in rows if r.get("_deleted")]
+    assert "P1" in tomb_ids
+    assert "T1" in tomb_ids  # cascaded
+    assert "P1" not in state["project_tasks"]
+
+
+def test_deleted_event_for_unknown_object_is_emitted_as_tombstone():
+    client = FakeTodoist(deletions=[_deleted_event("item", "T9")])
+    rows = list(_sync(client, {}))
+    assert any(r["id"] == "T9" and r["_deleted"] for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Source wiring (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_todoist_source_declares_document_marker():
+    from cognee.tasks.ingestion.dlt_utils import document_source_tag
+
+    source = todoist_source(token="test-token")
+    assert TODOIST_SOURCE_NAME == "todoist"
+    assert document_source_tag(source) == "todoist"
+
+
+def test_todoist_source_requires_token():
+    with pytest.raises(ValueError):
+        todoist_source(token=None, client=None)
+
+
+def test_document_data_item_tags_source():
+    # The row -> document-DataItem mapping is owned by the ingestion layer; a
+    # Todoist row (with its extra kind/_deleted columns) must map cleanly.
+    from cognee.tasks.ingestion.resolve_dlt_sources import _build_document_data_item
+
+    row = SimpleNamespace(
+        row_data={
+            "id": "T1",
+            "kind": "task",
+            "url": "https://app.todoist.com/app/task/T1",
+            "title": "Buy milk",
+            "content": "Buy milk\n\nskim",
+            "_deleted": False,
+        },
+        content_hash="abc123",
+    )
+    data_id = uuid5(NAMESPACE_OID, "T1")
+
+    item = _build_document_data_item(row, data_id, "todoist")
+
+    assert item.external_metadata["source"] == "todoist"
+    assert item.external_metadata["external_id"] == "T1"
+    assert item.data_id == data_id
+    assert item.data.startswith("# Buy milk")
+
+
+# ---------------------------------------------------------------------------
+# dlt pipeline: incremental merge + forget-on-delete (needs dlt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dlt_mod():
+    return pytest.importorskip("dlt")
+
+
+def _make_pipeline(dlt, tmp_path, name):
+    db_path = (tmp_path / f"{name}.db").as_posix()
+    return dlt.pipeline(
+        pipeline_name=name,
+        destination=dlt.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="todoist_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+
+
+def _read_rows(pipeline):
+    """Return {id: {title, kind, content}} for the todoist staging table."""
+    with (
+        pipeline.sql_client() as client,
+        client.execute_query("SELECT id, kind, title, content FROM todoist") as cursor,
+    ):
+        rows = cursor.fetchall()
+    return {row[0]: {"kind": row[1], "title": row[2], "content": row[3]} for row in rows}
+
+
+def test_pipeline_backfill_and_incremental_resync(dlt_mod, tmp_path):
+    client = FakeTodoist(
+        projects=[_project(pid="P1", name="Work")],
+        items=[_task(tid="T1", content="Buy milk")],
+        notes=[_note(nid="N1", content="Called the store")],
+    )
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "todoist_resync")
+    pipeline.run(todoist_source(client=client))
+
+    rows = _read_rows(pipeline)
+    assert set(rows) == {"P1", "T1", "N1"}
+    assert rows["T1"]["title"] == "Buy milk"
+
+    # Incremental run: content changed + one new task, same pipeline (state
+    # persists). Only the delta is fetched; merge upserts the changed row.
+    client.items = [
+        _task(tid="T1", content="Buy oat milk"),
+        _task(tid="T2", content="Walk the dog"),
+    ]
+    pipeline.run(todoist_source(client=client))
+
+    rows = _read_rows(pipeline)
+    assert set(rows) == {"P1", "T1", "T2", "N1"}
+    assert "oat milk" in rows["T1"]["content"]
+    assert "Buy milk" not in rows["T1"]["content"]
+    # Second sync must have used the recorded sync_token, not a fresh backfill.
+    assert client.sync_calls == ["*", "tok-1"]
+
+
+def test_pipeline_delta_tombstone_removes_row(dlt_mod, tmp_path):
+    client = FakeTodoist(items=[_task(tid="T1"), _task(tid="T2")])
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "todoist_tomb")
+    pipeline.run(todoist_source(client=client))
+    assert set(_read_rows(pipeline)) == {"T1", "T2"}
+
+    # T1 deleted upstream: the delta returns it as an is_deleted tombstone.
+    client.items = [_task(tid="T1", is_deleted=1), _task(tid="T2")]
+    pipeline.run(todoist_source(client=client))
+
+    rows = _read_rows(pipeline)
+    assert "T1" not in rows
+    assert "T2" in rows
+
+
+def test_pipeline_activities_deletion_removes_row(dlt_mod, tmp_path, frozen_clock):
+    client = FakeTodoist(items=[_task(tid="T1"), _task(tid="T2")])
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "todoist_feed")
+    pipeline.run(todoist_source(client=client))
+    assert set(_read_rows(pipeline)) == {"T1", "T2"}
+
+    # T1 deleted upstream between the runs: dropped from the delta entirely;
+    # only the activities feed knows about it.
+    client.items = [_task(tid="T2")]
+    client.deletions = [_deleted_event("item", "T1", minutes=15.0)]
+    pipeline.run(todoist_source(client=client))
+
+    rows = _read_rows(pipeline)
+    assert "T1" not in rows
+    assert "T2" in rows
+
+
+def test_pipeline_deleted_project_cascades(dlt_mod, tmp_path, frozen_clock):
+    client = FakeTodoist(
+        projects=[_project(pid="P1")],
+        items=[_task(tid="T1", project_id="P1"), _task(tid="T2", project_id="P2")],
+    )
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "todoist_cascade")
+    pipeline.run(todoist_source(client=client))
+    assert set(_read_rows(pipeline)) == {"P1", "T1", "T2"}
+
+    # The project (and everything in it) is gone upstream between the runs.
+    client.projects = []
+    client.items = [_task(tid="T2", project_id="P2")]
+    client.deletions = [_deleted_event("project", "P1", minutes=15.0)]
+    pipeline.run(todoist_source(client=client))
+
+    rows = _read_rows(pipeline)
+    assert "P1" not in rows
+    assert "T1" not in rows  # cascaded with its project
+    assert "T2" in rows
+
+
+def test_client_deleted_events_filters_since():
+    client = TodoistSyncClient("token")
+    # Inject a fake _post instead of hitting the network: two pages, then done.
+    pages = [
+        {"events": [_deleted_event("item", "T1", minutes=-540.0)] * 100},
+        {"events": [_deleted_event("item", "T2", minutes=-30.0)]},
+    ]
+    calls = []
+
+    def fake_post(url, data):
+        calls.append(data)
+        return pages[data["offset"] // 100]
+
+    client._post = fake_post
+
+    events = client.deleted_events(since=_ts_at(-60.0))
+    assert [e["object_id"] for e in events] == ["T2"]
+    # Pagination walked exactly two pages with the documented params.
+    assert calls[0]["object_event_type"] == "deleted"
+    assert calls[0]["limit"] == 100


### PR DESCRIPTION
## Summary

Implements topoteretes/cognee#4815 — a `todoist` connector under `packages/connector/todoist/`, following the shape of the existing connectors and the incremental model already established by gmail/google-drive.

- **Auth:** Todoist API token (`token=` or `TODOIST_API_TOKEN`); read-only usage, no OAuth dance
- **Ingest:** projects, tasks, and comments as documents — the resource declares `cognee_document_source = "todoist"`, so rows flow through the normal cognify entity-extraction pipeline (same treatment as notion/google-drive)
- **Incremental sync:** Sync API `sync_token` cursor persisted in dlt resource state; first run is a full backfill (`sync_token="*"`), later runs fetch exactly what changed
- **Forget-on-delete:** deletions surface via delta tombstones (`is_deleted=1`) *and* the activities deletion feed polled since the last sync start; a deleted project cascades to its tracked tasks (kept in resource state). Rows carry the same `_deleted` hard-delete column as gmail/google-drive, so cognee's existing `orphan_cleanup` purges them from graph + vector + relational stores
- **Robustness:** retries with backoff for 429/5xx/timeouts/network errors; volatile metadata (due date, priority, labels, ordering) is excluded from document text so content-hash `data_id`s stay stable

## Package layout (per the issue)

```
packages/connector/todoist/
├── README.md
├── cognee_community_connector_todoist/
│   ├── __init__.py
│   └── todoist.py
├── examples/example.py
├── tests/test_todoist.py
└── pyproject.toml
```

## Testing

`pytest packages/connector/todoist/tests -q` → **22 passed** (offline; Todoist API faked, dlt runs against a temp SQLite destination):

- row builders (project/task/comment, volatile-field exclusion, parent-kind inference)
- deletion-feed mapping (`_extract_deleted`), timestamp parsing, retry classification
- sync strategies: full backfill vs recorded `sync_token`, delta tombstones, activities feed with `since` filter, project-deletion cascade
- dlt pipeline against sqlite: backfill → incremental re-sync upserts only the delta, delta-tombstone removal, activities-feed removal, project cascade removal
- document-path wiring: `document_source_tag(source) == "todoist"`, `_build_document_data_item` mapping

`ruff check` / `ruff format --check` clean.

## Acceptance criteria (from the issue)

- [x] A user connects via API token and selects what to ingest
- [x] Selected content is ingested and searchable in cognee (document path → cognify)
- [x] Incremental sync picks up only what changed since the last run (`sync_token`)
- [x] Deleting the source upstream removes it from the graph on the next sync (tombstones + activities feed + cascade)
- [x] README with setup steps and a runnable example under `examples/`
- [x] Tests covering the ingest path and the incremental cursor

Closes topoteretes/cognee#4815