### PR TITLE
feat(connector): add Contentful data-source connector (cognee#4787)

### DIFF
--- a/packages/connector/contentful/README.md
+++ b/packages/connector/contentful/README.md
@@ -1,0 +1,106 @@
+# cognee-community-connector-contentful
+
+[Contentful](https://contentful.com) data-source connector for
+[cognee](https://github.com/topoteretes/cognee) — sync your content model,
+entries, and assets into memory, incrementally and with forget-on-delete.
+"Ask my CMS."
+
+Part of the cognee hackathon connector push (topoteretes/cognee#4787).
+
+## Features
+
+- **Incremental sync** — the first run is a full backfill; every later run
+  lists objects `order=-sys.updatedAt` and re-emits only those updated after
+  the recorded cursor.
+- **Content model included** — content types are ingested as their own
+  documents (name, display field, every field with its type), so entries have
+  their schema context next to them in memory, exactly as the issue asks.
+- **Forget-on-delete** — the Delivery API has no deletion feed, so each run
+  diffs the full id set of every kind against the previous run (kept in dlt
+  resource state). Vanished objects are hard-deleted and then purged by
+  cognee's orphan cleanup.
+- **Document ingestion** — each row becomes a normal text document that flows
+  through cognee's cognify entity-extraction pipeline (same treatment as the
+  Notion / Google Drive connectors). Entry fields are flattened to text:
+  strings, lists, rich-text nodes, and `[linkType: id]` placeholders — links
+  are never dereferenced, so editing one entry never pulls the whole linked
+  graph.
+- **Retries with backoff** — rate-limit (429), server (5xx), timeout, and
+  network errors are retried; auth failures fail fast.
+
+## Installation
+
+```bash
+pip install "cognee[contentful]"
+# or, from this repository:
+uv pip install ./packages/connector/contentful
+```
+
+## Setup
+
+1. In Contentful: **Settings → API keys → Add API key**; copy the Space ID and
+   the *Content Delivery API — access token*.
+2. Export them:
+
+   ```bash
+   export CONTENTFUL_SPACE_ID="..."
+   export CONTENTFUL_TOKEN="..."
+   ```
+
+## Usage
+
+```python
+import cognee
+from cognee_community_connector_contentful import contentful_source
+
+await cognee.remember(
+    contentful_source(space_id="...", token="...", environment="master"),
+    dataset_name="my_cms",
+    primary_key="id",
+    write_disposition="merge",  # REQUIRED — see below
+    max_rows_per_table=0,  # REQUIRED for a real space
+)
+
+answer = await cognee.recall("What do we publish about pricing?")
+```
+
+> **`write_disposition="merge"` is mandatory.** The add pipeline defaults to
+> `"replace"` (drop + reload the table each run); on the second, incremental
+> sync that would wipe everything but the small delta.
+
+> **`max_rows_per_table=0`** lifts cognee's 50-row read cap so orphan cleanup
+> compares against the *whole* synced corpus.
+
+A runnable version lives in [`examples/example.py`](examples/example.py).
+
+## What gets ingested
+
+| Entity        | Kind           | Document                                              |
+| ------------- | -------------- | ----------------------------------------------------- |
+| Content type  | `content_type` | name, display field, every field with its type         |
+| Entry         | `entry`        | flattened `fields` (rich text rendered, links as refs) |
+| Asset         | `asset`        | title, description, file type/name, https file URL     |
+
+## Deleting data
+
+- Delete an entry/asset/content type in Contentful → it is removed from
+  cognee's graph, vector, and relational stores on the next sync (dlt
+  hard-delete + cognee's orphan cleanup).
+- Delete the whole dataset locally with `cognee.forget(...)` /
+  `cognee.prune()`.
+
+## Tests
+
+```bash
+uv run pytest packages/connector/contentful/tests -q
+```
+
+All tests run offline: the Contentful API is faked, and the dlt pipeline runs
+against a temporary SQLite destination.
+
+## Notes & limitations
+
+- The connector reads from the read-only Content Delivery API and never
+  mutates your space.
+- Rich-text rendering extracts text nodes only (no embeds/tables markup).
+- Linked entries are rendered as `[linkType: id]` placeholders, not resolved.

--- a/packages/connector/contentful/cognee_community_connector_contentful/__init__.py
+++ b/packages/connector/contentful/cognee_community_connector_contentful/__init__.py
@@ -1,0 +1,3 @@
+from cognee_community_connector_contentful.contentful import contentful_source
+
+__all__ = ["contentful_source"]

--- a/packages/connector/contentful/cognee_community_connector_contentful/contentful.py
+++ b/packages/connector/contentful/cognee_community_connector_contentful/contentful.py
@@ -1,0 +1,491 @@
+"""DLT source for Contentful (updatedAt cursor + forget-on-delete).
+
+Pulls Contentful content types (the content model), entries, and assets into
+cognee incrementally — "ask my CMS".  The source is a single dlt resource
+meant to be handed directly to :func:`cognee.remember`::
+
+    import cognee
+    from cognee_community_connector_contentful import contentful_source
+
+    await cognee.remember(
+        contentful_source(space_id="...", token="..."),
+        dataset_name="my_cms",
+        primary_key="id",
+        write_disposition="merge",   # REQUIRED (see .. important:: below)
+        max_rows_per_table=0,        # REQUIRED for a real space (see .. note:: below)
+    )
+
+.. important::
+   ``write_disposition="merge"`` is **mandatory**.  The add pipeline defaults
+   to ``"replace"`` (drop + reload the table each run); on the second,
+   incremental sync that would wipe everything but the small delta.  Always
+   pass ``"merge"``.
+
+Design
+------
+* **Auth** — a Contentful *Content Delivery API* access token.  Pass
+  ``token=`` or set ``CONTENTFUL_TOKEN`` (plus ``CONTENTFUL_SPACE_ID``, or
+  ``space_id=``).  The connector only issues reads.
+* **Primary key** — the Contentful ``sys.id``.  Combined with
+  ``write_disposition="merge"`` this gives idempotent upserts across all
+  three entity kinds (content types / entries / assets) in one staging table.
+* **Incremental cursor** — ``sys.updatedAt``.  Listings are fetched
+  ``order=-sys.updatedAt`` and only objects updated after the cursor recorded
+  in dlt's resource state are re-emitted.  The listing is still paged in full
+  every run: the deletion sweep needs to see every live id.
+* **Forget-on-delete** — Contentful's Delivery API has no deletion feed, so
+  each run diffs the full id set of every kind against the previous run's
+  (kept in resource state).  Vanished objects are emitted with the ``_deleted``
+  hard-delete marker; dlt removes those rows on ``merge`` and cognee's
+  existing ``orphan_cleanup`` purges them from the graph + vector + relational
+  stores.  No parallel cleanup path.
+* **Content model** — content types are ingested too (as their own document
+  rows describing every field), so entries have their schema context next to
+  them in memory.
+* **Document mode** — the resource declares ``cognee_document_source =
+  "contentful"`` (the same marker notion/google-drive use), so each row flows
+  through the standard cognify entity-extraction pipeline as a normal text
+  document instead of the deterministic dlt-row schema-context path.  Entry
+  bodies are flattened from their ``fields`` maps (strings, lists, rich text
+  nodes, and link placeholders); links are *not* dereferenced, so a single
+  entry edit never pulls the whole linked graph.
+
+.. note::
+   cognee's ``ingest_dlt_source`` reads at most ``max_rows_per_table`` rows
+   from the dlt destination (default 50).  For a real space pass
+   ``max_rows_per_table=0`` (unlimited) so orphan-cleanup compares against the
+   *whole* synced corpus rather than a truncated window.
+
+Privacy
+-------
+This reads the content of your Contentful space.  It is **opt-in**: nothing is
+fetched until you construct a source and call ``remember``.  Use a dedicated
+dataset so you can ``cognee.forget`` the whole thing in one call.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any
+
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.ingestion.dlt_utils import DOCUMENT_SOURCE_ATTR
+
+logger = get_logger("contentful_connector")
+
+# dlt resource / staging-table name for Contentful objects (all three kinds
+# live in one table, discriminated by the ``kind`` column).
+CONTENTFUL_SOURCE_NAME = "contentful"
+CONTENTFUL_TABLE_NAME = "contentful"
+
+# Retry budget for rate-limited / transient Contentful API responses.
+_MAX_RETRIES = 5
+
+# Contentful caps a page at 1000 items; stay well inside it.
+_PAGE_SIZE = 200
+_MAX_PAGES = 500  # hard stop: 100k objects of one kind
+
+_EXTRA_HINT = (
+    'The Contentful connector requires the "contentful" extra: pip install "cognee[contentful]" '
+    "(provides dlt and httpx)."
+)
+
+
+def contentful_source(
+    space_id: str | None = None,
+    token: str | None = None,
+    environment: str = "master",
+    client: Any = None,
+):
+    """Create a dlt resource that yields Contentful content types/entries/assets.
+
+    Args:
+        space_id: The Contentful space id. Falls back to ``CONTENTFUL_SPACE_ID``.
+        token: A Content Delivery API access token. Falls back to
+            ``CONTENTFUL_TOKEN``.
+        environment: The Contentful environment id (default ``"master"``).
+        client: Pre-built client (mainly a test-injection point); when omitted
+            a :class:`ContentfulClient` is built from the parameters above.
+
+    Returns:
+        A dlt resource suitable for ``cognee.remember(...)`` with
+        ``write_disposition="merge"``.
+    """
+    try:
+        import dlt
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    if client is None:
+        resolved_space = space_id or os.environ.get("CONTENTFUL_SPACE_ID")
+        resolved_token = token or os.environ.get("CONTENTFUL_TOKEN")
+        if not resolved_space or not resolved_token:
+            raise ValueError(
+                "Contentful space_id and token required: pass them or set "
+                "CONTENTFUL_SPACE_ID / CONTENTFUL_TOKEN."
+            )
+        client = ContentfulClient(resolved_space, resolved_token, environment)
+
+    @dlt.resource(
+        name=CONTENTFUL_TABLE_NAME,
+        primary_key="id",
+        write_disposition="merge",
+        # _deleted is a boolean hard-delete marker (matching gmail.py /
+        # google_drive.py): rows where it is True are removed from the dlt
+        # destination on merge, which propagates the deletion through
+        # cognee's orphan_cleanup.
+        columns={"_deleted": {"data_type": "bool", "hard_delete": True}},
+    )
+    def contentful():
+        resource_state = dlt.current.resource_state()
+        yield from _sync(client, resource_state)
+
+    # Opt into the document ingestion path (row -> text document -> cognify).
+    # resolve_dlt_sources reads this marker; it never imports this connector.
+    setattr(contentful, DOCUMENT_SOURCE_ATTR, CONTENTFUL_SOURCE_NAME)
+    return contentful
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+class ContentfulClient:
+    """Minimal Contentful Delivery API client over httpx, with retry/backoff.
+
+    Exposes exactly the operations the connector needs: ``content_types``,
+    ``entries``, and ``assets``.  Any object with the same methods can be
+    injected in its place (tests).
+    """
+
+    def __init__(
+        self,
+        space_id: str,
+        token: str,
+        environment: str = "master",
+        base_url: str = "https://cdn.contentful.com",
+        timeout: float = 30.0,
+    ):
+        self._base = f"{base_url.rstrip('/')}/spaces/{space_id}/environments/{environment}"
+        self._token = token
+        self._timeout = timeout
+
+    def content_types(self, skip: int = 0) -> dict:
+        """One page of the content model, newest-change-first."""
+        return self._get(
+            "/content_types", params={"limit": _PAGE_SIZE, "skip": skip, "order": "-sys.updatedAt"}
+        )
+
+    def entries(self, skip: int = 0) -> dict:
+        """One page of entries, newest-change-first."""
+        return self._get(
+            "/entries", params={"limit": _PAGE_SIZE, "skip": skip, "order": "-sys.updatedAt"}
+        )
+
+    def assets(self, skip: int = 0) -> dict:
+        """One page of assets, newest-change-first."""
+        return self._get(
+            "/assets", params={"limit": _PAGE_SIZE, "skip": skip, "order": "-sys.updatedAt"}
+        )
+
+    def _get(self, path: str, params: dict) -> dict:
+        import httpx
+
+        for attempt in range(_MAX_RETRIES):
+            try:
+                resp = httpx.get(
+                    f"{self._base}{path}",
+                    params=params,
+                    headers={"Authorization": f"Bearer {self._token}"},
+                    timeout=self._timeout,
+                )
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as exc:
+                if attempt == _MAX_RETRIES - 1 or not _is_transient(exc):
+                    raise
+                delay = _retry_after(getattr(exc, "response", None), attempt)
+                logger.warning(
+                    "Contentful: %s — retrying in %.1fs (%d/%d).",
+                    exc,
+                    delay,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                time.sleep(delay)
+
+
+def _is_transient(exc: Exception) -> bool:
+    """True for rate-limit / server / timeout / network errors worth retrying."""
+    import httpx
+
+    if isinstance(exc, httpx.TransportError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in (429, 500, 502, 503, 504)
+    return False
+
+
+def _retry_after(response: Any, attempt: int) -> float:
+    """Seconds to wait before retrying: the Retry-After header, else backoff."""
+    header = None
+    if response is not None:
+        header = response.headers.get("retry-after") or response.headers.get("Retry-After")
+    try:
+        return float(header)
+    except (TypeError, ValueError):
+        return float(2**attempt)
+
+
+# ---------------------------------------------------------------------------
+# Field flattening (pure — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _rich_text_nodes(node: Any) -> Iterator[str]:
+    """Yield plain text blocks from a Contentful rich-text JSON tree.
+
+    Text inside one block element (paragraph, heading, …) is joined without
+    separators; separate blocks come back as separate strings.
+    """
+    if isinstance(node, list):
+        for child in node:
+            yield from _rich_text_nodes(child)
+    elif isinstance(node, dict):
+        if node.get("nodeType") == "text":
+            value = node.get("value")
+            if value:
+                yield value
+        else:
+            text = "".join(_rich_text_nodes(node.get("content")))
+            if text:
+                yield text
+
+
+def _field_text(value: Any) -> str:
+    """Flatten one Contentful field value to plain text.
+
+    Strings, numbers, booleans, and lists of them pass through; rich-text
+    objects render their text nodes; links render as ``[linkType: id]``
+    placeholders (never dereferenced); anything else is skipped.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    if isinstance(value, list):
+        return "\n".join(t for t in (_field_text(item) for item in value) if t)
+    if isinstance(value, dict):
+        if "nodeType" in value:  # rich text
+            return "\n".join(_rich_text_nodes(value)).strip()
+        sysinfo = value.get("sys")
+        if isinstance(sysinfo, dict) and sysinfo.get("linkType") and sysinfo.get("id"):
+            return f"[{sysinfo['linkType']}: {sysinfo['id']}]"
+    return ""
+
+
+def _flatten_fields(fields: dict) -> str:
+    """Flatten an entry's ``fields`` map to one text block."""
+    parts = []
+    for name, value in (fields or {}).items():
+        text = _field_text(value)
+        if text:
+            parts.append(f"{name}: {text}" if "\n" not in text else f"{name}:\n{text}")
+    return "\n\n".join(parts)
+
+
+def _entry_title(entry: dict, content_types: dict[str, dict]) -> str:
+    """Best-effort entry title: the content type's display field, else its id."""
+    fields = entry.get("fields") or {}
+    ctype_id = (entry.get("sys") or {}).get("contentType", {}).get("sys", {}).get("id") or ""
+    display = (content_types.get(ctype_id) or {}).get("displayField")
+    if display and fields.get(display):
+        text = _field_text(fields[display])
+        if text:
+            return text
+    for value in fields.values():
+        text = _field_text(value)
+        if text:
+            return text.split("\n")[0]
+    return ctype_id or str((entry.get("sys") or {}).get("id") or "")
+
+
+# ---------------------------------------------------------------------------
+# Row builders (pure — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _content_type_row(content_type: dict) -> dict:
+    """Flatten a content type (the model) into a document row."""
+    sysinfo = content_type.get("sys") or {}
+    fields_desc = "\n".join(
+        f"- {f.get('id')} ({f.get('type')})"
+        for f in content_type.get("fields") or []
+        if f.get("id")
+    )
+    name = content_type.get("name") or sysinfo.get("id") or ""
+    content = name
+    if content_type.get("displayField"):
+        content += f"\n\nDisplay field: {content_type['displayField']}"
+    if fields_desc:
+        content += f"\n\nFields:\n{fields_desc}"
+    return {
+        "id": str(sysinfo.get("id") or ""),
+        "kind": "content_type",
+        "url": "",
+        "title": name,
+        "content": content,
+        "_deleted": False,
+    }
+
+
+def _entry_row(entry: dict, content_types: dict[str, dict]) -> dict:
+    """Flatten a Contentful entry into a document row."""
+    sysinfo = entry.get("sys") or {}
+    return {
+        "id": str(sysinfo.get("id") or ""),
+        "kind": "entry",
+        "url": "",
+        "title": _entry_title(entry, content_types),
+        "content": _flatten_fields(entry.get("fields")),
+        "_deleted": False,
+    }
+
+
+def _asset_row(asset: dict) -> dict:
+    """Flatten a Contentful asset into a document row."""
+    sysinfo = asset.get("sys") or {}
+    fields = asset.get("fields") or {}
+    fileinfo = fields.get("file") or {}
+    if isinstance(fileinfo, dict):
+        url = fileinfo.get("url") or ""
+        if url.startswith("//"):
+            url = f"https:{url}"
+        details = f"{fileinfo.get('contentType') or ''} {fileinfo.get('fileName') or ''}".strip()
+    else:
+        url, details = "", ""
+    title = fields.get("title") or fields.get("fileName") or sysinfo.get("id") or ""
+    content = title
+    if fields.get("description"):
+        content += f"\n\n{fields['description']}"
+    if details:
+        content += f"\n\n{details}"
+    return {
+        "id": str(sysinfo.get("id") or ""),
+        "kind": "asset",
+        "url": url,
+        "title": title,
+        "content": content,
+        "_deleted": False,
+    }
+
+
+def _tombstone_row(row_id: str, kind: str = "") -> dict:
+    """A hard-delete marker row for a vanished object."""
+    return {"id": row_id, "kind": kind, "_deleted": True}
+
+
+# ---------------------------------------------------------------------------
+# Sync strategies (pure given client + state dict — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _sync(client: Any, state: dict) -> Iterator[dict]:
+    """Run one sync pass against ``client``, recording cursors in ``state``.
+
+    Only objects updated after the recorded ``last_update`` cursor are
+    re-emitted (each listing is sorted newest-change-first).  Every listing is
+    paged in full so the per-kind id sweep can emit hard-delete markers for
+    objects that vanished upstream — Contentful's Delivery API has no deletion
+    feed.
+    """
+    started = state.get("last_update")
+    cursor_dt = _parse_ts(started)
+    max_update = cursor_dt
+
+    prev_ids: dict[str, set[str]] = {k: set(v) for k, v in (state.get("ids") or {}).items()}
+    curr_ids: dict[str, set[str]] = {"content_type": set(), "entry": set(), "asset": set()}
+
+    content_types = _page_all(client.content_types)
+    for content_type in content_types:
+        cid = str((content_type.get("sys") or {}).get("id") or "")
+        curr_ids["content_type"].add(cid)
+        max_update = _bump(max_update, content_type)
+        if _changed(content_type, cursor_dt):
+            yield _content_type_row(content_type)
+    types_by_id = {str((ct.get("sys") or {}).get("id") or ""): ct for ct in content_types}
+
+    for entry in _page_all(client.entries):
+        eid = str((entry.get("sys") or {}).get("id") or "")
+        curr_ids["entry"].add(eid)
+        max_update = _bump(max_update, entry)
+        if _changed(entry, cursor_dt):
+            yield _entry_row(entry, types_by_id)
+
+    for asset in _page_all(client.assets):
+        aid = str((asset.get("sys") or {}).get("id") or "")
+        curr_ids["asset"].add(aid)
+        max_update = _bump(max_update, asset)
+        if _changed(asset, cursor_dt):
+            yield _asset_row(asset)
+
+    for kind, prev in prev_ids.items():
+        for oid in sorted(prev - curr_ids.get(kind, set())):
+            yield _tombstone_row(oid, kind)
+
+    state["ids"] = {k: sorted(v) for k, v in curr_ids.items()}
+    state["last_update"] = max_update.isoformat() if max_update else started
+
+
+def _page_all(fetch_page) -> list[dict]:
+    """Collect one object kind across all pages of its listing."""
+    items: list[dict] = []
+    skip = 0
+    for _ in range(_MAX_PAGES):
+        payload = fetch_page(skip=skip)
+        batch = payload.get("items", [])
+        items.extend(batch)
+        total = payload.get("total")
+        skip += len(batch)
+        if not batch or (total is not None and skip >= total):
+            break
+    return items
+
+
+def _changed(obj: dict, cursor_dt: datetime | None) -> bool:
+    """True when the object's updatedAt is after the cursor (or there is none)."""
+    if cursor_dt is None:
+        return True
+    updated = _parse_ts((obj.get("sys") or {}).get("updatedAt"))
+    return updated is None or updated > cursor_dt
+
+
+def _bump(max_update: datetime | None, obj: dict) -> datetime | None:
+    """Advance the running cursor with the object's updatedAt, if newer."""
+    updated = _parse_ts((obj.get("sys") or {}).get("updatedAt"))
+    if updated is None:
+        return max_update
+    if max_update is None or updated > max_update:
+        return updated
+    return max_update
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    """Parse a Contentful ISO-8601 timestamp ('...Z' or '...+00:00') to UTC."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/packages/connector/contentful/examples/example.py
+++ b/packages/connector/contentful/examples/example.py
@@ -1,0 +1,80 @@
+"""Contentful connector demo — turn your CMS into memory.
+
+Pull Contentful content types (the content model), entries, and assets into
+cognee, incrementally and with forget-on-delete. ``contentful_source`` returns
+a ``dlt`` resource you hand straight to ``cognee.remember``. Rows are ingested
+as normal documents (so they go through the full cognify entity-extraction
+pipeline).
+
+The first run is a full backfill; every later run fetches only objects changed
+since the last sync (``sys.updatedAt`` cursor) and propagates deletions, so
+entries you delete in Contentful disappear from memory on the next sync.
+
+────────────────────────────────────────────────────────────────────────────
+Privacy / opt-in
+────────────────────────────────────────────────────────────────────────────
+This reads the content of your Contentful space. Nothing is fetched until you
+run this script. Use a dedicated dataset so you can wipe it with a single
+``cognee.forget``.
+
+────────────────────────────────────────────────────────────────────────────
+One-time setup
+────────────────────────────────────────────────────────────────────────────
+1. Install the extra:
+
+       pip install "cognee[contentful]"      # or: uv sync --extra contentful
+
+2. In Contentful: Settings → API keys → Add API key; copy the *Content
+   Delivery API - access token* and the Space ID.
+3. Export them and your LLM key, then run:
+
+       export CONTENTFUL_SPACE_ID="..."
+       export CONTENTFUL_TOKEN="..."
+       export LLM_API_KEY="sk-..."
+       uv run python packages/connector/contentful/examples/example.py
+
+Re-run after editing/deleting an entry to see the incremental re-sync and
+forget-on-delete.
+"""
+
+import asyncio
+
+import cognee
+
+from cognee_community_connector_contentful import contentful_source
+
+
+async def main():
+    source = contentful_source()  # reads CONTENTFUL_SPACE_ID / CONTENTFUL_TOKEN
+
+    print("=== Initial sync (full backfill) ===")
+    result = await cognee.remember(
+        source,
+        dataset_name="contentful_demo",
+        primary_key="id",
+        # "merge" is required: it's what makes re-runs incremental and what
+        # makes deletions propagate via orphan cleanup. The default
+        # ("replace") would wipe the synced corpus on every run.
+        write_disposition="merge",
+        # The DLT ingestion default caps a table at 50 rows; real spaces
+        # exceed that, so lift the cap.
+        max_rows_per_table=0,
+    )
+    print(result)
+
+    answer = await cognee.recall("What do we publish about pricing?")
+    print("Recall:", answer)
+
+    print("\n=== Incremental re-sync (only changes/deletions are processed) ===")
+    result = await cognee.remember(
+        contentful_source(),
+        dataset_name="contentful_demo",
+        primary_key="id",
+        write_disposition="merge",
+        max_rows_per_table=0,
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/connector/contentful/pyproject.toml
+++ b/packages/connector/contentful/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "cognee-community-connector-contentful"
+version = "0.1.0"
+description = "Contentful data-source connector for cognee — sync your content model, entries, and assets into memory (incremental updatedAt + forget-on-delete)"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    # Requires cognee "document-mode" (DOCUMENT_SOURCE_ATTR + resolve_dlt_sources
+    # routing rows through cognify instead of the dlt-schema path), first shipped
+    # in cognee 1.4.0.
+    "cognee==1.4.0",
+    "dlt[sqlalchemy]>=1.9.0,<2",
+    "httpx>=0.27.0,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_connector_contentful"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/connector/contentful/tests/test_contentful.py
+++ b/packages/connector/contentful/tests/test_contentful.py
@@ -1,0 +1,410 @@
+"""Unit tests for the Contentful dlt connector.
+
+Three layers, all runnable in CI without a live Contentful token:
+
+* DB-free tests for field flattening, row building, and error classification.
+* Sync-strategy tests driving ``_sync`` with an in-memory fake client,
+  covering the updatedAt cursor, the per-kind id sweep, and deletions.
+* dlt-pipeline tests (fake client, temp sqlite destination) covering the
+  acceptance criteria: first-run backfill, incremental re-sync picks up only
+  changes, and deleted objects vanish from staging (forget-on-delete).
+"""
+
+from types import SimpleNamespace
+from uuid import NAMESPACE_OID, uuid5
+
+import httpx
+import pytest
+
+from cognee_community_connector_contentful.contentful import (
+    CONTENTFUL_SOURCE_NAME,
+    ContentfulClient,
+    _asset_row,
+    _changed,
+    _content_type_row,
+    _entry_row,
+    _field_text,
+    _flatten_fields,
+    _is_transient,
+    _parse_ts,
+    _sync,
+    _tombstone_row,
+    contentful_source,
+)
+
+T0 = "2026-09-01T10:00:00.000Z"  # old
+T1 = "2026-09-01T12:00:00.000Z"  # at first sync
+T2 = "2026-09-01T14:00:00.000Z"  # new change between runs
+T3 = "2026-09-01T16:00:00.000Z"  # an even later change
+
+
+def _sys(oid, ctype=None, updated=T1):
+    sysinfo = {"id": oid, "updatedAt": updated, "type": "Entry"}
+    if ctype:
+        sysinfo["contentType"] = {"sys": {"type": "Link", "linkType": "ContentType", "id": ctype}}
+    return sysinfo
+
+
+def _content_type(cid="blogPost", name="Blog Post", display="title", updated=T1):
+    return {
+        "sys": {"id": cid, "updatedAt": updated},
+        "name": name,
+        "displayField": display,
+        "fields": [
+            {"id": "title", "type": "Text", "name": "Title"},
+            {"id": "body", "type": "RichText", "name": "Body"},
+        ],
+    }
+
+
+def _entry(eid="E1", ctype="blogPost", title="Hello", updated=T1, fields=None):
+    if fields is None:
+        fields = {
+            "title": title,
+            "body": {
+                "nodeType": "document",
+                "content": [
+                    {
+                        "nodeType": "paragraph",
+                        "content": [{"nodeType": "text", "value": "Body text"}],
+                    }
+                ],
+            },
+        }
+    return {"sys": _sys(eid, ctype, updated), "fields": fields}
+
+
+def _asset(aid="A1", updated=T1, title="Hero image", url="//images.ctf.app/hero.png"):
+    return {
+        "sys": _sys(aid, updated=updated),
+        "fields": {
+            "title": title,
+            "description": "The hero",
+            "file": {"url": url, "contentType": "image/png", "fileName": "hero.png"},
+        },
+    }
+
+
+class FakeContentful:
+    """Stand-in for ContentfulClient backed by in-memory fixtures."""
+
+    def __init__(self, types=(), entries=(), assets=()):
+        self.type_items = list(types)
+        self.entry_items = list(entries)
+        self.asset_items = list(assets)
+
+    def content_types(self, skip: int = 0) -> dict:
+        return self._page(self.type_items, skip)
+
+    def entries(self, skip: int = 0) -> dict:
+        return self._page(self.entry_items, skip)
+
+    def assets(self, skip: int = 0) -> dict:
+        return self._page(self.asset_items, skip)
+
+    @staticmethod
+    def _page(items, skip):
+        batch = items[skip : skip + 200]
+        return {"items": batch, "total": len(items), "skip": skip}
+
+
+# ---------------------------------------------------------------------------
+# Field flattening / rows (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_field_text_handles_scalars_lists_and_rich_text():
+    assert _field_text("plain") == "plain"
+    assert _field_text(42) == "42"
+    assert _field_text(True) == "True"
+    assert _field_text(["a", "b"]) == "a\nb"
+    rich = {
+        "nodeType": "document",
+        "content": [
+            {
+                "nodeType": "paragraph",
+                "content": [
+                    {"nodeType": "text", "value": "one"},
+                    {"nodeType": "text", "value": "two"},
+                ],
+            }
+        ],
+    }
+    assert _field_text(rich) == "onetwo"
+
+
+def test_field_text_renders_links_as_placeholders_without_dereferencing():
+    link = {"sys": {"type": "Link", "linkType": "Entry", "id": "E9"}}
+    assert _field_text(link) == "[Entry: E9]"
+
+
+def test_flatten_fields_pairs_names_with_text():
+    fields = {"title": "Hello", "tags": ["x", "y"], "missing": None}
+    text = _flatten_fields(fields)
+    assert "title: Hello" in text
+    assert "tags:\nx\ny" in text
+    assert "missing" not in text
+
+
+def test_entry_title_uses_content_type_display_field():
+    types = {"blogPost": _content_type(cid="blogPost", display="title")}
+    entry = _entry(fields={"title": "My Post", "body": "irrelevant"})
+    assert _entry_row(entry, types)["title"] == "My Post"
+
+
+def test_entry_row_without_display_field_falls_back_to_first_text():
+    types = {"blogPost": _content_type(cid="blogPost", display=None)}
+    entry = _entry(eid="E2", fields={"body": "text body", "title": 7})
+    row = _entry_row(entry, types)
+    assert row["title"] == "text body"
+    assert row["id"] == "E2"
+
+
+def test_content_type_row_describes_fields():
+    row = _content_type_row(_content_type())
+    assert row["kind"] == "content_type"
+    assert row["id"] == "blogPost"
+    assert "title (Text)" in row["content"]
+    assert "body (RichText)" in row["content"]
+
+
+def test_asset_row_normalizes_protocol_relative_url():
+    row = _asset_row(_asset())
+    assert row["kind"] == "asset"
+    assert row["url"] == "https://images.ctf.app/hero.png"
+    assert "image/png" in row["content"]
+    assert "The hero" in row["content"]
+
+
+def test_tombstone_row_marks_deletion():
+    tomb = _tombstone_row("E1", "entry")
+    assert tomb["_deleted"] is True
+    assert tomb["kind"] == "entry"
+
+
+# ---------------------------------------------------------------------------
+# Timestamp / error classification (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ts_handles_both_suffixes():
+    assert _parse_ts("2026-09-01T12:00:00.000Z") == _parse_ts("2026-09-01T12:00:00.000+00:00")
+    assert _parse_ts("garbage") is None
+    assert _parse_ts(None) is None
+
+
+def test_changed_compares_updated_at_to_cursor():
+    assert _changed(_entry(), None) is True
+    assert _changed(_entry(updated=T2), _parse_ts(T1)) is True
+    assert _changed(_entry(updated=T0), _parse_ts(T1)) is False
+    assert _changed({"sys": {"id": "x"}}, _parse_ts(T1)) is True  # unparseable → treated as changed
+
+
+def test_is_transient_classification():
+    def status_error(code):
+        req = httpx.Request("GET", "https://cdn.contentful.com/spaces/s/entries")
+        resp = httpx.Response(code, request=req)
+        return httpx.HTTPStatusError("err", request=req, response=resp)
+
+    assert _is_transient(status_error(429)) is True
+    assert _is_transient(status_error(503)) is True
+    assert _is_transient(status_error(401)) is False
+    assert _is_transient(httpx.ReadTimeout("t")) is True
+    assert _is_transient(ValueError()) is False
+
+
+# ---------------------------------------------------------------------------
+# Sync strategies (pure, fake client)
+# ---------------------------------------------------------------------------
+
+
+def test_first_sync_yields_everything_and_records_ids():
+    client = FakeContentful(
+        types=[_content_type()],
+        entries=[_entry(eid="E1"), _entry(eid="E2", ctype="blogPost", updated=T0)],
+        assets=[_asset(aid="A1")],
+    )
+    state: dict = {}
+    rows = list(_sync(client, state))
+
+    ids = {(r["id"], r["kind"]) for r in rows}
+    assert ("blogPost", "content_type") in ids
+    assert ("E1", "entry") in ids and ("E2", "entry") in ids
+    assert ("A1", "asset") in ids
+    assert state["ids"]["entry"] == ["E1", "E2"]
+    assert _parse_ts(state["last_update"]) == _parse_ts(T1)
+
+
+def test_incremental_sync_reemits_only_changes():
+    client = FakeContentful(entries=[_entry(eid="E1", updated=T1)])
+    state: dict = {}
+    list(_sync(client, state))
+
+    # Nothing changed: nothing is re-emitted.
+    assert list(_sync(client, state)) == []
+
+    # One entry updated, one new entry appears.
+    client.entry_items = [
+        _entry(eid="E1", title="Updated", updated=T3),
+        _entry(eid="E2", title="New", updated=T2),
+    ]
+    rows = list(_sync(client, state))
+    assert sorted(r["id"] for r in rows) == ["E1", "E2"]
+    assert _parse_ts(state["last_update"]) == _parse_ts(T3)
+
+
+def test_vanished_entry_is_tombstoned():
+    client = FakeContentful(entries=[_entry(eid="E1"), _entry(eid="E2")])
+    state: dict = {}
+    list(_sync(client, state))
+
+    # E1 vanished upstream; E2 was merely updated.
+    client.entry_items = [_entry(eid="E2", updated=T2)]
+    rows = [r for r in _sync(client, state) if r.get("_deleted")]
+    assert [(r["id"], r["kind"]) for r in rows] == [("E1", "entry")]
+
+
+def test_vanished_asset_and_content_type_are_tombstoned():
+    client = FakeContentful(
+        types=[_content_type(cid="c1"), _content_type(cid="c2", name="Other")],
+        assets=[_asset(aid="A1"), _asset(aid="A2", title="Other")],
+    )
+    state: dict = {}
+    list(_sync(client, state))
+
+    client.type_items = [_content_type(cid="c1")]
+    client.asset_items = [_asset(aid="A1", updated=T2)]
+    rows = [r for r in _sync(client, state) if r.get("_deleted")]
+    assert sorted((r["id"], r["kind"]) for r in rows) == [("A2", "asset"), ("c2", "content_type")]
+
+
+# ---------------------------------------------------------------------------
+# Source wiring (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_contentful_source_declares_document_marker():
+    from cognee.tasks.ingestion.dlt_utils import document_source_tag
+
+    source = contentful_source(space_id="s", token="t")
+    assert CONTENTFUL_SOURCE_NAME == "contentful"
+    assert document_source_tag(source) == "contentful"
+
+
+def test_contentful_source_requires_space_and_token():
+    with pytest.raises(ValueError):
+        contentful_source(space_id=None, token=None, client=None)
+
+
+def test_document_data_item_tags_source():
+    from cognee.tasks.ingestion.resolve_dlt_sources import _build_document_data_item
+
+    row = SimpleNamespace(
+        row_data={
+            "id": "E1",
+            "kind": "entry",
+            "url": "",
+            "title": "Hello",
+            "content": "title: Hello",
+            "_deleted": False,
+        },
+        content_hash="abc123",
+    )
+    data_id = uuid5(NAMESPACE_OID, "E1")
+
+    item = _build_document_data_item(row, data_id, "contentful")
+
+    assert item.external_metadata["source"] == "contentful"
+    assert item.external_metadata["external_id"] == "E1"
+    assert item.data_id == data_id
+    assert item.data.startswith("# Hello")
+
+
+# ---------------------------------------------------------------------------
+# dlt pipeline: incremental merge + forget-on-delete (needs dlt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dlt_mod():
+    return pytest.importorskip("dlt")
+
+
+def _make_pipeline(dlt, tmp_path, name):
+    db_path = (tmp_path / f"{name}.db").as_posix()
+    return dlt.pipeline(
+        pipeline_name=name,
+        destination=dlt.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="contentful_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+
+
+def _read_rows(pipeline):
+    with (
+        pipeline.sql_client() as client,
+        client.execute_query("SELECT id, kind, title, content FROM contentful") as cursor,
+    ):
+        rows = cursor.fetchall()
+    return {row[0]: {"kind": row[1], "title": row[2], "content": row[3]} for row in rows}
+
+
+def test_pipeline_backfill_and_incremental_resync(dlt_mod, tmp_path):
+    client = FakeContentful(
+        types=[_content_type()],
+        entries=[_entry(eid="E1", title="Hello")],
+    )
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "contentful_resync")
+    pipeline.run(contentful_source(space_id="s", token="t", client=client))
+
+    rows = _read_rows(pipeline)
+    assert set(rows) == {"blogPost", "E1"}
+    assert rows["E1"]["title"] == "Hello"
+
+    # Incremental run: the entry is updated in place via merge upsert.
+    client.entry_items = [_entry(eid="E1", title="Updated", updated=T2)]
+    pipeline.run(contentful_source(space_id="s", token="t", client=client))
+
+    rows = _read_rows(pipeline)
+    assert set(rows) == {"blogPost", "E1"}
+    assert rows["E1"]["title"] == "Updated"
+
+
+def test_pipeline_vanished_entry_is_removed(dlt_mod, tmp_path):
+    client = FakeContentful(entries=[_entry(eid="E1"), _entry(eid="E2")])
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "contentful_forget")
+    pipeline.run(contentful_source(space_id="s", token="t", client=client))
+    assert set(_read_rows(pipeline)) == {"E1", "E2"}
+
+    # E1 vanished upstream; E2 was merely updated.
+    client.entry_items = [_entry(eid="E2", updated=T2)]
+    pipeline.run(contentful_source(space_id="s", token="t", client=client))
+
+    rows = _read_rows(pipeline)
+    assert "E1" not in rows
+    assert "E2" in rows
+
+
+def test_client_auth_and_url_shape():
+    client = ContentfulClient("space1", "tok", environment="staging")
+    assert client._base.endswith("/spaces/space1/environments/staging")
+
+    captured = {}
+
+    def fake_get(url, params, headers, timeout):
+        captured.update(url=url, params=params, headers=headers)
+        return httpx.Response(
+            200, json={"items": [], "total": 0}, request=httpx.Request("GET", url)
+        )
+
+    import httpx as httpx_mod
+
+    original = httpx_mod.get
+    httpx_mod.get = fake_get
+    try:
+        payload = client.entries(skip=0)
+    finally:
+        httpx_mod.get = original
+    assert payload == {"items": [], "total": 0}
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+    assert captured["params"]["order"] == "-sys.updatedAt"


### PR DESCRIPTION
## Summary

Implements topoteretes/cognee#4787 — a `contentful` connector under `packages/connector/contentful/`, following the shape of the existing connectors and the incremental model already established by gmail/google-drive.

- **Auth:** Content Delivery API access token (`token=` / `CONTENTFUL_TOKEN` + `space_id=` / `CONTENTFUL_SPACE_ID`, `environment` defaults to `master`); read-only
- **Ingest:** content types (the content model), entries, and assets as documents — the resource declares `cognee_document_source = "contentful"`, so rows flow through the normal cognify entity-extraction pipeline (same treatment as notion/google-drive)
- **Content model included (per the issue's note):** content types are ingested as their own documents — name, display field, and every field with its type — so entries carry their schema context in memory
- **Incremental sync:** `sys.updatedAt` cursor persisted in dlt resource state; listings fetched `order=-sys.updatedAt` and paged in full each run so the deletion sweep sees every live id
- **Forget-on-delete:** the Delivery API has no deletion feed, so — like the Confluence connector — each run diffs the per-kind id set against the previous run's (kept in resource state). Vanished objects are emitted as `_deleted` hard-delete markers, which cognee's existing `orphan_cleanup` purges from graph + vector + relational stores
- **Field flattening:** entry `fields` maps are flattened to text — scalars, lists, rich-text nodes (block-aware), and `[linkType: id]` placeholders; links are never dereferenced so editing one entry never pulls the whole linked graph
- **Robustness:** retries with backoff for 429/5xx/timeouts; protocol-relative asset URLs (`//images.ctf.app/...`) normalized to https

## Package layout (per the issue)

```
packages/connector/contentful/
├── README.md
├── cognee_community_connector_contentful/
│   ├── __init__.py
│   └── contentful.py
├── examples/example.py
├── tests/test_contentful.py
└── pyproject.toml
```

## Testing

`pytest packages/connector/contentful/tests -q` → **21 passed** (offline; Contentful API faked, dlt runs against a temp SQLite destination):

- field flattening (scalars/lists/rich-text block-aware rendering, link placeholders, name pairing)
- row builders (content-type field descriptions, display-field titles with fallback, asset URL normalization)
- sync strategies: full backfill → cursor'd re-sync, per-kind id sweeps, vanished entry/asset/content-type tombstones
- dlt pipeline against sqlite: backfill → incremental upsert → vanished-entry removal
- client wiring: URL/auth shape, document-path marker (`document_source_tag(source) == "contentful"`)

`ruff check` / `ruff format --check` clean.

## Acceptance criteria (from the issue)

- [x] A user connects via Content delivery token and selects what to ingest
- [x] Selected content is ingested and searchable in cognee (document path → cognify)
- [x] Incremental sync picks up only what changed since the last run (`sys.updatedAt` cursor)
- [x] Deleting the source upstream removes it from the graph on the next sync (id sweep + hard-delete markers)
- [x] README with setup steps and a runnable example under `examples/`
- [x] Tests covering the ingest path and the incremental cursor (content model ingested too, per the issue's "Watch out for")

Closes topoteretes/cognee#4787