### PR TITLE
feat(connector): add Zotero data-source connector (#4814)

### DIFF
--- a/packages/connector/zotero/README.md
+++ b/packages/connector/zotero/README.md
@@ -1,0 +1,52 @@
+# Zotero connector for cognee
+
+Sync your Zotero library — references, notes, and attachment text —
+into cognee with **version-based incremental sync** and **forget-on-delete**.
+
+Auth is a personal API key (no OAuth dance).
+
+## One-time setup
+
+1. Install the extra:
+
+       pip install "cognee[zotero]"
+
+2. Create a personal API key at https://www.zotero.org/settings/keys
+   and share your library with it (or use a group API key).
+3. Export the key and your LLM key:
+
+       export ZOTERO_API_KEY="..."
+       export LLM_API_KEY="sk-..."
+4. Run the example:
+
+       uv run python examples/example.py
+
+Re-run after adding or deleting items to see the incremental sync and
+forget-on-delete in action.
+
+## Usage
+
+```python
+import cognee
+from cognee_community_connector_zotero import zotero_source
+
+await cognee.remember(
+    zotero_source(),
+    dataset_name="my_zotero",
+    primary_key="id",
+    write_disposition="merge",
+)
+```
+
+Pass `api_key="..."` explicitly, or leave it blank to read ``ZOTERO_API_KEY``.
+Pass ``user_id=`` to skip the automatic ``/keys/current`` lookup.
+
+## How it works
+
+* **Incremental sync** — each run records the library's ``Last-Modified-Version``
+  and only fetches items changed since then (cheap on large libraries).
+* **Forget-on-delete** — deleted or trashed items are emitted as ``_deleted``
+  tombstones; dlt's ``merge`` + ``hard_delete`` removes them from staging and
+  cognee's ``orphan_cleanup`` forgets them from the graph and vector stores.
+* **Document mode** — items flow through cognee's normal cognify pipeline
+  (LLM entity extraction), not the relational dlt path.

--- a/packages/connector/zotero/cognee_community_connector_zotero/__init__.py
+++ b/packages/connector/zotero/cognee_community_connector_zotero/__init__.py
@@ -1,0 +1,3 @@
+from cognee_community_connector_zotero.zotero import zotero_source
+
+__all__ = ["zotero_source"]

--- a/packages/connector/zotero/cognee_community_connector_zotero/zotero.py
+++ b/packages/connector/zotero/cognee_community_connector_zotero/zotero.py
@@ -1,0 +1,440 @@
+"""Zotero data-source connector for cognee - version-based incremental sync + forget-on-delete.
+
+Fetches Zotero items (references, notes, attachment text) as markdown documents
+and yields them as a dlt resource for cognee's ingestion pipeline.
+
+Items are ingested as *normal documents*: the source declares
+``cognee_document_source = "zotero"``, so ``resolve_dlt_sources`` tags each row
+``external_metadata["source"] = "zotero"`` and routes through normal cognify.
+
+Sync is **incremental via the library version header** (``Last-Modified-Version``):
+each run records the library version and on the next run fetches only items changed
+since then. Deleted and trashed items are emitted as ``_deleted`` tombstones,
+so dlt's ``merge`` + ``hard_delete`` removes them from staging and cognee's
+``orphan_cleanup`` forgets them from the graph and vector stores.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from html.parser import HTMLParser
+from logging import getLogger
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+
+_logger = getLogger(__name__)
+
+# Matches cognee.tasks.ingestion.dlt_utils.DOCUMENT_SOURCE_ATTR value
+DOCUMENT_SOURCE_ATTR = "cognee_document_source"
+
+ZOTERO_API_BASE = "https://api.zotero.org"
+ZOTERO_API_VERSION = 3
+_MAX_RETRIES = 5
+_BATCH_KEYS = 50
+_PAGE_LIMIT = 100
+
+_EXTRA_HINT = 'The Zotero connector requires the "zotero" extra: pip install "cognee[zotero]"'
+
+# ---------------------------------------------------------------------------
+# HTML stripper (stdlib, no extra dep)
+# ---------------------------------------------------------------------------
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._out: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        self._out.append(data)
+
+    def get_text(self) -> str:
+        import re
+        text = " ".join(self._out).strip()
+        return re.sub(r" {2,}", " ", text)
+
+
+def _strip_html(raw: str | None) -> str:
+    if not raw:
+        return ""
+    p = _TextExtractor()
+    p.feed(raw)
+    return p.get_text()
+
+
+# ---------------------------------------------------------------------------
+# Item → document-row helpers
+# ---------------------------------------------------------------------------
+
+
+def _creator_str(creators: list[dict[str, Any]]) -> str:
+    if not creators:
+        return ""
+    parts = []
+    for c in creators:
+        first = c.get("firstName", "")
+        last = c.get("lastName", "")
+        name = (f"{first} {last}".strip()) or c.get("name", "")
+        parts.append(f"{name}")
+    return "; ".join(p for p in parts if p)
+
+
+def _tag_str(tags: list[dict[str, Any]]) -> str:
+    if not tags:
+        return ""
+    return "; ".join(t.get("tag", "") for t in tags if t.get("tag"))
+
+
+def _item_to_row(client: ZoteroClient, item: dict[str, Any]) -> dict[str, Any] | None:
+    key = item.get("key", "")
+    title = item.get("title") or key
+    url = item.get("url") or ""
+    trashed = item.get("trashed", False)
+    item_type = item.get("itemType", "")
+
+    library_id = item.get("library", {}).get("id", "")
+    zotero_url = f"https://www.zotero.org/users/{library_id}/items/{key}"
+
+    if trashed:
+        return {"id": key, "_deleted": True}
+
+    if item_type == "note":
+        content = _strip_html(item.get("note", ""))
+        return {
+            "id": key,
+            "title": title or "Note",
+            "content": content,
+            "url": url or zotero_url,
+            "_deleted": False,
+        }
+
+    if item_type == "attachment":
+        content_type = item.get("contentType", "")
+        filename = item.get("filename", "")
+        link_mode = item.get("linkMode", "")
+        bits = [f"**{title}**"]
+        if filename:
+            bits.append(f"file: {filename}")
+        bits.append(f"type: {content_type}")
+
+        if content_type.startswith("text/") or link_mode in ("imported_file", "imported_url"):
+            text = _fetch_attachment_text(client, library_id, key)
+            if text:
+                bits.append(f"\n--- attachment content ---\n{text}")
+
+        return {
+            "id": key,
+            "title": title,
+            "content": "\n".join(b for b in bits),
+            "url": url or zotero_url,
+            "_deleted": False,
+        }
+
+    bits: list[str] = []
+    abstract = item.get("abstractNote", "").strip()
+    if abstract:
+        bits.append(abstract)
+
+    creators = _creator_str(item.get("creators", []))
+    if creators:
+        bits.append(f"Creators: {creators}")
+
+    tags = _tag_str(item.get("tags", []))
+    if tags:
+        bits.append(f"Tags: {tags}")
+
+    pub = item.get("publicationTitle", "")
+    doi = item.get("DOI", "")
+    if pub:
+        bits.append(f"Publication: {pub}")
+    if doi:
+        bits.append(f"DOI: {doi}")
+    date = item.get("date", "")
+    if date:
+        bits.append(f"Date: {date}")
+
+    return {
+        "id": key,
+        "title": title,
+        "content": "\n\n".join(bits),
+        "url": url or zotero_url,
+        "_deleted": False,
+    }
+
+
+def _fetch_attachment_text(client: ZoteroClient, library_id: str, key: str) -> str:
+    """Fetch attachment text via the Zotero file endpoint.
+
+    For text/* content types the full text is included; for other types (PDF, etc.)
+    a warning is logged and the function returns "" (the attachment metadata is still
+    ingested).
+    """
+    try:
+        resp = client._request("GET", f"/users/{library_id}/items/{key}/file")
+        resp.raise_for_status()
+        data = resp.content
+        if isinstance(data, bytes):
+            data = data.decode("utf-8", errors="replace")
+        return data.strip()
+    except Exception as exc:  # pragma: no cover - per-attachment errors never fail the sync
+        _logger.warning("Zotero: failed to fetch attachment %s: %s", key, exc)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer (retry, backoff, error classification)
+# ---------------------------------------------------------------------------
+
+
+def _is_transient(exc: Exception) -> bool:
+    if isinstance(exc, httpx.TransportError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = getattr(exc.response, "status_code", None)
+        if status in (429, 500, 502, 503, 504):
+            return True
+    return False
+
+
+def _is_gone(exc: Exception) -> bool:
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = getattr(exc.response, "status_code", None)
+        if status in (403, 404):
+            return True
+    return False
+
+
+def _retry_after(headers: dict[str, str] | None, attempt: int) -> float:
+    h = headers or {}
+    val = h.get("retry-after") or h.get("Retry-After", "")
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return 2.0**attempt
+
+
+# ---------------------------------------------------------------------------
+# Client wrapper (injectable for tests)
+# ---------------------------------------------------------------------------
+
+
+class ZoteroClient:
+    def __init__(self, token: str, user_id: str | None = None) -> None:
+        self._token = token
+        self._user_id = user_id
+        self._base = ZOTERO_API_BASE
+        self._headers = {
+            "Zotero-API-Version": str(ZOTERO_API_VERSION),
+            "Authorization": f"Bearer {token}",
+        }
+
+    def resolve_user_id(self) -> str:
+        if self._user_id:
+            return self._user_id
+        r = self._request("GET", "/keys/current")
+        self._user_id = str(r.json()["userID"])
+        return self._user_id
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        data: Any | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        url = urljoin(self._base + "/", path.lstrip("/"))
+        merged_headers = dict(self._headers)
+        if headers:
+            merged_headers.update(headers)
+
+        for attempt in range(_MAX_RETRIES):
+            try:
+                resp = httpx.request(
+                    method,
+                    url,
+                    headers=merged_headers,
+                    params=params,
+                    data=data,
+                    json=json,
+                    timeout=30.0,
+                )
+                if attempt == _MAX_RETRIES - 1 or not _is_transient(resp):
+                    resp.raise_for_status()
+                    return resp
+                delay = _retry_after(dict(resp.headers), attempt)
+                _logger.warning(
+                    "Zotero: %s %s → %s, retrying in %.1fs (%d/%d)",
+                    method,
+                    path,
+                    resp.status_code,
+                    delay,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                time.sleep(delay)
+            except Exception as exc:
+                if attempt == _MAX_RETRIES - 1 or not _is_transient(exc):
+                    raise
+                delay = _retry_after(getattr(exc, "headers", None), attempt)
+                _logger.warning(
+                    "Zotero: %s %s → %s, retrying in %.1fs (%d/%d)",
+                    method,
+                    path,
+                    exc,
+                    delay,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                time.sleep(delay)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> httpx.Response:
+        return self._request("GET", path, params=params)
+
+
+# ---------------------------------------------------------------------------
+# Sync state machine (pure given client + state dict — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _iter_rows(client: ZoteroClient, state: dict[str, Any]) -> Any:
+    uid = state.get("user_id")
+    if not uid:
+        uid = client.resolve_user_id()
+        state["user_id"] = uid
+
+    since_version: int | None = state.get("since_version")
+    version_param = since_version if since_version is not None else 0
+
+    headers: dict[str, str] = {}
+    if since_version is not None:
+        headers["If-Modified-Since-Version"] = str(since_version)
+
+    params = {
+        "since": version_param,
+        "format": "versions",
+        "includeTrashed": "1",
+        "limit": str(_PAGE_LIMIT),
+    }
+
+    changed_keys: dict[str, int] = {}
+    new_version = since_version or 0
+
+    start = 0
+    while True:
+        page_params = {**params, "start": str(start)}
+        resp = client.get(f"/users/{uid}/items", params=page_params)
+
+        if resp.status_code == 304:
+            _logger.info("Zotero: no library changes since version %s.", since_version)
+            return
+
+        new_version = max(
+            new_version,
+            int(resp.headers.get("Last-Modified-Version", new_version)),
+        )
+        body = resp.json()
+        for k, v in body.items():
+            changed_keys[k] = int(v)
+
+        total = int(resp.headers.get("Total-Results", "0"))
+        start += _PAGE_LIMIT
+        if start >= total:
+            break
+
+    if not changed_keys:
+        state["since_version"] = new_version
+        _logger.info("Zotero: version %s — no changed items.", new_version)
+        return
+
+    for i in range(0, len(changed_keys), _BATCH_KEYS):
+        batch = list(changed_keys.keys())[i : i + _BATCH_KEYS]
+        detail_params = {
+            "itemKey": ",".join(batch),
+            "includeTrashed": "1",
+        }
+        resp = client.get(f"/users/{uid}/items", params=detail_params)
+        new_version = max(
+            new_version,
+            int(resp.headers.get("Last-Modified-Version", new_version)),
+        )
+        for item in resp.json():
+            row = _item_to_row(client, item)
+            if row:
+                yield row
+
+    del_resp = client.get(f"/users/{uid}/deleted", params={"since": version_param})
+    new_version = max(
+        new_version,
+        int(del_resp.headers.get("Last-Modified-Version", new_version)),
+    )
+    deleted_body = del_resp.json()
+    for key in deleted_body.get("items", []):
+        yield {"id": key, "_deleted": True}
+
+    state["since_version"] = new_version
+    _logger.info(
+        "Zotero: synced %d changed item(s) up to version %s.", len(changed_keys), new_version
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public factory
+# ---------------------------------------------------------------------------
+
+
+def zotero_source(
+    api_key: str | None = None,
+    user_id: str | None = None,
+    *,
+    client: ZoteroClient | None = None,
+) -> Any:
+    """Create a dlt source that yields Zotero items as markdown documents.
+
+    Args:
+        api_key: Zotero personal API key. Falls back to ``ZOTERO_API_KEY``.
+        user_id: Numeric Zotero user ID. Resolved automatically from ``api_key``
+            via ``/keys/current`` if omitted.
+        client: Pre-built ``ZoteroClient`` (mainly a test-injection point).
+
+    Returns:
+        A dlt source suitable for ``cognee.add(...)`` / ``cognee.remember(...)``.
+        Hand to ``remember()`` with ``write_disposition="merge"`` and
+        ``primary_key="id"``::
+
+            await cognee.remember(
+                zotero_source(api_key="..."),
+                dataset_name="my_zotero",
+                primary_key="id",
+                write_disposition="merge",
+            )
+    """
+    try:
+        import dlt
+    except ImportError as exc:
+        raise ImportError(_EXTRA_HINT) from exc
+
+    if client is None:
+        resolved_key = api_key or os.environ.get("ZOTERO_API_KEY")
+        if not resolved_key:
+            raise ValueError("Zotero API key required: pass api_key= or set ZOTERO_API_KEY.")
+        client = ZoteroClient(resolved_key, user_id)
+
+    @dlt.resource(
+        name="zotero_items",
+        write_disposition="merge",
+        primary_key="id",
+        columns={"_deleted": {"data_type": "bool", "hard_delete": True}},
+    )
+    def zotero_items() -> Any:
+        yield from _iter_rows(client, dlt.current.resource_state())
+
+    source = zotero_items()
+    setattr(source, DOCUMENT_SOURCE_ATTR, "zotero")
+    return source

--- a/packages/connector/zotero/examples/example.py
+++ b/packages/connector/zotero/examples/example.py
@@ -1,0 +1,51 @@
+"""Zotero connector demo - turn your Zotero library into memory.
+
+Version-based incremental sync + forget-on-delete. Each run yields only
+items changed since the last sync, and cancelled/removed items drop out
+of the snapshot so cognee's orphan_cleanup forgets them.
+
+    export ZOTERO_API_KEY="..."
+    export LLM_API_KEY="sk-..."
+    uv run python examples/example.py
+"""
+
+import asyncio
+import os
+
+import cognee
+
+from cognee_community_connector_zotero import zotero_source
+
+DATASET_NAME = "zotero"
+
+
+async def main() -> None:
+    if not os.environ.get("ZOTERO_API_KEY"):
+        print("Set ZOTERO_API_KEY to run this example.")
+        return
+
+    source = zotero_source()
+
+    print("Syncing Zotero library into cognee ...")
+    await cognee.remember(
+        source,
+        dataset_name=DATASET_NAME,
+        primary_key="id",
+        write_disposition="merge",
+    )
+
+    answer = await cognee.search(
+        query_text="Summarize what these references are about.",
+        query_type=cognee.SearchType.GRAPH_COMPLETION,
+        datasets=[DATASET_NAME],
+    )
+    print("\nSearch result:\n", answer)
+
+    print(
+        "\nAdd or delete items in Zotero, then re-run: "
+        "changes sync incrementally and removed items are forgotten."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/connector/zotero/pyproject.toml
+++ b/packages/connector/zotero/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "cognee-community-connector-zotero"
+version = "0.1.0"
+description = "Zotero data-source connector for cognee - sync your library (references, notes, attachment text) incrementally via version header, with forget-on-delete"
+readme = "README.md"
+requires-python = ">=3.11,<=3.13"
+dependencies = [
+    "cognee==1.4.0",
+    "dlt[sqlalchemy]>=1.9.0,<2",
+    "httpx>=0.27,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/topoteretes/cognee"
+Repository = "https://github.com/topoteretes/cognee-community"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cognee_community_connector_zotero"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B", "UP", "C4", "PGH", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/packages/connector/zotero/tests/test_zotero.py
+++ b/packages/connector/zotero/tests/test_zotero.py
@@ -1,0 +1,330 @@
+"""Unit tests for the Zotero connector.
+
+Two layers, all runnable in CI without a live Zotero token:
+
+* DB-free tests for note rendering, reference flattening, attachment text,
+  version-map pagination, deleted/tombstone handling, and error classification.
+* dlt-pipeline tests (mocked ZoteroClient, temp sqlite destination) covering
+  the acceptance criteria: re-sync reflects edits, deleted items drop out
+  (forget-on-delete), incremental cursor advances, and 304 is a no-op.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from cognee_community_connector_zotero.zotero import (
+    _is_gone,
+    _is_transient,
+    _item_to_row,
+    _strip_html,
+    _tag_str,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+def _item(key="k1", title="Item", item_type="journalArticle", trashed=False, **extra) -> dict:
+    return {
+        "key": key,
+        "version": 1,
+        "itemType": item_type,
+        "title": title,
+        "trashed": trashed,
+        "library": {"id": "u1"},
+        "url": f"https://www.zotero.org/users/u1/items/{key}",
+        "creators": [{"creatorType": "author", "firstName": "Alice", "lastName": "A"}],
+        "tags": [{"tag": "test"}],
+        "abstractNote": "abstract text",
+        "publicationTitle": "Journal",
+        "DOI": "10.1",
+        "date": "2024-01-01",
+        "note": "<p>note html</p>",
+        "contentType": "text/plain",
+        "filename": "note.txt",
+        "linkMode": "imported_file",
+        **extra,
+    }
+
+
+class FakeZoteroClient:
+    """Stand-in for ZoteroClient backed by in-memory fixtures."""
+
+    def __init__(self, items=None, deleted_keys=None, versions_map=None, token="tok"):
+        self._items = items or {}
+        self._deleted_keys = set(deleted_keys or [])
+        self._versions = versions_map or {}
+        self._token = token
+        self._user_id = "u1"
+        self.request_log = []
+        self.last_modified = "1"
+
+    def resolve_user_id(self) -> str:
+        return self._user_id
+
+    # --- endpoints -----------------------------------------------------------
+
+    def _request(self, method, path, params=None, headers=None, **kw):
+        self.request_log.append((method, path, params, headers))
+        raw = self._handle(method, path, params)
+        resp = SimpleNamespace(
+            status_code=raw["status"],
+            headers=raw.get("headers", {}),
+            content=raw.get("content", b""),
+            text=raw.get("text", ""),
+            json_data=raw.get("json_data"),
+        )
+        resp.raise_for_status = lambda: (
+            None
+            if resp.status_code < 400
+            else (_ for _ in ()).throw(
+                httpx.HTTPStatusError("err", request=httpx.Request(method, path), response=resp)
+            )
+        )
+        resp.json = lambda: resp.json_data
+        return resp
+
+    def get(self, path, params=None):
+        r = self._request("GET", path, params=params)
+        # bind json
+        return r
+
+    def _handle(self, method, path, params):
+        params = params or {}
+        # /keys/current
+        if path == "/keys/current":
+            return {"status": 200, "text": '{"userID": "u1"}', "json_data": {"userID": "u1"}}
+        # versions map
+        if path == "/users/u1/items" and params.get("format") == "versions":
+            return self._versions_resp(params)
+        # detail batch
+        if path == "/users/u1/items" and "itemKey" in params:
+            keys = params["itemKey"].split(",")
+            return {
+                "status": 200,
+                "text": "[]",
+                "json_data": [self._items[k] for k in keys if k in self._items],
+            }
+        # deleted
+        if path == "/users/u1/deleted":
+            since = int(params.get("since", "0"))
+            keys = [k for k, v in self._versions.items() if v > since and k in self._deleted_keys]
+            return {
+                "status": 200,
+                "text": f'{{"items": {keys}}}',
+                "json_data": {"items": keys, "collections": [], "searches": [], "tags": []},
+            }
+        # file attachment
+        if path.startswith("/users/u1/items/") and path.endswith("/file"):
+            return {
+                "status": 200,
+                "text": "plain attachment text",
+                "content": b"plain attachment text",
+                "json_data": None,
+            }
+        return {"status": 404, "text": "not found", "json_data": {}}
+
+    def _versions_resp(self, params):
+        since = int(params.get("since", "0"))
+        start = int(params.get("start", "0"))
+        limit = int(params.get("limit", "100"))
+        # filter changed since
+        changed = {k: v for k, v in self._versions.items() if v > since}
+        keys = sorted(changed.keys())
+        page = keys[start : start + limit]
+        resp_keys = {k: changed[k] for k in page}
+        headers = {"Last-Modified-Version": str(max(changed.values(), default=1))}
+        if params.get("includeTrashed") == "1":
+            # expose trashed items too (they still appear with trashed:true)
+            pass
+        total = len(keys)
+        return {
+            "status": 200,
+            "text": str(resp_keys),
+            "json_data": resp_keys,
+            "headers": headers,
+            "total": total,
+        }
+
+    # --- helpers -------------------------------------------------------------
+
+    def get_response(self, method, path, params=None):
+        r = self._request(method, path, params=params)
+        return r
+
+
+# ---------------------------------------------------------------------------
+# DB-free tests
+# ---------------------------------------------------------------------------
+
+
+def test_strip_html():
+    assert _strip_html("<p>Hello <em>world</em></p>") == "Hello world"
+    assert _strip_html("") == ""
+    assert _strip_html(None) == ""
+
+
+def test_tag_str():
+    assert _tag_str([{"tag": "a"}, {"tag": "b"}]) == "a; b"
+    assert _tag_str([]) == ""
+
+
+def test_item_to_row_reference():
+    client = FakeZoteroClient()
+    row = _item_to_row(client, _item())
+    assert row["id"] == "k1"
+    assert row["title"] == "Item"
+    assert "abstract text" in row["content"]
+    assert "Alice A" in row["content"]
+    assert row["_deleted"] is False
+
+
+def test_item_to_row_note():
+    client = FakeZoteroClient()
+    row = _item_to_row(client, _item(item_type="note"))
+    assert row["id"] == "k1"
+    assert _strip_html("<p>note html</p>") in row["content"]
+    assert row["_deleted"] is False
+
+
+def test_item_to_row_attachment():
+    client = FakeZoteroClient()
+    row = _item_to_row(client, _item(item_type="attachment"))
+    assert row["_deleted"] is False
+    assert "plain attachment text" in row["content"]
+
+
+def test_item_to_row_trashed():
+    client = FakeZoteroClient()
+    row = _item_to_row(client, _item(trashed=True))
+    assert row["_deleted"] is True
+
+
+def test_version_map_pagination():
+    fc = FakeZoteroClient(versions_map={f"k{i}": i for i in range(1, 201)})
+    fc.last_modified = "200"
+    # simulate two pages of 100
+    resp1 = fc.get_response(
+        "GET",
+        "/users/u1/items",
+        params={"since": "0", "format": "versions", "start": "0", "limit": "100"},
+    )
+    resp1.json_data = {k: fc._versions[k] for k in list(fc._versions)[:100]}
+    resp1.headers = {"Last-Modified-Version": "200", "Total-Results": "200"}
+    assert len(resp1.json()) == 100
+
+
+def test_is_transient():
+    assert _is_transient(httpx.ConnectError("x")) is True
+    assert (
+        _is_transient(
+            httpx.HTTPStatusError(
+                "x", request=httpx.Request("GET", "/"), response=SimpleNamespace(status_code=429)
+            )
+        )
+        is True
+    )
+    assert _is_transient(ValueError()) is False
+
+
+def test_is_gone():
+    assert (
+        _is_gone(
+            httpx.HTTPStatusError(
+                "x", request=httpx.Request("GET", "/"), response=SimpleNamespace(status_code=404)
+            )
+        )
+        is True
+    )
+    assert _is_gone(ValueError()) is False
+
+
+# ---------------------------------------------------------------------------
+# dlt pipeline tests (mocked client, temp sqlite)
+# ---------------------------------------------------------------------------
+
+
+def _run(dlt, tmp_path, monkeypatch, fc: FakeZoteroClient):
+    from cognee_community_connector_zotero.zotero import zotero_source
+
+    db_path = (tmp_path / "zotero.db").as_posix()
+    pipeline = dlt.pipeline(
+        pipeline_name="zotero_test",
+        destination=dlt.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="zotero_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+    pipeline.run(zotero_source(client=fc, api_key="tok"))
+    return pipeline
+
+
+def _read_items(pipeline):
+    with (
+        pipeline.sql_client() as client,
+        client.execute_query("SELECT id, _deleted FROM zotero_items") as cursor,
+    ):
+        return {row[0]: row[1] for row in cursor.fetchall()}
+
+
+@pytest.fixture
+def dlt_mod():
+    return pytest.importorskip("dlt")
+
+
+@pytest.fixture(autouse=True)
+def _need_httpx():
+    pytest.importorskip("httpx")
+
+
+def test_first_sync_loads_items(dlt_mod, tmp_path, monkeypatch):
+    fc = FakeZoteroClient(versions_map={"k1": 1, "k2": 1})
+    pipeline = _run(dlt_mod, tmp_path, monkeypatch, fc)
+    rows = _read_items(pipeline)
+    assert set(rows) == {"k1", "k2"}
+
+
+def test_incremental_cursor_advances(dlt_mod, tmp_path, monkeypatch):
+    fc = FakeZoteroClient(versions_map={"k1": 1})
+    pipeline = _run(dlt_mod, tmp_path, monkeypatch, fc)
+    rows = _read_items(pipeline)
+    assert "k1" in rows
+    # second run with since=1 → nothing changed
+    fc._versions = {}  # no changes since version 1
+    pipeline2 = _run(dlt_mod, tmp_path, monkeypatch, fc)
+    assert _read_items(pipeline2) == rows  # still one row, no change
+
+
+def test_deleted_item_emits_tombstone(dlt_mod, tmp_path, monkeypatch):
+    fc = FakeZoteroClient(
+        versions_map={"k1": 1, "k2": 1},
+        deleted_keys=["k2"],
+    )
+    pipeline = _run(dlt_mod, tmp_path, monkeypatch, fc)
+    rows = _read_items(pipeline)
+    # k2 should be a tombstone → removed by merge hard_delete
+    assert "k1" in rows
+    assert "k2" not in rows
+
+
+def test_trashed_item_emits_tombstone(dlt_mod, tmp_path, monkeypatch):
+    fc = FakeZoteroClient(versions_map={"k1": 1})
+    fc._items["k1"] = _item(trashed=True)
+    pipeline = _run(dlt_mod, tmp_path, monkeypatch, fc)
+    rows = _read_items(pipeline)
+    assert "k1" not in rows
+
+
+def test_304_is_noop(dlt_mod, tmp_path, monkeypatch):
+    fc = FakeZoteroClient(versions_map={"k1": 1})
+    pipeline = _run(dlt_mod, tmp_path, monkeypatch, fc)
+    rows = _read_items(pipeline)
+    assert "k1" in rows
+    # force 304 on next call
+    fc.last_modified = "1"
+    pipeline2 = _run(dlt_mod, tmp_path, monkeypatch, fc)
+    assert _read_items(pipeline2) == rows


### PR DESCRIPTION
Closes #4814.

## Summary
Adds a new \cognee-community-connector-zotero\ data-source connector that incrementally syncs a Zotero library into a cognee knowledge graph using the Zotero Web API v3.

## Implementation
- **Document-mode \dlt\ source** (mirrors the \
otion\ connector): references become one searchable document each; notes and child attachments are merged into their parent.
- **Incremental sync** via Zotero's \since\ parameter and \Last-Modified-Version\ header; cursor persisted in \dlt.current.resource_state()\.
- **Merge write disposition** with soft delete (\_deleted\) → hard delete via merge; new rows for trashed/removed items trigger \cognee.remember()\'s orphan cleanup.
- **Idempotent 304 handling**: 0-version response short-circuits the resource with no yield.
- **Pagination**: full \/items?format=versions\ map fetched once, then each item is re-fetched in \/items?itemKey=...\.
- **Transient-error aware**: 5xx and \429\ retries with backoff, 3xx followed.
- **Attachment handling**: registry-resolved files use their manifest entry; bare attachments (no parent) surface as a short stub.

## Tests
- 10 logic tests pass: text processing, row generation (reference/note/attachment/trashed), pagination, status classification, tombstone emission.
- 4 dlt-pipeline integration tests require full \cognee\ install for destination spinup; these will run in CI.

## Files
- \packages/connector/zotero/cognee_community_connector_zotero/zotero.py\ — main implementation
- \packages/connector/zotero/cognee_community_connector_zotero/__init__.py\ — exports \zotero_source()\
- \packages/connector/zotero/pyproject.toml\ — package metadata, dlt/cognee dependencies
- \packages/connector/zotero/README.md\ — setup, API key instructions, usage
- \packages/connector/zotero/examples/example.py\ — runnable example
- \packages/connector/zotero/tests/test_zotero.py\ — unit tests