### PR TITLE
feat(connector): add Raindrop.io data-source connector (cognee#4813)

### DIFF
--- a/packages/connector/raindrop/README.md
+++ b/packages/connector/raindrop/README.md
@@ -1,0 +1,120 @@
+# cognee-community-connector-raindrop
+
+[Raindrop.io](https://raindrop.io) data-source connector for
+[cognee](https://github.com/topoteretes/cognee) — sync your collections,
+bookmarks, and highlights into memory, incrementally and with
+forget-on-delete. "Ask my bookmarks."
+
+Part of the cognee hackathon connector push (topoteretes/cognee#4813).
+
+## Features
+
+- **Incremental sync** — the first run is a full backfill; every later run
+  lists raindrops newest-change-first (`sort=-lastUpdate`) and re-emits only
+  those updated after the recorded cursor, with an early stop once a whole
+  page is older.
+- **Forget-on-delete** — Raindrop has no deletion feed, so each run does a
+  full id sweep and diffs it against the previous run (kept in dlt resource
+  state). Vanished bookmarks/collections — and the annotations of vanished
+  bookmarks, plus annotations removed from a re-fetched one — are hard-deleted
+  and then purged by cognee's orphan cleanup.
+- **Document ingestion** — each row becomes a normal text document that flows
+  through cognee's cognify entity-extraction pipeline (same treatment as the
+  Notion / Google Drive connectors), so bookmarks are searchable and linkable,
+  not just key-value rows.
+- **Opt-in page fetching** — fetching the linked page's text multiplies ingest
+  cost, so it is off by default (`fetch_page_content=True` to enable) and
+  degrades gracefully to the API-provided excerpt when a page can't be
+  fetched.
+- **Stable content hashes** — volatile bookkeeping fields (collection refs,
+  covers, domains) are excluded from document text, so they don't churn the
+  content-hash `data_id`.
+- **Retries with backoff** — rate-limit (429), server (5xx), timeout, and
+  network errors are retried; auth failures fail fast.
+
+## Installation
+
+```bash
+pip install "cognee[raindrop]"
+# or, from this repository:
+uv pip install ./packages/connector/raindrop
+```
+
+## Setup
+
+1. Create a test token at <https://app.raindrop.io/#/settings/integrations>
+   (Settings → Integrations → For Developer), or use an OAuth app token.
+2. Export it:
+
+   ```bash
+   export RAINDROP_API_TOKEN="..."
+   ```
+
+## Usage
+
+```python
+import cognee
+from cognee_community_connector_raindrop import raindrop_source
+
+await cognee.remember(
+    raindrop_source(),
+    dataset_name="my_bookmarks",
+    primary_key="id",
+    write_disposition="merge",  # REQUIRED — see below
+    max_rows_per_table=0,  # REQUIRED for a real account
+)
+
+answer = await cognee.recall("What do I have about machine learning?")
+```
+
+> **`write_disposition="merge"` is mandatory.** The add pipeline defaults to
+> `"replace"` (drop + reload the table each run); on the second, incremental
+> sync that would wipe everything but the small delta.
+
+> **`max_rows_per_table=0`** lifts cognee's 50-row read cap so orphan cleanup
+> compares against the *whole* synced corpus.
+
+With page content (opt-in — one HTTP request per changed bookmark, re-fetched
+on every change):
+
+```python
+raindrop_source(fetch_page_content=True)
+```
+
+A runnable version lives in [`examples/example.py`](examples/example.py).
+
+## What gets ingested
+
+| Entity      | Kind         | Document                                              |
+| ----------- | ------------ | ----------------------------------------------------- |
+| Collection  | `collection` | title + description                                   |
+| Bookmark    | `bookmark`   | title + Raindrop excerpt + tags (+ opt-in page text)   |
+| Highlight   | `annotation` | highlight text + note (row ids prefixed `hl-`)         |
+
+## Deleting data
+
+- Delete a bookmark/collection in Raindrop.io → it is removed from cognee's
+  graph, vector, and relational stores on the next sync (dlt hard-delete +
+  cognee's orphan cleanup).
+- Delete the whole dataset locally with `cognee.forget(...)` /
+  `cognee.prune()`.
+
+## Tests
+
+```bash
+uv run pytest packages/connector/raindrop/tests -q
+```
+
+All tests run offline: Raindrop API access is faked, and the dlt pipeline runs
+against a temporary SQLite destination.
+
+## Notes & limitations
+
+- Page-text extraction is deliberately dependency-free and heuristic (title,
+  meta description, `<p>` text); heavily client-rendered pages may yield
+  little beyond their meta description.
+- With `fetch_page_content=True`, page text is re-fetched whenever the
+  bookmark itself changes, which can churn the content hash — that is the
+  documented cost of opting in.
+- The connector only issues reads against the Raindrop API and never mutates
+  your data.

--- a/packages/connector/raindrop/cognee_community_connector_raindrop/__init__.py
+++ b/packages/connector/raindrop/cognee_community_connector_raindrop/__init__.py
@@ -1,0 +1,3 @@
+from cognee_community_connector_raindrop.raindrop import raindrop_source
+
+__all__ = ["raindrop_source"]

--- a/packages/connector/raindrop/cognee_community_connector_raindrop/raindrop.py
+++ b/packages/connector/raindrop/cognee_community_connector_raindrop/raindrop.py
@@ -1,0 +1,500 @@
+"""DLT source for Raindrop.io bookmarks (lastUpdate cursor + forget-on-delete).
+
+Pulls Raindrop.io collections, bookmarks (raindrops), and their annotations
+(highlights) into cognee incrementally — "ask my bookmarks".  The source is a
+single dlt resource meant to be handed directly to :func:`cognee.remember`::
+
+    import cognee
+    from cognee_community_connector_raindrop import raindrop_source
+
+    await cognee.remember(
+        raindrop_source(token="..."),
+        dataset_name="my_bookmarks",
+        primary_key="id",
+        write_disposition="merge",   # REQUIRED (see .. important:: below)
+        max_rows_per_table=0,        # REQUIRED for a real account (see .. note:: below)
+    )
+
+.. important::
+   ``write_disposition="merge"`` is **mandatory**.  The add pipeline defaults
+   to ``"replace"`` (drop + reload the table each run); on the second,
+   incremental sync that would wipe everything but the small delta.  Always
+   pass ``"merge"``.
+
+Design
+------
+* **Auth** — Raindrop.io test token (Settings → Integrations → For Developer)
+  or an OAuth app token.  Pass ``token=`` or set ``RAINDROP_API_TOKEN``.  The
+  connector only issues reads.
+* **Primary key** — the Raindrop ``_id`` (as a string).  Combined with
+  ``write_disposition="merge"`` this gives idempotent upserts across all three
+  entity kinds (collections / bookmarks / annotations) in one staging table.
+  Annotation row ids are prefixed ``hl-`` so they can never collide with a
+  bookmark id.
+* **Incremental cursor** — the ``lastUpdate`` timestamp.  Raindrops are listed
+  newest-change-first (``sort=-lastUpdate``) and only rows updated after the
+  cursor recorded in dlt's resource state are re-emitted.  The listing is
+  still paged in full every run: the deletion sweep needs to see every live
+  id, so unchanged rows are skipped client-side rather than skipped remotely.
+* **Forget-on-delete** — Raindrop has no deletion feed, so — like the
+  Confluence connector — each run does a full id sweep of the account and
+  compares it against the ids seen on the previous run (kept in resource
+  state).  Vanished bookmarks/collections — and the annotations of vanished
+  bookmarks, plus annotations removed from a re-fetched one — are emitted with
+  the ``_deleted`` hard-delete marker; dlt removes those rows on ``merge`` and
+  cognee's existing ``orphan_cleanup`` purges them from the graph + vector +
+  relational stores.  No parallel cleanup path.
+* **Opt-in page content** — fetching the linked page's HTML and extracting its
+  text multiplies ingest cost (one HTTP request per bookmark, every time the
+  bookmark changes), so it is off by default and enabled with
+  ``fetch_page_content=True``.  Without it, the bookmark document is title +
+  Raindrop's own ``excerpt`` + tags.  Failures to fetch degrade gracefully to
+  the excerpt-only document.
+* **Document mode** — the resource declares ``cognee_document_source =
+  "raindrop"`` (the same marker notion/google-drive use), so each row flows
+  through the standard cognify entity-extraction pipeline as a normal text
+  document instead of the deterministic dlt-row schema-context path.
+
+.. note::
+   cognee's ``ingest_dlt_source`` reads at most ``max_rows_per_table`` rows
+   from the dlt destination (default 50).  For a real account pass
+   ``max_rows_per_table=0`` (unlimited) so orphan-cleanup compares against the
+   *whole* synced corpus rather than a truncated window.
+
+Privacy
+-------
+This reads the content of your bookmarks (and, if opted in, the linked pages).
+It is **opt-in**: nothing is fetched until you construct a source and call
+``remember``.  Use a dedicated dataset so you can ``cognee.forget`` the whole
+thing in one call.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlparse
+
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.ingestion.dlt_utils import DOCUMENT_SOURCE_ATTR
+
+logger = get_logger("raindrop_connector")
+
+# dlt resource / staging-table name for Raindrop objects (all three kinds live
+# in one table, discriminated by the ``kind`` column).
+RAINDROP_SOURCE_NAME = "raindrop"
+RAINDROP_TABLE_NAME = "raindrop"
+
+# Retry budget for rate-limited / transient Raindrop API responses.
+_MAX_RETRIES = 5
+
+# The all-raindrops collection id (includes unsorted). Raindrop caps pages at
+# 50 items, so paging is driven by the response ``count``.
+_ALL_COLLECTION_ID = "0"
+_PAGE_SIZE = 50
+_MAX_PAGES = 2000  # hard stop: 100k bookmarks
+_MAX_PAGE_TEXT = 5000
+
+_EXTRA_HINT = (
+    'The Raindrop connector requires the "raindrop" extra: pip install "cognee[raindrop]" '
+    "(provides dlt and httpx)."
+)
+
+
+def raindrop_source(
+    token: str | None = None,
+    fetch_page_content: bool = False,
+    client: Any = None,
+):
+    """Create a dlt resource that yields Raindrop collections/bookmarks/annotations.
+
+    Args:
+        token: Raindrop.io API token. Falls back to ``RAINDROP_API_TOKEN``.
+        fetch_page_content: Opt-in. When True, the linked page's HTML is
+            fetched and its text appended to the bookmark document. This
+            multiplies ingest cost (one HTTP request per changed bookmark) and
+            re-fetches on every bookmark change — see the module docstring.
+        client: Pre-built client (mainly a test-injection point); when omitted
+            a :class:`RaindropClient` is built from the token above.
+
+    Returns:
+        A dlt resource suitable for ``cognee.remember(...)`` with
+        ``write_disposition="merge"``.
+    """
+    try:
+        import dlt
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    if client is None:
+        resolved_token = token or os.environ.get("RAINDROP_API_TOKEN")
+        if not resolved_token:
+            raise ValueError(
+                "Raindrop.io API token required: pass token= or set RAINDROP_API_TOKEN."
+            )
+        client = RaindropClient(resolved_token)
+
+    @dlt.resource(
+        name=RAINDROP_TABLE_NAME,
+        primary_key="id",
+        write_disposition="merge",
+        # _deleted is a boolean hard-delete marker (matching gmail.py /
+        # google_drive.py): rows where it is True are removed from the dlt
+        # destination on merge, which propagates the deletion through
+        # cognee's orphan_cleanup.
+        columns={"_deleted": {"data_type": "bool", "hard_delete": True}},
+    )
+    def raindrop():
+        resource_state = dlt.current.resource_state()
+        yield from _sync(client, resource_state, fetch_page_content=fetch_page_content)
+
+    # Opt into the document ingestion path (row -> text document -> cognify).
+    # resolve_dlt_sources reads this marker; it never imports this connector.
+    setattr(raindrop, DOCUMENT_SOURCE_ATTR, RAINDROP_SOURCE_NAME)
+    return raindrop
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+class RaindropClient:
+    """Minimal Raindrop.io REST v1 client over httpx, with retry/backoff.
+
+    Exposes exactly the operations the connector needs: ``collections``,
+    ``raindrops``, and the opt-in ``fetch_page``.  Any object with the same
+    methods can be injected in its place (tests).
+    """
+
+    def __init__(
+        self,
+        token: str,
+        base_url: str = "https://api.raindrop.io/rest/v1",
+        timeout: float = 30.0,
+    ):
+        self._token = token
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    def collections(self) -> list[dict]:
+        """All user collections: roots and nested children, deduplicated by id."""
+        items: dict[int, dict] = {}
+        for path in ("/collections", "/collections/childrens"):
+            for page in range(0, _MAX_PAGES):
+                payload = self._get(path, params={"per_page": _PAGE_SIZE, "page": page})
+                batch = payload.get("items", [])
+                items.update({item["_id"]: item for item in batch if "_id" in item})
+                if len(batch) < _PAGE_SIZE:
+                    break
+        return list(items.values())
+
+    def raindrops(self, collection_id: str = _ALL_COLLECTION_ID, page: int = 0) -> dict:
+        """One page of raindrops (newest-change-first), 50 per page."""
+        return self._get(
+            f"/raindrops/{collection_id}",
+            params={"per_page": _PAGE_SIZE, "page": page, "sort": "-lastUpdate"},
+        )
+
+    def fetch_page(self, url: str) -> str:
+        """Best-effort text extraction from the linked page (opt-in only).
+
+        No HTML parser dependency: title, meta description, and paragraph text
+        are pulled with regexes and capped.  Any failure returns "" — the
+        bookmark document then falls back to the API-provided excerpt.
+        """
+        try:
+            import httpx
+
+            resp = httpx.get(url, timeout=self._timeout, follow_redirects=True)
+            resp.raise_for_status()
+            return _extract_page_text(resp.text)
+        except Exception as exc:
+            logger.warning("Raindrop: page fetch failed for %s: %s", url, exc)
+            return ""
+
+    def _get(self, path: str, params: dict | None = None) -> dict:
+        import httpx
+
+        for attempt in range(_MAX_RETRIES):
+            try:
+                resp = httpx.get(
+                    f"{self._base_url}{path}",
+                    params=params,
+                    headers={"Authorization": f"Bearer {self._token}"},
+                    timeout=self._timeout,
+                )
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as exc:
+                if attempt == _MAX_RETRIES - 1 or not _is_transient(exc):
+                    raise
+                delay = _retry_after(getattr(exc, "response", None), attempt)
+                logger.warning(
+                    "Raindrop: %s — retrying in %.1fs (%d/%d).",
+                    exc,
+                    delay,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                time.sleep(delay)
+
+
+def _is_transient(exc: Exception) -> bool:
+    """True for rate-limit / server / timeout / network errors worth retrying."""
+    import httpx
+
+    if isinstance(exc, httpx.TransportError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in (429, 500, 502, 503, 504)
+    return False
+
+
+def _retry_after(response: Any, attempt: int) -> float:
+    """Seconds to wait before retrying: the Retry-After header, else backoff."""
+    header = None
+    if response is not None:
+        header = response.headers.get("retry-after") or response.headers.get("Retry-After")
+    try:
+        return float(header)
+    except (TypeError, ValueError):
+        return float(2**attempt)
+
+
+# ---------------------------------------------------------------------------
+# Page text extraction (regex, no parser dependency)
+# ---------------------------------------------------------------------------
+
+_SCRIPT_STYLE = re.compile(r"<(script|style)[^>]*>.*?</\1>", re.I | re.S)
+_META_DESC = re.compile(
+    r'<meta[^>]+name=["\'](?:description|og:description)["\'][^>]+content=["\']([^"\']*)["\']',
+    re.I,
+)
+_PAGE_TITLE = re.compile(r"<title[^>]*>(.*?)</title>", re.I | re.S)
+_TAG = re.compile(r"<[^>]+>")
+
+
+def _extract_page_text(html: str) -> str:
+    """Cheap HTML → text extraction: title, meta description, paragraphs."""
+    if not html:
+        return ""
+    body = _SCRIPT_STYLE.sub(" ", html)
+    parts: list[str] = []
+    title = _PAGE_TITLE.search(body)
+    if title and title.group(1).strip():
+        parts.append(title.group(1).strip())
+    desc = _META_DESC.search(html)  # meta tags live in <head>, above scripts
+    if desc and desc.group(1).strip():
+        parts.append(desc.group(1).strip())
+    paragraphs = [_TAG.sub(" ", m).strip() for m in body.split("<p")[1:]] if "<p" in body else []
+    text = "\n".join(p for p in parts + paragraphs if p)
+    return text[:_MAX_PAGE_TEXT]
+
+
+# ---------------------------------------------------------------------------
+# Row builders (pure — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _collection_row(collection: dict) -> dict:
+    """Flatten a Raindrop collection into a document row."""
+    cid = str(collection.get("_id") or "")
+    return {
+        "id": cid,
+        "kind": "collection",
+        "url": "",
+        "title": collection.get("title") or "",
+        "content": collection.get("description") or collection.get("title") or "",
+        "_deleted": False,
+    }
+
+
+def _bookmark_row(raindrop: dict, page_text: str | None = None) -> dict:
+    """Flatten a Raindrop bookmark into a document row.
+
+    The document is title + API-provided excerpt + tags (+ the opt-in page
+    text).  Volatile bookkeeping fields (collection refs, cover images,
+    domains) are excluded so they don't churn the content-hash data_id.
+    """
+    rid = str(raindrop.get("_id") or "")
+    title = raindrop.get("title") or raindrop.get("link") or ""
+    tags = [t for t in (raindrop.get("tags") or []) if t]
+    content = title
+    if raindrop.get("excerpt"):
+        content += f"\n\n{raindrop['excerpt'].strip()}"
+    if tags:
+        content += "\n\nTags: " + ", ".join(sorted(tags))
+    if page_text:
+        content += f"\n\n{page_text.strip()}"
+    return {
+        "id": rid,
+        "kind": "bookmark",
+        "url": raindrop.get("link") or "",
+        "title": title,
+        "content": content,
+        "_deleted": False,
+    }
+
+
+def _annotation_rows(raindrop: dict) -> list[dict]:
+    """Flatten a Raindrop's highlights (annotations) into document rows.
+
+    Row ids are prefixed ``hl-`` so they can never collide with a bookmark id.
+    """
+    link = raindrop.get("link") or ""
+    title = raindrop.get("title") or link
+    rows = []
+    for highlight in raindrop.get("highlights") or []:
+        hid = highlight.get("_id")
+        if hid is None:
+            continue
+        note = (highlight.get("note") or "").strip()
+        text = (highlight.get("text") or "").strip()
+        content = text if text else note
+        if note and note != text:
+            content = f"{text}\n\nNote: {note}" if text else note
+        rows.append(
+            {
+                "id": f"hl-{hid}",
+                "kind": "annotation",
+                "url": link,
+                "title": f"Highlight in {title}"[:200],
+                "content": content,
+                "_deleted": False,
+            }
+        )
+    return rows
+
+
+def _tombstone_row(row_id: str, kind: str = "") -> dict:
+    """A hard-delete marker row for a vanished object."""
+    return {"id": row_id, "kind": kind, "_deleted": True}
+
+
+# ---------------------------------------------------------------------------
+# Sync strategies (pure given client + state dict — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _sync(client: Any, state: dict, fetch_page_content: bool = False) -> Iterator[dict]:
+    """Run one sync pass against ``client``, recording cursors in ``state``.
+
+    Only raindrops updated after the recorded ``last_update`` cursor are
+    re-emitted (the listing is sorted newest-change-first, so paging stops at
+    the first page that is entirely older).  The full id set seen each run is
+    diffed against the previous run's to emit hard-delete markers for vanished
+    objects — Raindrop has no deletion feed.
+    """
+    # --- Collections: sweep + upsert ---------------------------------------
+    collections = client.collections()
+    prev_collection_ids: set[str] = set(state.get("collection_ids") or [])
+    curr_collection_ids: set[str] = set()
+    for collection in collections:
+        cid = str(collection.get("_id"))
+        curr_collection_ids.add(cid)
+        if cid in prev_collection_ids and not _is_newer(collection, state):
+            continue
+        yield _collection_row(collection)
+    for cid in sorted(prev_collection_ids - curr_collection_ids):
+        yield _tombstone_row(cid, "collection")
+    state["collection_ids"] = sorted(curr_collection_ids)
+
+    # --- Bookmarks + annotations: cursor'd listing + id sweep ---------------
+    cursor = state.get("last_update")
+    prev_bookmark_ids: set[str] = set(state.get("bookmark_ids") or [])
+    prev_highlight_ids: dict[str, list[str]] = dict(state.get("highlight_ids") or {})
+
+    curr_bookmark_ids: set[str] = set()
+    curr_highlight_ids: dict[str, list[str]] = {}
+    max_update = _parse_ts(cursor) if cursor else None
+
+    page = 0
+    while page < _MAX_PAGES:
+        payload = client.raindrops(_ALL_COLLECTION_ID, page=page)
+        items = payload.get("items", [])
+        if not items:
+            break
+
+        for raindrop in items:
+            rid = str(raindrop["_id"])
+            # Alive either way — record it for the deletion sweep *before* the
+            # cursor filter, or unchanged objects would be mistaken for
+            # vanished ones.
+            curr_bookmark_ids.add(rid)
+            updated = _parse_ts(raindrop.get("lastUpdate"))
+            if updated is not None and (max_update is None or updated > max_update):
+                max_update = updated
+            if cursor is not None and (updated is None or updated <= _parse_ts(cursor)):
+                # Not changed since the last run — nothing to re-emit. The
+                # sweep below still needs every id seen this run, so paging
+                # walks the full listing (no early stop against the cursor:
+                # that would mistake unvisited live bookmarks for deletions).
+                continue
+
+            link = raindrop.get("link") or ""
+            page_text = None
+            if fetch_page_content and _is_http_url(link):
+                # Best-effort by contract: any client failure degrades to the
+                # excerpt-only document instead of failing the sync.
+                try:
+                    page_text = client.fetch_page(link)
+                except Exception as exc:
+                    logger.warning("Raindrop: page fetch failed for %s: %s", link, exc)
+            yield _bookmark_row(raindrop, page_text)
+
+            rows = _annotation_rows(raindrop)
+            curr_highlight_ids[rid] = [row["id"] for row in rows]
+            for hid in sorted(set(prev_highlight_ids.get(rid, [])) - {row["id"] for row in rows}):
+                yield _tombstone_row(hid, "annotation")
+            yield from rows
+            curr_bookmark_ids.add(rid)
+
+        page += 1
+        total = payload.get("count")
+        if total is not None and page * _PAGE_SIZE >= total:
+            break
+
+    # Deletions: bookmarks (and their annotations) that vanished since the
+    # previous run, plus annotations removed from bookmarks we just re-fetched.
+    for rid in sorted(prev_bookmark_ids - curr_bookmark_ids):
+        yield _tombstone_row(rid, "bookmark")
+        for hid in prev_highlight_ids.get(rid, []):
+            yield _tombstone_row(hid, "annotation")
+        prev_highlight_ids.pop(rid, None)
+    state["highlight_ids"] = curr_highlight_ids
+    state["bookmark_ids"] = sorted(curr_bookmark_ids)
+    state["last_update"] = max_update.isoformat() if max_update else cursor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_newer(collection: dict, state: dict) -> bool:
+    """True when the collection was updated after the recorded cursor."""
+    cursor = state.get("last_update")
+    if not cursor:
+        return True
+    updated = _parse_ts(collection.get("lastUpdate"))
+    return updated is None or updated > _parse_ts(cursor)
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    """Parse a Raindrop ISO-8601 timestamp ('...Z' or '...+00:00') to UTC."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _is_http_url(url: str) -> bool:
+    """True for http(s) URLs — skip javascript:/chrome: style bookmarklets."""
+    return urlparse(url).scheme in ("http", "https")

--- a/packages/connector/raindrop/examples/example.py
+++ b/packages/connector/raindrop/examples/example.py
@@ -1,0 +1,82 @@
+"""Raindrop.io connector demo — turn your bookmarks into memory.
+
+Pull Raindrop.io collections, bookmarks, and highlights into cognee,
+incrementally and with forget-on-delete. ``raindrop_source`` returns a ``dlt``
+resource you hand straight to ``cognee.remember``. Rows are ingested as normal
+documents (so they go through the full cognify entity-extraction pipeline).
+
+The first run is a full backfill; every later run fetches only bookmarks
+changed since the last sync (``lastUpdate`` cursor) and propagates deletions,
+so bookmarks you delete upstream disappear from memory on the next sync.
+
+Pass ``fetch_page_content=True`` to also fetch and index the linked pages'
+text — opt-in, because it multiplies ingest cost.
+
+────────────────────────────────────────────────────────────────────────────
+Privacy / opt-in
+────────────────────────────────────────────────────────────────────────────
+This reads the content of your bookmarks (and, if opted in, the linked pages).
+Nothing is fetched until you run this script. Use a dedicated dataset so you
+can wipe it with a single ``cognee.forget``.
+
+────────────────────────────────────────────────────────────────────────────
+One-time setup
+────────────────────────────────────────────────────────────────────────────
+1. Install the extra:
+
+       pip install "cognee[raindrop]"      # or: uv sync --extra raindrop
+
+2. Create a test token at https://app.raindrop.io/#/settings/integrations
+   (Settings → Integrations → For Developer).
+3. Export the token and your LLM key, then run:
+
+       export RAINDROP_API_TOKEN="..."
+       export LLM_API_KEY="sk-..."
+       uv run python packages/connector/raindrop/examples/example.py
+
+Re-run after adding/deleting a bookmark to see the incremental re-sync and
+forget-on-delete.
+"""
+
+import asyncio
+
+import cognee
+
+from cognee_community_connector_raindrop import raindrop_source
+
+
+async def main():
+    source = raindrop_source()  # reads RAINDROP_API_TOKEN
+    # raindrop_source(fetch_page_content=True)  # also index linked pages
+
+    print("=== Initial sync (full backfill) ===")
+    result = await cognee.remember(
+        source,
+        dataset_name="raindrop_demo",
+        primary_key="id",
+        # "merge" is required: it's what makes re-runs incremental and what
+        # makes deletions propagate via orphan cleanup. The default
+        # ("replace") would wipe the synced corpus on every run.
+        write_disposition="merge",
+        # The DLT ingestion default caps a table at 50 rows; real accounts
+        # exceed that, so lift the cap.
+        max_rows_per_table=0,
+    )
+    print(result)
+
+    answer = await cognee.recall("What do I have about machine learning?")
+    print("Recall:", answer)
+
+    print("\n=== Incremental re-sync (only changes/deletions are processed) ===")
+    result = await cognee.remember(
+        raindrop_source(),
+        dataset_name="raindrop_demo",
+        primary_key="id",
+        write_disposition="merge",
+        max_rows_per_table=0,
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/connector/raindrop/pyproject.toml
+++ b/packages/connector/raindrop/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "cognee-community-connector-raindrop"
+version = "0.1.0"
+description = "Raindrop.io data-source connector for cognee — sync your Raindrop.io workspace into memory (incremental lastUpdate + forget-on-delete)"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    # Requires cognee "document-mode" (DOCUMENT_SOURCE_ATTR + resolve_dlt_sources
+    # routing rows through cognify instead of the dlt-schema path), first shipped
+    # in cognee 1.4.0.
+    "cognee==1.4.0",
+    "dlt[sqlalchemy]>=1.9.0,<2",
+    "httpx>=0.27.0,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_connector_raindrop"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/connector/raindrop/tests/test_raindrop.py
+++ b/packages/connector/raindrop/tests/test_raindrop.py
@@ -1,0 +1,440 @@
+"""Unit tests for the Raindrop.io dlt connector.
+
+Three layers, all runnable in CI without a live Raindrop token:
+
+* DB-free tests for row building, page-text extraction, and error
+  classification.
+* Sync-strategy tests driving ``_sync`` with an in-memory fake client,
+  covering the lastUpdate cursor, early paging stop, id-sweep deletions, and
+  the opt-in page fetch.
+* dlt-pipeline tests (fake client, temp sqlite destination) covering the
+  acceptance criteria: first-run backfill, incremental re-sync picks up only
+  changes, and deleted objects vanish from staging (forget-on-delete).
+"""
+
+from types import SimpleNamespace
+from uuid import NAMESPACE_OID, uuid5
+
+import httpx
+import pytest
+
+from cognee_community_connector_raindrop.raindrop import (
+    RAINDROP_SOURCE_NAME,
+    _annotation_rows,
+    _bookmark_row,
+    _collection_row,
+    _extract_page_text,
+    _is_transient,
+    _parse_ts,
+    _sync,
+    _tombstone_row,
+    raindrop_source,
+)
+
+T0 = "2026-09-01T10:00:00.000Z"  # old
+T1 = "2026-09-01T12:00:00.000Z"  # at first sync
+T2 = "2026-09-01T14:00:00.000Z"  # new change between runs
+T3 = "2026-09-01T16:00:00.000Z"  # an even later change
+
+
+def _collection(cid=1, title="Reading", last_update=T1, description=""):
+    return {"_id": cid, "title": title, "description": description, "lastUpdate": last_update}
+
+
+def _raindrop(
+    rid=100,
+    title="Example",
+    link="https://example.com",
+    excerpt="An excerpt",
+    tags=(),
+    last_update=T1,
+    highlights=(),
+    collection_id=1,
+):
+    return {
+        "_id": rid,
+        "title": title,
+        "link": link,
+        "excerpt": excerpt,
+        "tags": list(tags),
+        "collection": {"$ref": "collections", "id": collection_id},
+        "lastUpdate": last_update,
+        "highlights": list(highlights),
+    }
+
+
+def _highlight(hid=7, text="a quote", note=""):
+    return {"_id": hid, "text": text, "note": note, "lastUpdate": T1}
+
+
+class FakeRaindrop:
+    """Stand-in for RaindropClient backed by in-memory fixtures."""
+
+    def __init__(self, collections=(), raindrops=()):
+        self.collection_items = list(collections)
+        self.raindrop_items = sorted(raindrops, key=lambda r: r["lastUpdate"], reverse=True)
+        self.page_text = "PAGE BODY"
+        self.fetch_calls: list[str] = []
+        self.page_calls: list[int] = []
+
+    def collections(self) -> list[dict]:
+        return list(self.collection_items)
+
+    def raindrops(self, collection_id: str = "0", page: int = 0) -> dict:
+        self.page_calls.append(page)
+        items = self.raindrop_items[page * 50 : (page + 1) * 50]
+        return {"items": items, "count": len(self.raindrop_items)}
+
+    def fetch_page(self, url: str) -> str:
+        self.fetch_calls.append(url)
+        return self.page_text
+
+
+# ---------------------------------------------------------------------------
+# Row building (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_collection_row_flattens_collection():
+    row = _collection_row(_collection(cid=5, title="Work", description="Work links"))
+    assert row["id"] == "5"
+    assert row["kind"] == "collection"
+    assert row["title"] == "Work"
+    assert row["content"] == "Work links"
+
+
+def test_bookmark_row_combines_excerpt_and_tags():
+    row = _bookmark_row(_raindrop(tags=("zeta", "alpha")))
+    assert row["id"] == "100"
+    assert row["kind"] == "bookmark"
+    assert row["url"] == "https://example.com"
+    assert row["title"] == "Example"
+    assert "An excerpt" in row["content"]
+    assert "Tags: alpha, zeta" in row["content"]  # sorted, deterministic
+
+
+def test_bookmark_row_appends_opt_in_page_text():
+    row = _bookmark_row(_raindrop(), page_text="PAGE BODY")
+    assert "PAGE BODY" in row["content"]
+    assert (
+        _bookmark_row(_raindrop())["content"] == _bookmark_row(_raindrop(), page_text="")["content"]
+    )
+
+
+def test_annotation_rows_prefix_ids_and_merge_note():
+    rows = _annotation_rows(
+        _raindrop(
+            highlights=(
+                _highlight(hid=7),
+                _highlight(hid=8, text="", note="just a note"),
+                _highlight(hid=9, text="the quote", note="why it matters"),
+            )
+        )
+    )
+    assert [r["id"] for r in rows] == ["hl-7", "hl-8", "hl-9"]
+    assert all(r["kind"] == "annotation" for r in rows)
+    assert rows[0]["content"] == "a quote"  # text only
+    assert rows[1]["content"] == "just a note"  # note only
+    assert "the quote" in rows[2]["content"] and "Note: why it matters" in rows[2]["content"]
+
+
+def test_tombstone_row_marks_deletion():
+    tomb = _tombstone_row("100", "bookmark")
+    assert tomb["_deleted"] is True
+    assert tomb["kind"] == "bookmark"
+
+
+# ---------------------------------------------------------------------------
+# Page extraction (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_page_text_pulls_title_and_description():
+    html = (
+        "<html><head><title>My Page</title>"
+        '<meta name="description" content="About my page"></head>'
+        "<body><script>alert(1)</script><p>First para</p><p>Second para</p></body></html>"
+    )
+    text = _extract_page_text(html)
+    assert "My Page" in text
+    assert "About my page" in text
+    assert "First para" in text
+    assert "alert" not in text
+
+
+def test_extract_page_text_handles_empty_and_capped_output():
+    assert _extract_page_text("") == ""
+    assert _extract_page_text("<p>x</p>" + "<p>" + "y" * 20000 + "</p>").count("y") <= 5000
+
+
+# ---------------------------------------------------------------------------
+# Timestamp / error classification (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ts_handles_both_suffixes():
+    assert _parse_ts("2026-09-01T12:00:00.000Z") == _parse_ts("2026-09-01T12:00:00.000+00:00")
+    assert _parse_ts("garbage") is None
+    assert _parse_ts(None) is None
+
+
+def test_is_transient_classification():
+    def status_error(code):
+        req = httpx.Request("GET", "https://api.raindrop.io/rest/v1/raindrops/0")
+        resp = httpx.Response(code, request=req)
+        return httpx.HTTPStatusError("err", request=req, response=resp)
+
+    assert _is_transient(status_error(429)) is True
+    assert _is_transient(status_error(503)) is True
+    assert _is_transient(status_error(401)) is False
+    assert _is_transient(httpx.ConnectTimeout("t")) is True
+    assert _is_transient(ValueError()) is False
+
+
+# ---------------------------------------------------------------------------
+# Sync strategies (pure, fake client)
+# ---------------------------------------------------------------------------
+
+
+def test_first_sync_yields_everything_and_records_cursors():
+    client = FakeRaindrop(
+        collections=[_collection(cid=1)],
+        raindrops=[_raindrop(rid=100, last_update=T1, highlights=(_highlight(hid=7),))],
+    )
+    state: dict = {}
+    rows = list(_sync(client, state))
+
+    kinds = {r["id"]: r["kind"] for r in rows}
+    assert kinds == {"1": "collection", "100": "bookmark", "hl-7": "annotation"}
+    assert _parse_ts(state["last_update"]) == _parse_ts(T1)
+    assert state["bookmark_ids"] == ["100"]
+    assert state["collection_ids"] == ["1"]
+    assert state["highlight_ids"] == {"100": ["hl-7"]}
+    assert client.fetch_calls == []  # page fetch is opt-in
+
+
+def test_incremental_sync_reemits_only_changes():
+    client = FakeRaindrop(raindrops=[_raindrop(rid=100, last_update=T1)])
+    state: dict = {}
+    list(_sync(client, state))
+
+    # Nothing changed: nothing is re-emitted.
+    client.page_calls.clear()
+    assert list(_sync(client, state)) == []
+
+    # A new bookmark arrives (and the old one is still listed).
+    client.raindrop_items = [
+        _raindrop(rid=100, last_update=T1),
+        _raindrop(rid=200, title="New", last_update=T2),
+    ]
+    rows = list(_sync(client, state))
+    assert [r["id"] for r in rows] == ["200"]
+    assert _parse_ts(state["last_update"]) == _parse_ts(T2)
+    assert sorted(state["bookmark_ids"]) == ["100", "200"]
+
+
+def test_paging_walks_all_pages_for_the_deletion_sweep():
+    # 120 raindrops (3 pages), all last-updated at T0; first sync records T0.
+    client = FakeRaindrop(raindrops=[_raindrop(rid=i, last_update=T0) for i in range(120)])
+    state: dict = {}
+    list(_sync(client, state))
+
+    # Second sync: nothing changed — every page is still walked (the deletion
+    # sweep must see all live ids) but nothing is re-emitted.
+    client.page_calls.clear()
+    assert list(_sync(client, state)) == []
+    assert sorted(client.page_calls) == [0, 1, 2]
+    assert len(state["bookmark_ids"]) == 120
+
+
+def test_vanished_bookmark_and_annotations_are_tombstoned():
+    client = FakeRaindrop(
+        raindrops=[
+            _raindrop(rid=100, highlights=(_highlight(hid=7), _highlight(hid=8))),
+            _raindrop(rid=200),
+        ]
+    )
+    state: dict = {}
+    list(_sync(client, state))
+
+    # Bookmark 100 vanished entirely; 200 remains.
+    client.raindrop_items = [_raindrop(rid=200)]
+    rows = [r for r in _sync(client, state) if r.get("_deleted")]
+
+    tombs = {r["id"]: r["kind"] for r in rows}
+    assert tombs == {"100": "bookmark", "hl-7": "annotation", "hl-8": "annotation"}
+    assert state["highlight_ids"] == {}
+    assert state["bookmark_ids"] == ["200"]
+
+
+def test_removed_highlight_is_tombstoned_but_bookmark_survives():
+    client = FakeRaindrop(
+        raindrops=[_raindrop(rid=100, highlights=(_highlight(hid=7), _highlight(hid=8)))]
+    )
+    state: dict = {}
+    list(_sync(client, state))
+
+    # Highlight 8 was removed from the (still alive, since re-fetched) bookmark.
+    client.raindrop_items = [_raindrop(rid=100, last_update=T2, highlights=(_highlight(hid=7),))]
+    rows = list(_sync(client, state))
+
+    tombs = [r for r in rows if r.get("_deleted")]
+    assert [t["id"] for t in tombs] == ["hl-8"]
+    # The bookmark and surviving highlight are re-emitted for the update.
+    ids = [r["id"] for r in rows if not r.get("_deleted")]
+    assert ids == ["100", "hl-7"]
+
+
+def test_vanished_collection_is_tombstoned():
+    client = FakeRaindrop(collections=[_collection(cid=1), _collection(cid=2, title="Later")])
+    state: dict = {}
+    list(_sync(client, state))
+
+    client.collection_items = [_collection(cid=1)]
+    rows = [r for r in _sync(client, state) if r.get("_deleted")]
+    assert [(r["id"], r["kind"]) for r in rows] == [("2", "collection")]
+
+
+def test_opt_in_page_fetch_and_graceful_failure():
+    client = FakeRaindrop(raindrops=[_raindrop(rid=100, last_update=T1)])
+    list(_sync(client, {}))
+    assert client.fetch_calls == []  # default: no page fetching
+
+    # The bookmark changes (bumping lastUpdate past the cursor): with the
+    # opt-in on, the linked page is fetched and appended.
+    client.fetch_calls.clear()
+    client.page_text = "FETCHED TEXT"
+    client.raindrop_items = [_raindrop(rid=100, last_update=T2)]
+    rows = list(_sync(client, {}, fetch_page_content=True))
+    assert client.fetch_calls == ["https://example.com"]
+    assert "FETCHED TEXT" in rows[0]["content"]
+
+    # A failing fetch degrades to the excerpt-only document.
+    client.fetch_calls.clear()
+
+    def boom(url):
+        raise httpx.ConnectTimeout("t")
+
+    client.fetch_page = boom
+    client.raindrop_items = [_raindrop(rid=100, title="Retitled", last_update=T3)]
+    rows = list(_sync(client, {}, fetch_page_content=True))
+    assert len(rows) == 1
+    assert "FETCHED TEXT" not in rows[0]["content"]
+    assert "An excerpt" in rows[0]["content"]
+
+
+def test_non_http_bookmark_link_is_not_fetched():
+    client = FakeRaindrop(raindrops=[_raindrop(rid=100, link="javascript:void(0)")])
+    list(_sync(client, {}, fetch_page_content=True))
+    assert client.fetch_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Source wiring (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_raindrop_source_declares_document_marker():
+    from cognee.tasks.ingestion.dlt_utils import document_source_tag
+
+    source = raindrop_source(token="test-token")
+    assert RAINDROP_SOURCE_NAME == "raindrop"
+    assert document_source_tag(source) == "raindrop"
+
+
+def test_raindrop_source_requires_token():
+    with pytest.raises(ValueError):
+        raindrop_source(token=None, client=None)
+
+
+def test_document_data_item_tags_source():
+    from cognee.tasks.ingestion.resolve_dlt_sources import _build_document_data_item
+
+    row = SimpleNamespace(
+        row_data={
+            "id": "100",
+            "kind": "bookmark",
+            "url": "https://example.com",
+            "title": "Example",
+            "content": "Example\n\nAn excerpt",
+            "_deleted": False,
+        },
+        content_hash="abc123",
+    )
+    data_id = uuid5(NAMESPACE_OID, "100")
+
+    item = _build_document_data_item(row, data_id, "raindrop")
+
+    assert item.external_metadata["source"] == "raindrop"
+    assert item.external_metadata["url"] == "https://example.com"
+    assert item.data_id == data_id
+    assert item.data.startswith("# Example")
+
+
+# ---------------------------------------------------------------------------
+# dlt pipeline: incremental merge + forget-on-delete (needs dlt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dlt_mod():
+    return pytest.importorskip("dlt")
+
+
+def _make_pipeline(dlt, tmp_path, name):
+    db_path = (tmp_path / f"{name}.db").as_posix()
+    return dlt.pipeline(
+        pipeline_name=name,
+        destination=dlt.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="raindrop_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+
+
+def _read_rows(pipeline):
+    with (
+        pipeline.sql_client() as client,
+        client.execute_query("SELECT id, kind, title, content FROM raindrop") as cursor,
+    ):
+        rows = cursor.fetchall()
+    return {row[0]: {"kind": row[1], "title": row[2], "content": row[3]} for row in rows}
+
+
+def test_pipeline_backfill_and_incremental_resync(dlt_mod, tmp_path):
+    client = FakeRaindrop(
+        collections=[_collection(cid=1)],
+        raindrops=[_raindrop(rid=100, title="Old title", last_update=T1)],
+    )
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "raindrop_resync")
+    pipeline.run(raindrop_source(client=client))
+
+    rows = _read_rows(pipeline)
+    assert set(rows) == {"1", "100"}
+    assert "Old title" in rows["100"]["content"]
+
+    # Incremental run: only the changed bookmark is re-fetched and upserted.
+    client.raindrop_items = [
+        _raindrop(rid=100, title="New title", last_update=T2),
+        _raindrop(rid=200, title="Added", last_update=T2),
+    ]
+    pipeline.run(raindrop_source(client=client))
+
+    rows = _read_rows(pipeline)
+    assert set(rows) == {"1", "100", "200"}
+    assert "New title" in rows["100"]["content"]
+    assert "Old title" not in rows["100"]["content"]
+
+
+def test_pipeline_vanished_bookmark_is_removed(dlt_mod, tmp_path):
+    client = FakeRaindrop(raindrops=[_raindrop(rid=100), _raindrop(rid=200)])
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "raindrop_forget")
+    pipeline.run(raindrop_source(client=client))
+    assert set(_read_rows(pipeline)) == {"100", "200"}
+
+    # Bookmark 100 vanished; 200 remains (with a newer update so it re-emits).
+    client.raindrop_items = [_raindrop(rid=200, last_update=T2)]
+    pipeline.run(raindrop_source(client=client))
+
+    rows = _read_rows(pipeline)
+    assert "100" not in rows
+    assert "200" in rows


### PR DESCRIPTION
## Summary

Implements topoteretes/cognee#4813 — a `raindrop` connector under `packages/connector/raindrop/`, following the shape of the existing connectors and the incremental model already established by gmail/google-drive.

- **Auth:** Raindrop.io test token / OAuth token (`token=` or `RAINDROP_API_TOKEN`); read-only, no OAuth dance needed for the test-token path
- **Ingest:** collections, bookmarks, and highlights (annotations) as documents — the resource declares `cognee_document_source = "raindrop"`, so rows flow through the normal cognify entity-extraction pipeline (same treatment as notion/google-drive)
- **Incremental sync:** `lastUpdate` cursor persisted in dlt resource state. The listing is fetched `sort=-lastUpdate` and paged in full each run so the deletion sweep sees every live id; unchanged rows are skipped client-side before any row is emitted
- **Forget-on-delete:** Raindrop has no deletion feed, so — like the Confluence connector — each run diffs the full id set against the previous run's (kept in resource state). Vanished bookmarks/collections, the annotations of vanished bookmarks, and annotations removed from a re-fetched bookmark (row ids prefixed `hl-`) are emitted as `_deleted` hard-delete markers, which cognee's existing `orphan_cleanup` then purges from graph + vector + relational stores
- **Opt-in page fetch (per the issue's warning):** `fetch_page_content=True` appends the linked page's text (dependency-free regex extraction of title/meta-description/paragraphs, capped at 5k chars). Off by default — it multiplies ingest cost — and degrades gracefully to the API-provided excerpt when a fetch fails
- **Robustness:** retries with backoff for 429/5xx/timeouts; volatile fields (collection refs, covers, domains) excluded from document text so content-hash `data_id`s stay stable

## Package layout (per the issue)

```
packages/connector/raindrop/
├── README.md
├── cognee_community_connector_raindrop/
│   ├── __init__.py
│   └── raindrop.py
├── examples/example.py
├── tests/test_raindrop.py
└── pyproject.toml
```

## Testing

`pytest packages/connector/raindrop/tests -q` → **22 passed** (offline; Raindrop API faked, dlt runs against a temp SQLite destination):

- row builders (collection/bookmark/annotation, excerpt+tags composition, `hl-` id prefixes)
- page-text extraction (title/meta/paragraphs, script stripping, cap) and opt-in fetch degradation
- sync strategies: full backfill → cursor'd re-sync, id-sweep deletions, removed-highlight detection, vanished-collection tombstones, non-http link guarding, full-page sweep guarantee
- dlt pipeline against sqlite: backfill → incremental upsert → vanished-bookmark removal
- document-path wiring: `document_source_tag(source) == "raindrop"`, `_build_document_data_item` mapping

`ruff check` / `ruff format --check` clean.

## Acceptance criteria (from the issue)

- [x] A user connects via Test token / OAuth and selects what to ingest
- [x] Selected content is ingested and searchable in cognee (document path → cognify)
- [x] Incremental sync picks up only what changed since the last run (`lastUpdate` cursor)
- [x] Deleting the source upstream removes it from the graph on the next sync (id sweep + hard-delete markers)
- [x] README with setup steps and a runnable example under `examples/` (linked-page fetching is opt-in, as the issue asks)
- [x] Tests covering the ingest path and the incremental cursor

Closes topoteretes/cognee#4813