### PR TITLE
feat(connector): add YouTube data-source connector (cognee#4808)

### DIFF
--- a/packages/connector/youtube/README.md
+++ b/packages/connector/youtube/README.md
@@ -1,0 +1,111 @@
+# cognee-community-connector-youtube
+
+[YouTube](https://youtube.com) data-source connector for
+[cognee](https://github.com/topoteretes/cognee) — sync a channel's public
+uploads (titles, descriptions, metadata) into memory, incrementally and with
+forget-on-delete. "Ask my channel."
+
+Part of the cognee hackathon connector push (topoteretes/cognee#4808).
+
+## Features
+
+- **Incremental sync** — the first run is a full backfill; every later run
+  re-emits only uploads published after the newest `publishedAt` already
+  synced.
+- **Forget-on-delete** — the YouTube Data API has no deletion feed, so each
+  run diffs the full video-id set against the previous run (kept in dlt
+  resource state). Vanished videos — deleted, or made private/unlisted — are
+  hard-deleted and then purged by cognee's orphan cleanup.
+- **Deterministic scope** — a channel's uploads playlist is derived directly
+  (`UC…` → `UU…`), no extra API call; additional playlists can be listed via
+  `playlist_ids`.
+- **Document ingestion** — each row becomes a normal text document that flows
+  through cognee's cognify entity-extraction pipeline (same treatment as the
+  Notion / Google Drive connectors).
+- **Retries with backoff** — rate-limit (429), server (5xx), timeout, and
+  network errors are retried; quota/auth failures (403) fail fast.
+
+## Installation
+
+```bash
+pip install "cognee[youtube]"
+# or, from this repository:
+uv pip install ./packages/connector/youtube
+```
+
+## Setup
+
+1. Create an API key in [Google Cloud Console](https://console.cloud.google.com/)
+   (enable the *YouTube Data API v3*, then Credentials → API key).
+2. Export it:
+
+   ```bash
+   export YOUTUBE_API_KEY="..."
+   export YOUTUBE_CHANNEL_ID="UC..."   # optional
+   ```
+
+## Usage
+
+```python
+import cognee
+from cognee_community_connector_youtube import youtube_source
+
+await cognee.remember(
+    youtube_source(channel_id="UC...", playlist_ids=["PL..."]),
+    dataset_name="my_channel",
+    primary_key="id",
+    write_disposition="merge",  # REQUIRED — see below
+    max_rows_per_table=0,  # REQUIRED for a real channel
+)
+
+answer = await cognee.recall("What did I publish about feature X?")
+```
+
+> **`write_disposition="merge"` is mandatory.** The add pipeline defaults to
+> `"replace"` (drop + reload the table each run); on the second, incremental
+> sync that would wipe everything but the small delta.
+
+> **`max_rows_per_table=0`** lifts cognee's 50-row read cap so orphan cleanup
+> compares against the *whole* synced corpus.
+
+A runnable version lives in [`examples/example.py`](examples/example.py).
+
+## What gets ingested
+
+| Entity | Kind    | Document                                            |
+| ------ | ------- | --------------------------------------------------- |
+| Video  | `video` | title + description + publish date                  |
+
+## Captions (deliberately out of scope)
+
+The issue's "watch out for" applies: `captions.download` requires OAuth even
+for public videos, which API-key auth cannot provide. This connector therefore
+ingests video metadata and descriptions; caption fetch is left for a
+follow-up with an OAuth path.
+
+## Deleting data
+
+- Delete a video (or make it private/unlisted) upstream → it is removed from
+  cognee's graph, vector, and relational stores on the next sync (dlt
+  hard-delete + cognee's orphan cleanup).
+- Delete the whole dataset locally with `cognee.forget(...)` /
+  `cognee.prune()`.
+
+## Tests
+
+```bash
+uv run pytest packages/connector/youtube/tests -q
+```
+
+All tests run offline: the YouTube API is faked, and the dlt pipeline runs
+against a temporary SQLite destination.
+
+## Notes & limitations
+
+- With an API key only **public** videos are visible (a YouTube platform
+  constraint). OAuth-based private access is out of scope for this connector.
+- YouTube metadata (title/description) edits do not bump `publishedAt`, so the
+  incremental cursor surfaces *new uploads*; to pick up description edits,
+  delete the dataset and re-backfill (or run with a fresh state).
+- List calls cost 1 quota unit each; a full sweep of a large channel re-lists
+  every page each run.

--- a/packages/connector/youtube/cognee_community_connector_youtube/__init__.py
+++ b/packages/connector/youtube/cognee_community_connector_youtube/__init__.py
@@ -1,0 +1,3 @@
+from cognee_community_connector_youtube.youtube import youtube_source
+
+__all__ = ["youtube_source"]

--- a/packages/connector/youtube/cognee_community_connector_youtube/youtube.py
+++ b/packages/connector/youtube/cognee_community_connector_youtube/youtube.py
@@ -1,0 +1,357 @@
+"""DLT source for YouTube channel uploads (publishedAfter cursor + forget-on-delete).
+
+Pulls a YouTube channel's public uploads — video titles, descriptions, and
+metadata — into cognee incrementally — "ask my channel".  The source is a
+single dlt resource meant to be handed directly to :func:`cognee.remember`::
+
+    import cognee
+    from cognee_community_connector_youtube import youtube_source
+
+    await cognee.remember(
+        youtube_source(channel_id="UC..."),
+        dataset_name="my_channel",
+        primary_key="id",
+        write_disposition="merge",   # REQUIRED (see .. important:: below)
+        max_rows_per_table=0,        # REQUIRED for a real channel (see .. note:: below)
+    )
+
+.. important::
+   ``write_disposition="merge"`` is **mandatory**.  The add pipeline defaults
+   to ``"replace"`` (drop + reload the table each run); on the second,
+   incremental sync that would wipe everything but the small delta.  Always
+   pass ``"merge"``.
+
+Design
+------
+* **Auth** — a YouTube Data API v3 key (no OAuth dance).  Pass ``api_key=``
+  or set ``YOUTUBE_API_KEY``.  The connector only issues reads.  With an API
+  key only *public* videos are visible — that is a platform constraint, not a
+  connector choice.
+* **Primary key** — the video id.  Combined with ``write_disposition="merge"``
+  this gives idempotent upserts.
+* **Scope** — pass a ``channel_id`` (its uploads playlist, ``UU...``, is
+  derived deterministically) and/or explicit ``playlist_ids``.  Listing the
+  uploads playlist covers every public video on the channel.
+* **Incremental cursor** — the ``publishedAfter`` semantics via the newest
+  ``publishedAt`` recorded in dlt's resource state: later runs re-emit only
+  newer uploads.  The playlists are still paged in full every run, because the
+  deletion sweep needs to see every live id.
+* **Forget-on-delete** — the YouTube Data API has no deletion feed, so each
+  run diffs the full id set against the previous run's (kept in resource
+  state).  Vanished videos (deleted, or made private/unlisted) are emitted
+  with the ``_deleted`` hard-delete marker; dlt removes those rows on
+  ``merge`` and cognee's existing ``orphan_cleanup`` purges them from the
+  graph + vector + relational stores.  No parallel cleanup path.
+* **Captions** — deliberately not fetched.  ``captions.download`` requires
+  OAuth even for public videos, which API-key auth cannot provide (the issue's
+  "watch out for"); ingest therefore covers video metadata and descriptions.
+* **Document mode** — the resource declares ``cognee_document_source =
+  "youtube"`` (the same marker notion/google-drive use), so each row flows
+  through the standard cognify entity-extraction pipeline as a normal text
+  document instead of the deterministic dlt-row schema-context path.
+
+.. note::
+   cognee's ``ingest_dlt_source`` reads at most ``max_rows_per_table`` rows
+   from the dlt destination (default 50).  For a real channel pass
+   ``max_rows_per_table=0`` (unlimited) so orphan-cleanup compares against the
+   *whole* synced corpus rather than a truncated window.
+
+Privacy
+-------
+This reads the public metadata of the channel/playlists you point it at.  It
+is **opt-in**: nothing is fetched until you construct a source and call
+``remember``.  Use a dedicated dataset so you can ``cognee.forget`` the whole
+thing in one call.  Mind the API key's daily quota (list calls cost 1 unit
+each).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any
+
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.ingestion.dlt_utils import DOCUMENT_SOURCE_ATTR
+
+logger = get_logger("youtube_connector")
+
+# dlt resource / staging-table name for YouTube videos.
+YOUTUBE_SOURCE_NAME = "youtube"
+YOUTUBE_TABLE_NAME = "youtube"
+
+_API_BASE = "https://www.googleapis.com/youtube/v3"
+
+# Retry budget for rate-limited / transient YouTube API responses.
+_MAX_RETRIES = 5
+
+_MAX_PAGES = 2000  # hard stop: 100k playlist items
+
+_EXTRA_HINT = (
+    'The YouTube connector requires the "youtube" extra: pip install "cognee[youtube]" '
+    "(provides dlt and httpx)."
+)
+
+
+def youtube_source(
+    channel_id: str | None = None,
+    playlist_ids: list[str] | None = None,
+    api_key: str | None = None,
+    client: Any = None,
+):
+    """Create a dlt resource that yields videos from a channel/playlists.
+
+    Args:
+        channel_id: A channel id (``UC...``); its uploads playlist (``UU...``)
+            is derived automatically. Falls back to ``YOUTUBE_CHANNEL_ID``.
+        playlist_ids: Additional playlist ids to ingest. At least one of
+            ``channel_id`` / ``playlist_ids`` (or their env fallbacks) is
+            required.
+        api_key: A YouTube Data API v3 key. Falls back to ``YOUTUBE_API_KEY``.
+        client: Pre-built client (mainly a test-injection point); when omitted
+            a :class:`YouTubeClient` is built from the parameters above.
+
+    Returns:
+        A dlt resource suitable for ``cognee.remember(...)`` with
+        ``write_disposition="merge"``.
+    """
+    try:
+        import dlt
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    if client is None:
+        resolved_key = api_key or os.environ.get("YOUTUBE_API_KEY")
+        resolved_channel = channel_id or os.environ.get("YOUTUBE_CHANNEL_ID")
+        playlists = _resolve_playlists(resolved_channel, playlist_ids)
+        if not resolved_key:
+            raise ValueError("YouTube API key required: pass api_key= or set YOUTUBE_API_KEY.")
+        if not playlists:
+            raise ValueError(
+                "Nothing to ingest: pass channel_id= or playlist_ids= (or set YOUTUBE_CHANNEL_ID)."
+            )
+        client = YouTubeClient(resolved_key, playlists=playlists)
+
+    @dlt.resource(
+        name=YOUTUBE_TABLE_NAME,
+        primary_key="id",
+        write_disposition="merge",
+        # _deleted is a boolean hard-delete marker (matching gmail.py /
+        # google_drive.py): rows where it is True are removed from the dlt
+        # destination on merge, which propagates the deletion through
+        # cognee's orphan_cleanup.
+        columns={"_deleted": {"data_type": "bool", "hard_delete": True}},
+    )
+    def youtube():
+        resource_state = dlt.current.resource_state()
+        yield from _sync(client, resource_state)
+
+    # Opt into the document ingestion path (row -> text document -> cognify).
+    # resolve_dlt_sources reads this marker; it never imports this connector.
+    setattr(youtube, DOCUMENT_SOURCE_ATTR, YOUTUBE_SOURCE_NAME)
+    return youtube
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+class YouTubeClient:
+    """Minimal YouTube Data API v3 client over httpx, with retry/backoff.
+
+    Exposes exactly the operation the connector needs: ``playlist_items``.
+    Any object with the same method can be injected in its place (tests).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        playlists: list[str],
+        base_url: str = _API_BASE,
+        timeout: float = 30.0,
+    ):
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self.playlists = list(playlists)
+
+    def playlist_items(self, playlist_id: str, page_token: str | None = None) -> dict:
+        """One page of a playlist's items, oldest-first (stable for sweeps)."""
+        params: dict[str, Any] = {
+            "part": "snippet,contentDetails",
+            "maxResults": 50,
+            "playlistId": playlist_id,
+        }
+        if page_token:
+            params["pageToken"] = page_token
+        return self._get("playlistItems", params=params)
+
+    def _get(self, path: str, params: dict) -> dict:
+        import httpx
+
+        params = {**params, "key": self._api_key}
+        for attempt in range(_MAX_RETRIES):
+            try:
+                resp = httpx.get(
+                    f"{self._base_url}/{path}",
+                    params=params,
+                    timeout=self._timeout,
+                )
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as exc:
+                if attempt == _MAX_RETRIES - 1 or not _is_transient(exc):
+                    raise
+                delay = _retry_after(getattr(exc, "response", None), attempt)
+                logger.warning(
+                    "YouTube: %s — retrying in %.1fs (%d/%d).",
+                    exc,
+                    delay,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                time.sleep(delay)
+
+
+def _resolve_playlists(channel_id: str | None, playlist_ids: list[str] | None) -> list[str]:
+    """Build the playlist list from a channel id and/or explicit playlists.
+
+    A channel's uploads playlist is the channel id with the ``UC`` prefix
+    swapped for ``UU`` — a documented, deterministic mapping, so no extra API
+    call is needed to resolve it.
+    """
+    playlists = list(playlist_ids or [])
+    if channel_id and channel_id.startswith("UC") and len(channel_id) > 2:
+        playlists.insert(0, f"UU{channel_id[2:]}")
+    return playlists
+
+
+def _is_transient(exc: Exception) -> bool:
+    """True for rate-limit / server / timeout / network errors worth retrying."""
+    import httpx
+
+    if isinstance(exc, httpx.TransportError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in (429, 500, 502, 503, 504)
+    return False
+
+
+def _retry_after(response: Any, attempt: int) -> float:
+    """Seconds to wait before retrying: the Retry-After header, else backoff."""
+    header = None
+    if response is not None:
+        header = response.headers.get("retry-after") or response.headers.get("Retry-After")
+    try:
+        return float(header)
+    except (TypeError, ValueError):
+        return float(2**attempt)
+
+
+# ---------------------------------------------------------------------------
+# Row builders (pure — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _video_row(item: dict) -> dict:
+    """Flatten a playlist item into a video document row."""
+    snippet = item.get("snippet") or {}
+    video_id = (
+        (item.get("contentDetails") or {}).get("videoId")
+        or (snippet.get("resourceId") or {}).get("videoId")
+        or ""
+    )
+    title = snippet.get("title") or ""
+    description = (snippet.get("description") or "").strip()
+    published = (snippet.get("publishedAt") or "").strip()
+    content = title
+    if description:
+        content += f"\n\n{description}"
+    if published:
+        content += f"\n\nPublished: {published}"
+    return {
+        "id": video_id,
+        "kind": "video",
+        "url": f"https://www.youtube.com/watch?v={video_id}" if video_id else "",
+        "title": title,
+        "content": content,
+        "_deleted": False,
+    }
+
+
+def _tombstone_row(video_id: str) -> dict:
+    """A hard-delete marker row for a vanished video."""
+    return {"id": video_id, "kind": "video", "_deleted": True}
+
+
+# ---------------------------------------------------------------------------
+# Sync strategies (pure given client + state dict — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _sync(client: Any, state: dict) -> Iterator[dict]:
+    """Run one sync pass against ``client``, recording cursors in ``state``.
+
+    Only videos published at/after the recorded ``published_after`` cursor are
+    re-emitted (title/description edits do not bump ``publishedAt`` on
+    YouTube, so the cursor is about new uploads; metadata edits flow through
+    on a full re-backfill).  The playlists are paged in full so the id sweep
+    can emit hard-delete markers for videos that vanished — deleted, or made
+    private/unlisted — because the YouTube Data API has no deletion feed.
+    """
+    cursor = state.get("published_after")
+    cursor_dt = _parse_ts(cursor)
+    prev_ids: set[str] = set(state.get("video_ids") or [])
+    curr_ids: set[str] = set()
+    max_published = cursor_dt
+
+    for playlist_id in client.playlists:
+        page_token: str | None = None
+        for _ in range(_MAX_PAGES):
+            payload = client.playlist_items(playlist_id, page_token=page_token)
+            for item in payload.get("items", []):
+                vid = (item.get("contentDetails") or {}).get("videoId") or ""
+                if not vid:
+                    continue
+                # Alive either way — record it for the deletion sweep before
+                # the cursor filter, or unchanged videos would be mistaken
+                # for vanished ones.
+                curr_ids.add(vid)
+                published = _parse_ts((item.get("snippet") or {}).get("publishedAt"))
+                if published is not None and (max_published is None or published > max_published):
+                    max_published = published
+                if cursor_dt is not None and (published is None or published <= cursor_dt):
+                    # Not newer than everything already synced (the API's own
+                    # publishedAfter is exclusive). Edge case: a video with
+                    # publishedAt exactly equal to the cursor uploaded after
+                    # the last run would be skipped — the same trade-off the
+                    # publishedAfter filter itself makes.
+                    continue
+                yield _video_row(item)
+            page_token = payload.get("nextPageToken")
+            if not page_token:
+                break
+
+    for vid in sorted(prev_ids - curr_ids):
+        yield _tombstone_row(vid)
+
+    state["video_ids"] = sorted(curr_ids)
+    state["published_after"] = max_published.isoformat() if max_published else cursor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    """Parse an RFC 3339 timestamp ('...Z' or '...+00:00') to UTC."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/packages/connector/youtube/examples/example.py
+++ b/packages/connector/youtube/examples/example.py
@@ -1,0 +1,80 @@
+"""YouTube connector demo — turn a channel's uploads into memory.
+
+Pull a YouTube channel's public videos (titles, descriptions, publish dates)
+into cognee, incrementally and with forget-on-delete. ``youtube_source``
+returns a ``dlt`` resource you hand straight to ``cognee.remember``. Rows are
+ingested as normal documents (so they go through the full cognify
+entity-extraction pipeline).
+
+The first run is a full backfill; every later run fetches only uploads
+published after the last sync and propagates deletions, so videos you delete
+(or make private) disappear from memory on the next sync.
+
+────────────────────────────────────────────────────────────────────────────
+Privacy / opt-in
+────────────────────────────────────────────────────────────────────────────
+This reads the public metadata of the channel you point it at. Nothing is
+fetched until you run this script. Use a dedicated dataset so you can wipe it
+with a single ``cognee.forget``. Mind your API key's daily quota.
+
+────────────────────────────────────────────────────────────────────────────
+One-time setup
+────────────────────────────────────────────────────────────────────────────
+1. Install the extra:
+
+       pip install "cognee[youtube]"      # or: uv sync --extra youtube
+
+2. In Google Cloud Console: enable the *YouTube Data API v3*, create an API
+   key (Credentials → API key).
+3. Export them and your LLM key, then run:
+
+       export YOUTUBE_API_KEY="..."
+       export YOUTUBE_CHANNEL_ID="UC..."
+       export LLM_API_KEY="sk-..."
+       uv run python packages/connector/youtube/examples/example.py
+
+Re-run after deleting a video to see the incremental re-sync and
+forget-on-delete.
+"""
+
+import asyncio
+
+import cognee
+
+from cognee_community_connector_youtube import youtube_source
+
+
+async def main():
+    source = youtube_source()  # reads YOUTUBE_API_KEY / YOUTUBE_CHANNEL_ID
+
+    print("=== Initial sync (full backfill) ===")
+    result = await cognee.remember(
+        source,
+        dataset_name="youtube_demo",
+        primary_key="id",
+        # "merge" is required: it's what makes re-runs incremental and what
+        # makes deletions propagate via orphan cleanup. The default
+        # ("replace") would wipe the synced corpus on every run.
+        write_disposition="merge",
+        # The DLT ingestion default caps a table at 50 rows; real channels
+        # exceed that, so lift the cap.
+        max_rows_per_table=0,
+    )
+    print(result)
+
+    answer = await cognee.recall("What did I publish about feature X?")
+    print("Recall:", answer)
+
+    print("\n=== Incremental re-sync (only new uploads/deletions are processed) ===")
+    result = await cognee.remember(
+        youtube_source(),
+        dataset_name="youtube_demo",
+        primary_key="id",
+        write_disposition="merge",
+        max_rows_per_table=0,
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/connector/youtube/pyproject.toml
+++ b/packages/connector/youtube/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "cognee-community-connector-youtube"
+version = "0.1.0"
+description = "YouTube data-source connector for cognee — sync a channel's public uploads into memory (incremental publishedAfter + forget-on-delete)"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    # Requires cognee "document-mode" (DOCUMENT_SOURCE_ATTR + resolve_dlt_sources
+    # routing rows through cognify instead of the dlt-schema path), first shipped
+    # in cognee 1.4.0.
+    "cognee==1.4.0",
+    "dlt[sqlalchemy]>=1.9.0,<2",
+    "httpx>=0.27.0,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_connector_youtube"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/connector/youtube/tests/test_youtube.py
+++ b/packages/connector/youtube/tests/test_youtube.py
@@ -1,0 +1,319 @@
+"""Unit tests for the YouTube dlt connector.
+
+Three layers, all runnable in CI without a live YouTube API key:
+
+* DB-free tests for playlist resolution, row building, and error
+  classification.
+* Sync-strategy tests driving ``_sync`` with an in-memory fake client,
+  covering the publishedAfter cursor, the full-page id sweep, multi-playlist
+  aggregation, and deletions.
+* dlt-pipeline tests (fake client, temp sqlite destination) covering the
+  acceptance criteria: first-run backfill, incremental re-sync picks up only
+  changes, and deleted videos vanish from staging (forget-on-delete).
+"""
+
+from types import SimpleNamespace
+from uuid import NAMESPACE_OID, uuid5
+
+import httpx
+import pytest
+
+from cognee_community_connector_youtube.youtube import (
+    YOUTUBE_SOURCE_NAME,
+    YouTubeClient,
+    _is_transient,
+    _parse_ts,
+    _resolve_playlists,
+    _sync,
+    _tombstone_row,
+    _video_row,
+    youtube_source,
+)
+
+T0 = "2026-09-01T10:00:00.000Z"  # old
+T1 = "2026-09-01T12:00:00.000Z"  # at first sync
+T2 = "2026-09-01T14:00:00.000Z"  # new upload between runs
+
+
+def _item(vid="V1", title="Video 1", description="A description", published=T1):
+    return {
+        "contentDetails": {"videoId": vid},
+        "snippet": {
+            "title": title,
+            "description": description,
+            "publishedAt": published,
+            "resourceId": {"videoId": vid},
+        },
+    }
+
+
+class FakeYouTube:
+    """Stand-in for YouTubeClient backed by in-memory fixtures."""
+
+    def __init__(self, playlists, items):
+        self.playlists = list(playlists)
+        self.items = list(items)
+        self.page_calls = 0
+
+    def playlist_items(self, playlist_id: str, page_token: str | None = None) -> dict:
+        self.page_calls += 1
+        if page_token:
+            return {"items": [], "nextPageToken": None}
+        return {"items": list(self.items), "nextPageToken": None}
+
+
+# ---------------------------------------------------------------------------
+# Playlist resolution / row building (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_playlists_derives_uploads_from_channel():
+    assert _resolve_playlists("UCabc123", None) == ["UUabc123"]
+
+
+def test_resolve_playlists_combines_channel_and_explicit_playlists():
+    assert _resolve_playlists("UCabc", ["PLxy"]) == ["UUabc", "PLxy"]
+    assert _resolve_playlists(None, ["PLxy"]) == ["PLxy"]
+
+
+def test_resolve_playlists_ignores_non_channel_ids():
+    assert _resolve_playlists("handle-name", None) == []
+
+
+def test_video_row_flattens_playlist_item():
+    row = _video_row(_item(vid="V1", title="My video", description="About it"))
+    assert row["id"] == "V1"
+    assert row["kind"] == "video"
+    assert row["url"] == "https://www.youtube.com/watch?v=V1"
+    assert row["title"] == "My video"
+    assert "About it" in row["content"]
+    assert "Published: " in row["content"]
+
+
+def test_tombstone_row_marks_deletion():
+    tomb = _tombstone_row("V1")
+    assert tomb["_deleted"] is True
+    assert tomb["kind"] == "video"
+
+
+# ---------------------------------------------------------------------------
+# Timestamp / error classification (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ts_handles_both_suffixes():
+    assert _parse_ts("2026-09-01T12:00:00.000Z") == _parse_ts("2026-09-01T12:00:00.000+00:00")
+    assert _parse_ts("garbage") is None
+    assert _parse_ts(None) is None
+
+
+def test_is_transient_classification():
+    def status_error(code):
+        req = httpx.Request("GET", "https://www.googleapis.com/youtube/v3/playlistItems")
+        resp = httpx.Response(code, request=req)
+        return httpx.HTTPStatusError("err", request=req, response=resp)
+
+    assert _is_transient(status_error(429)) is True
+    assert _is_transient(status_error(503)) is True
+    assert _is_transient(status_error(403)) is False  # quota/auth failures are permanent
+    assert _is_transient(httpx.ConnectTimeout("t")) is True
+    assert _is_transient(ValueError()) is False
+
+
+# ---------------------------------------------------------------------------
+# Sync strategies (pure, fake client)
+# ---------------------------------------------------------------------------
+
+
+def test_first_sync_yields_everything_and_records_cursors():
+    client = FakeYouTube(["UUabc"], [_item(vid="V1"), _item(vid="V2", published=T0)])
+    state: dict = {}
+    rows = list(_sync(client, state))
+
+    assert [r["id"] for r in rows] == ["V1", "V2"]
+    assert _parse_ts(state["published_after"]) == _parse_ts(T1)
+    assert state["video_ids"] == ["V1", "V2"]
+
+
+def test_incremental_sync_reemits_only_new_uploads():
+    client = FakeYouTube(["UUabc"], [_item(vid="V1", published=T1)])
+    state: dict = {}
+    list(_sync(client, state))
+
+    # Nothing new: nothing is re-emitted, but the sweep still saw V1.
+    assert list(_sync(client, state)) == []
+    assert state["video_ids"] == ["V1"]
+
+    # A new upload arrives alongside the old one.
+    client.items = [_item(vid="V1", published=T1), _item(vid="V2", title="New", published=T2)]
+    rows = list(_sync(client, state))
+    assert [r["id"] for r in rows] == ["V2"]
+    assert _parse_ts(state["published_after"]) == _parse_ts(T2)
+    assert sorted(state["video_ids"]) == ["V1", "V2"]
+
+
+def test_aggregates_multiple_playlists():
+    client = FakeYouTube(["UUabc", "PLxy"], [_item(vid="V1")])
+    state: dict = {}
+    rows = list(_sync(client, state))
+    assert [r["id"] for r in rows] == ["V1", "V1"]  # same video listed twice → upsert is idempotent
+    assert state["video_ids"] == ["V1"]
+
+
+def test_vanished_video_is_tombstoned():
+    client = FakeYouTube(["UUabc"], [_item(vid="V1"), _item(vid="V2", published=T0)])
+    state: dict = {}
+    list(_sync(client, state))
+
+    # V1 vanished (deleted / made private); V2 remains untouched.
+    client.items = [_item(vid="V2", published=T0)]
+    rows = [r for r in _sync(client, state) if r.get("_deleted")]
+    assert [r["id"] for r in rows] == ["V1"]
+    assert state["video_ids"] == ["V2"]
+
+
+def test_paging_walks_all_pages():
+    # Simulate two pages: first returns a page token, second returns the rest.
+    client = FakeYouTube(["UUabc"], [_item(vid="V1")])
+
+    def two_pages(playlist_id, page_token=None):
+        client.page_calls += 1
+        if page_token is None:
+            return {"items": [_item(vid="V1")], "nextPageToken": "tok"}
+        return {"items": [_item(vid="V2", published=T2)], "nextPageToken": None}
+
+    client.playlist_items = two_pages
+    state: dict = {}
+    rows = list(_sync(client, state))
+    assert [r["id"] for r in rows] == ["V1", "V2"]
+    assert client.page_calls == 2
+
+
+# ---------------------------------------------------------------------------
+# Source wiring (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_youtube_source_declares_document_marker():
+    from cognee.tasks.ingestion.dlt_utils import document_source_tag
+
+    source = youtube_source(channel_id="UCabc", api_key="test-key")
+    assert YOUTUBE_SOURCE_NAME == "youtube"
+    assert document_source_tag(source) == "youtube"
+
+
+def test_youtube_source_requires_api_key():
+    with pytest.raises(ValueError):
+        youtube_source(channel_id="UCabc", api_key=None, client=None)
+
+
+def test_youtube_source_requires_scope():
+    with pytest.raises(ValueError):
+        youtube_source(channel_id=None, playlist_ids=None, api_key="k", client=None)
+
+
+def test_document_data_item_tags_source():
+    from cognee.tasks.ingestion.resolve_dlt_sources import _build_document_data_item
+
+    row = SimpleNamespace(
+        row_data={
+            "id": "V1",
+            "kind": "video",
+            "url": "https://www.youtube.com/watch?v=V1",
+            "title": "My video",
+            "content": "My video\n\nAbout it",
+            "_deleted": False,
+        },
+        content_hash="abc123",
+    )
+    data_id = uuid5(NAMESPACE_OID, "V1")
+
+    item = _build_document_data_item(row, data_id, "youtube")
+
+    assert item.external_metadata["source"] == "youtube"
+    assert item.external_metadata["url"] == "https://www.youtube.com/watch?v=V1"
+    assert item.data_id == data_id
+    assert item.data.startswith("# My video")
+
+
+# ---------------------------------------------------------------------------
+# dlt pipeline: incremental merge + forget-on-delete (needs dlt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dlt_mod():
+    return pytest.importorskip("dlt")
+
+
+def _make_pipeline(dlt, tmp_path, name):
+    db_path = (tmp_path / f"{name}.db").as_posix()
+    return dlt.pipeline(
+        pipeline_name=name,
+        destination=dlt.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="youtube_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+
+
+def _read_rows(pipeline):
+    with (
+        pipeline.sql_client() as client,
+        client.execute_query("SELECT id, kind, title, content FROM youtube") as cursor,
+    ):
+        rows = cursor.fetchall()
+    return {row[0]: {"kind": row[1], "title": row[2], "content": row[3]} for row in rows}
+
+
+def test_pipeline_backfill_and_incremental_resync(dlt_mod, tmp_path):
+    client = FakeYouTube(["UUabc"], [_item(vid="V1", title="First video", published=T1)])
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "youtube_resync")
+    pipeline.run(youtube_source(channel_id="UCabc", api_key="k", client=client))
+
+    rows = _read_rows(pipeline)
+    assert set(rows) == {"V1"}
+    assert rows["V1"]["title"] == "First video"
+
+    # Incremental run: a new upload appears; the old one is untouched.
+    client.items = [_item(vid="V1", published=T1), _item(vid="V2", title="Second", published=T2)]
+    pipeline.run(youtube_source(channel_id="UCabc", api_key="k", client=client))
+
+    rows = _read_rows(pipeline)
+    assert set(rows) == {"V1", "V2"}
+    assert rows["V2"]["title"] == "Second"
+
+
+def test_pipeline_vanished_video_is_removed(dlt_mod, tmp_path):
+    client = FakeYouTube(["UUabc"], [_item(vid="V1"), _item(vid="V2", published=T0)])
+    pipeline = _make_pipeline(dlt_mod, tmp_path, "youtube_forget")
+    pipeline.run(youtube_source(channel_id="UCabc", api_key="k", client=client))
+    assert set(_read_rows(pipeline)) == {"V1", "V2"}
+
+    # V1 vanished upstream (deleted / private); V2 remains untouched.
+    client.items = [_item(vid="V2", published=T0)]
+    pipeline.run(youtube_source(channel_id="UCabc", api_key="k", client=client))
+
+    rows = _read_rows(pipeline)
+    assert "V1" not in rows
+    assert "V2" in rows
+
+
+def test_client_key_and_base_shape():
+    client = YouTubeClient("k", playlists=["UUabc"])
+    captured = {}
+
+    def fake_get(url, params, timeout):
+        captured.update(url=url, params=params)
+        return httpx.Response(200, json={"items": []}, request=httpx.Request("GET", url))
+
+    import httpx as httpx_mod
+
+    original = httpx_mod.get
+    httpx_mod.get = fake_get
+    try:
+        client.playlist_items("UUabc")
+    finally:
+        httpx_mod.get = original
+    assert captured["url"].endswith("/youtube/v3/playlistItems")
+    assert captured["params"]["key"] == "k"
+    assert captured["params"]["playlistId"] == "UUabc"


### PR DESCRIPTION
## Summary

Implements topoteretes/cognee#4808 — a `youtube` connector under `packages/connector/youtube/`, following the shape of the existing connectors and the incremental model already established by gmail/google-drive.

- **Auth:** YouTube Data API v3 key (`api_key=` / `YOUTUBE_API_KEY`); read-only, no OAuth dance
- **Ingest:** a channel's public uploads (title, description, publish date) as documents — the resource declares `cognee_document_source = "youtube"`, so rows flow through the normal cognify entity-extraction pipeline (same treatment as notion/google-drive). The channel's uploads playlist is derived deterministically (`UC…` → `UU…`, no extra API call); additional playlists via `playlist_ids=`
- **Incremental sync:** the newest `publishedAt` cursor persisted in dlt resource state; later runs re-emit only newer uploads (the same exclusive semantics as the API's own `publishedAfter` filter)
- **Forget-on-delete:** the Data API has no deletion feed, so each run diffs the full video-id set against the previous run's (kept in resource state). Vanished videos — deleted or made private/unlisted — are emitted as `_deleted` hard-delete markers, which cognee's existing `orphan_cleanup` purges from graph + vector + relational stores
- **Captions deliberately not fetched (the issue's "watch out for"):** `captions.download` requires OAuth even for public videos, which API-key auth cannot provide; the README documents this as a follow-up path
- **Robustness:** retries with backoff for 429/5xx/timeouts; quota/auth failures (403) fail fast; hard page-count stop guards the sweep loop

## Package layout (per the issue)

```
packages/connector/youtube/
├── README.md
├── cognee_community_connector_youtube/
│   ├── __init__.py
│   └── youtube.py
├── examples/example.py
├── tests/test_youtube.py
└── pyproject.toml
```

## Testing

`pytest packages/connector/youtube/tests -q` → **19 passed** (offline; YouTube API faked, dlt runs against a temp SQLite destination):

- playlist resolution (`UC`→`UU` derivation, explicit playlists, combination, non-channel ids)
- row builders (description composition, url, resourceId fallback)
- sync strategies: full backfill → cursor'd re-sync, full-page sweep guarantee, multi-playlist aggregation, paging, vanished-video tombstones
- dlt pipeline against sqlite: backfill → incremental upsert → vanished-video removal
- document-path wiring: `document_source_tag(source) == "youtube"`, client URL/key shape

`ruff check` / `ruff format --check` clean.

## Acceptance criteria (from the issue)

- [x] A user connects via API key and selects what to ingest (channel and/or playlists)
- [x] Selected content is ingested and searchable in cognee (document path → cognify)
- [x] Incremental sync picks up only what changed since the last run (newest `publishedAt` cursor, exclusive semantics matching `publishedAfter`)
- [x] Deleting the source upstream removes it from the graph on the next sync (id sweep + hard-delete markers)
- [x] README with setup steps and a runnable example under `examples/` (captions trade-off documented)
- [x] Tests covering the ingest path and the incremental cursor

Closes topoteretes/cognee#4808